### PR TITLE
(2/3) Use responsive hooks

### DIFF
--- a/react/src/about.tsx
+++ b/react/src/about.tsx
@@ -4,14 +4,16 @@ import ReactDOM from 'react-dom/client'
 import './style.css'
 import './common.css'
 import { PageTemplate } from './page_template/template'
-import { headerTextClass } from './utils/responsive'
+import { useHeaderTextClass } from './utils/responsive'
 
 function AboutPanel(): ReactNode {
+    const headerTextClass = useHeaderTextClass()
+
     return (
         <PageTemplate>
             {() => (
                 <div className="serif">
-                    <div className={headerTextClass()}>About</div>
+                    <div className={headerTextClass}>About</div>
 
                     <p>
                         Urban Stats is a database of various statistics, computed largely from Census Data for United States

--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -8,7 +8,7 @@ import { useSetting, useTableCheckboxSettings } from '../page_template/settings'
 import { PageTemplate } from '../page_template/template'
 import { longname_is_exclusively_american, useUniverse } from '../universe'
 import { Article, IRelatedButtons } from '../utils/protos'
-import { comparisonHeadStyle, headerTextClass, subHeaderTextClass } from '../utils/responsive'
+import { useComparisonHeadStyle, useHeaderTextClass, useSubHeaderTextClass } from '../utils/responsive'
 import { NormalizeProto } from '../utils/types'
 
 import { load_article } from './load-article'
@@ -29,13 +29,17 @@ export function ArticlePanel({ article }: { article: Article }): ReactNode {
         elements_to_render: [headers_ref.current!, table_ref.current!, map_ref.current!],
     })
 
+    const headerTextClass = useHeaderTextClass()
+    const subHeaderTextClass = useSubHeaderTextClass()
+    const comparisonHeadStyle = useComparisonHeadStyle('right')
+
     return (
         <PageTemplate screencap_elements={screencap_elements} has_universe_selector={true} universes={article.universes}>
             {template_info => (
                 <div>
                     <div ref={headers_ref}>
-                        <div className={headerTextClass()}>{article.shortname}</div>
-                        <div className={subHeaderTextClass()}>{article.longname}</div>
+                        <div className={headerTextClass}>{article.shortname}</div>
+                        <div className={subHeaderTextClass}>{article.longname}</div>
                     </div>
                     <div style={{ marginBlockEnd: '16px' }}></div>
 
@@ -64,7 +68,7 @@ export function ArticlePanel({ article }: { article: Article }): ReactNode {
 
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                         <div style={{ width: '30%', marginRight: '1em' }}>
-                            <div className="serif" style={comparisonHeadStyle('right')}>Compare to: </div>
+                            <div className="serif" style={comparisonHeadStyle}>Compare to: </div>
                         </div>
                         <div style={{ width: '70%' }}>
                             <ComparisonSearchBox longname={article.longname} />
@@ -87,7 +91,7 @@ function ComparisonSearchBox({ longname }: { longname: string }): ReactNode {
     const curr_universe = useUniverse()
     return (
         <SearchBox
-            style={{ ...comparisonHeadStyle(), width: '100%' }}
+            style={{ ...useComparisonHeadStyle(), width: '100%' }}
             placeholder="Other region..."
             on_change={(x) => {
                 document.location.href = comparison_link(

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -9,7 +9,7 @@ import { PageTemplate } from '../page_template/template'
 import { longname_is_exclusively_american, useUniverse } from '../universe'
 import { lighten } from '../utils/color'
 import { Article } from '../utils/protos'
-import { comparisonHeadStyle, headerTextClass, mobileLayout, subHeaderTextClass } from '../utils/responsive'
+import { useComparisonHeadStyle, useHeaderTextClass, useMobileLayout, useSubHeaderTextClass } from '../utils/responsive'
 
 import { ArticleRow, load_article } from './load-article'
 import { MapGeneric, MapGenericProps, Polygons } from './map'
@@ -85,8 +85,10 @@ export function ComparisonPanel(props: { joined_string: string, universes: strin
         )
     }
 
+    const mobileLayout = useMobileLayout()
+
     const max_columns = (): number => {
-        return mobileLayout() ? 4 : 6
+        return mobileLayout ? 4 : 6
     }
 
     const width_columns = (): number => {
@@ -108,22 +110,27 @@ export function ComparisonPanel(props: { joined_string: string, universes: strin
         return contents
     }
 
+    const headerTextClass = useHeaderTextClass()
+    const subHeaderTextClass = useSubHeaderTextClass()
+    const comparisonRightStyle = useComparisonHeadStyle('right')
+    const searchComparisonStyle = useComparisonHeadStyle()
+
     return (
         <PageTemplate screencap_elements={screencap_elements} has_universe_selector={true} universes={props.universes}>
             { template_info => (
                 <div>
-                    <div className={headerTextClass()}>Comparison</div>
-                    <div className={subHeaderTextClass()}>{props.joined_string}</div>
+                    <div className={headerTextClass}>Comparison</div>
+                    <div className={subHeaderTextClass}>{props.joined_string}</div>
                     <div style={{ marginBlockEnd: '16px' }}></div>
 
                     <div style={{ display: 'flex' }}>
                         <div style={{ width: `${100 * left_margin_pct}%` }} />
                         <div style={{ width: `${50 * (1 - left_margin_pct)}%`, marginRight: '1em' }}>
-                            <div className="serif" style={comparisonHeadStyle('right')}>Add another region:</div>
+                            <div className="serif" style={comparisonRightStyle}>Add another region:</div>
                         </div>
                         <div style={{ width: `${50 * (1 - left_margin_pct)}%` }}>
                             <SearchBox
-                                style={{ ...comparisonHeadStyle(), width: '100%' }}
+                                style={{ ...searchComparisonStyle, width: '100%' }}
                                 placeholder="Name"
                                 on_change={(x) => { add_new(props.names, x) }}
                                 autoFocus={false}
@@ -372,6 +379,7 @@ function ManipulationButton({ color: buttonColor, on_click, text }: { color: str
 function HeadingDisplay({ longname, include_delete, on_click, on_change: on_search_change, screenshot_mode }: { longname: string, include_delete: boolean, on_click: () => void, on_change: (q: string) => void, screenshot_mode: boolean }): ReactNode {
     const [is_editing, set_is_editing] = React.useState(false)
     const curr_universe = useUniverse()
+    const comparisonHeadStyle = useComparisonHeadStyle()
 
     const manipulation_buttons = (
         <div style={{ height: manipulation_button_height }}>
@@ -394,12 +402,12 @@ function HeadingDisplay({ longname, include_delete, on_click, on_change: on_sear
         <div>
             {screenshot_mode ? undefined : manipulation_buttons}
             <div style={{ height: '5px' }} />
-            <a className="serif" href={article_link(curr_universe, longname)} style={{ textDecoration: 'none' }}><div style={comparisonHeadStyle()}>{longname}</div></a>
+            <a className="serif" href={article_link(curr_universe, longname)} style={{ textDecoration: 'none' }}><div style={useComparisonHeadStyle()}>{longname}</div></a>
             {is_editing
                 ? (
                         <SearchBox
                             autoFocus={true}
-                            style={{ ...comparisonHeadStyle(), width: '100%' }}
+                            style={{ ...comparisonHeadStyle, width: '100%' }}
                             placeholder="Replacement"
                             on_change={on_search_change}
                         />

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -4,7 +4,7 @@ import '../common.css'
 import './header.css'
 import { article_link, universe_path } from '../navigation/links'
 import { set_universe, useUniverse } from '../universe'
-import { mobileLayout } from '../utils/responsive'
+import { useMobileLayout } from '../utils/responsive'
 
 import { Nav } from './hamburger'
 import { ScreenshotButton } from './screenshot'
@@ -34,7 +34,7 @@ export function Header(props: {
             <div className="right_panel_top" style={{ height: HEADER_BAR_SIZE }}>
                 {/* flex but stretch to fill */}
                 <div style={{ display: 'flex', flexDirection: 'row', height: '100%' }}>
-                    {!mobileLayout() && props.has_universe_selector
+                    {!useMobileLayout() && props.has_universe_selector
                         ? (
                                 <div style={{ paddingRight: '0.5em' }}>
                                     <UniverseSelector
@@ -87,7 +87,7 @@ function TopLeft(props: {
     has_universe_selector: boolean
     all_universes: string[]
 }): ReactNode {
-    if (mobileLayout()) {
+    if (useMobileLayout()) {
         return (
             <div className="left_panel_top">
                 <Nav hamburger_open={props.hamburger_open} set_hamburger_open={props.set_hamburger_open} />
@@ -114,13 +114,13 @@ function TopLeft(props: {
 }
 
 function HeaderImage(): ReactNode {
-    const path = mobileLayout() ? '/thumbnail.png' : '/banner.png'
+    const path = useMobileLayout() ? '/thumbnail.png' : '/banner.png'
     return (
         <a href="/index.html">
             <img
                 src={path}
                 style={{
-                    height: mobileLayout() ? HEADER_BAR_SIZE : HEADER_BAR_SIZE_DESKTOP,
+                    height: useMobileLayout() ? HEADER_BAR_SIZE : HEADER_BAR_SIZE_DESKTOP,
                 }}
                 alt="Urban Stats Logo"
             />

--- a/react/src/components/mapper-panel.tsx
+++ b/react/src/components/mapper-panel.tsx
@@ -12,7 +12,7 @@ import { consolidated_shape_link, consolidated_stats_link } from '../navigation/
 import { PageTemplate } from '../page_template/template'
 import { interpolate_color } from '../utils/color'
 import { ConsolidatedShapes, ConsolidatedStatistics, Feature, IAllStats } from '../utils/protos'
-import { headerTextClass } from '../utils/responsive'
+import { useHeaderTextClass } from '../utils/responsive'
 import { NormalizeProto } from '../utils/types'
 
 import { MapGeneric, MapGenericProps, Polygons } from './map'
@@ -350,6 +350,8 @@ export function MapperPanel(): ReactNode {
                 )
     }
 
+    const headerTextClass = useHeaderTextClass()
+
     if (new URLSearchParams(window.location.search).get('view') === 'true') {
         return mapper_panel('100%')
     }
@@ -358,7 +360,7 @@ export function MapperPanel(): ReactNode {
         <PageTemplate>
             {() => (
                 <div>
-                    <div className={headerTextClass()}>Urban Stats Mapper (beta)</div>
+                    <div className={headerTextClass}>Urban Stats Mapper (beta)</div>
                     <MapperSettings
                         names={names}
                         valid_geographies={valid_geographies}

--- a/react/src/components/quiz-panel.tsx
+++ b/react/src/components/quiz-panel.tsx
@@ -28,16 +28,11 @@ export function QuizPanel(props: { quizDescriptor: QuizDescriptor, today_name: s
 
     const todays_quiz_history = quiz_history[props.quizDescriptor.name] ?? { choices: [], correct_pattern: [] }
 
-    const is_daily = typeof props.quizDescriptor.name === 'number'
-
-    const is_weekly = typeof props.quizDescriptor.name === 'string' && (/^W-?\d+$/.exec(props.quizDescriptor.name))
-
     const set_todays_quiz_history = (history_today: History[string]): void => {
         const newHistory = { ...quiz_history, [props.quizDescriptor.name]: history_today }
         set_quiz_history(newHistory)
         setWaiting(true)
-        // if today is a number and not a string
-        if (is_daily || is_weekly) {
+        if (props.quizDescriptor.kind === 'juxtastat' || props.quizDescriptor.kind === 'retrostat') {
             localStorage.setItem('quiz_history', JSON.stringify(newHistory))
         }
     }
@@ -67,28 +62,6 @@ export function QuizPanel(props: { quizDescriptor: QuizDescriptor, today_name: s
                 }
 
                 if (index === quiz.length) {
-                    let get_per_question
-                    if (is_daily) {
-                        void reportToServer(quiz_history)
-                        // POST to endpoint /juxtastat/get_per_question_stats with the current day
-                        get_per_question = fetch(`${ENDPOINT}/juxtastat/get_per_question_stats`, {
-                            method: 'POST',
-                            body: JSON.stringify({ day: props.quizDescriptor.name }),
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                        })
-                    }
-                    if (is_weekly && typeof props.quizDescriptor.name === 'string') {
-                        void reportToServerRetro(quiz_history)
-                        get_per_question = fetch(`${ENDPOINT}/retrostat/get_per_question_stats`, {
-                            method: 'POST',
-                            body: JSON.stringify({ week: parseInt(props.quizDescriptor.name.substring(1)) }),
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                        })
-                    }
                     return (
                         <QuizResult
                             quiz={quiz}
@@ -96,7 +69,6 @@ export function QuizPanel(props: { quizDescriptor: QuizDescriptor, today_name: s
                             history={history}
                             today_name={props.today_name}
                             parameters={props.parameters}
-                            get_per_question={get_per_question}
                             quizDescriptor={props.quizDescriptor}
                         />
                     )

--- a/react/src/components/quiz-panel.tsx
+++ b/react/src/components/quiz-panel.tsx
@@ -3,10 +3,10 @@ import React, { ReactNode, useState } from 'react'
 import { PageTemplate } from '../page_template/template'
 import '../common.css'
 import './quiz.css'
-import { ENDPOINT, QuizDescriptor, QuizQuestion, a_correct } from '../quiz/quiz'
+import { QuizDescriptor, QuizQuestion, a_correct } from '../quiz/quiz'
 import { QuizQuestionDispatch } from '../quiz/quiz-question'
 import { QuizResult } from '../quiz/quiz-result'
-import { History, reportToServer, reportToServerRetro } from '../quiz/statistics'
+import { History } from '../quiz/statistics'
 
 function loadQuizHistory(): History {
     const history = JSON.parse(localStorage.getItem('quiz_history') ?? '{}') as History
@@ -32,8 +32,12 @@ export function QuizPanel(props: { quizDescriptor: QuizDescriptor, today_name: s
         const newHistory = { ...quiz_history, [props.quizDescriptor.name]: history_today }
         set_quiz_history(newHistory)
         setWaiting(true)
-        if (props.quizDescriptor.kind === 'juxtastat' || props.quizDescriptor.kind === 'retrostat') {
-            localStorage.setItem('quiz_history', JSON.stringify(newHistory))
+        switch (props.quizDescriptor.kind) {
+            case 'juxtastat':
+            case 'retrostat':
+                localStorage.setItem('quiz_history', JSON.stringify(newHistory))
+                break
+            default:
         }
     }
 

--- a/react/src/components/related-button.tsx
+++ b/react/src/components/related-button.tsx
@@ -5,7 +5,7 @@ import { article_link } from '../navigation/links'
 import { relationship_key, useSetting } from '../page_template/settings'
 import { useUniverse } from '../universe'
 import { lighten } from '../utils/color'
-import { mobileLayout } from '../utils/responsive'
+import { useMobileLayout } from '../utils/responsive'
 
 import { CheckboxSetting } from './sidebar'
 
@@ -41,12 +41,12 @@ function RelatedButton(props: { region: Region }): ReactNode {
     const type_category = type_to_type_category[props.region.rowType]
 
     let classes = `serif button_related`
-    if (mobileLayout()) {
+    if (useMobileLayout()) {
         classes += ' button_related_mobile'
     }
     const color = colorsEach[type_category]
     return (
-        <li className={`linklistel${mobileLayout() ? ' linklistel_mobile' : ''}`}>
+        <li className={`linklistel${useMobileLayout() ? ' linklistel_mobile' : ''}`}>
             <a
                 className={classes}
                 style={{ color: 'black', backgroundColor: lighten(color, 0.7) }}
@@ -70,6 +70,7 @@ function RelatedList(props: { articleType: string, buttonType: string, regions: 
     }
 
     const checkId = useId()
+    const mobileLayout = useMobileLayout()
 
     return (
         <li className="list_of_lists">
@@ -91,10 +92,10 @@ function RelatedList(props: { articleType: string, buttonType: string, regions: 
                             return (
                                 <ul key={j} className="linklist">
                                     <li
-                                        className={`serif linklistel${mobileLayout() ? ' linklistel_mobile' : ''}`}
+                                        className={`serif linklistel${mobileLayout ? ' linklistel_mobile' : ''}`}
                                         style={{
                                             fontSize:
-                                                mobileLayout() ? '12pt' : '10pt',
+                                                mobileLayout ? '12pt' : '10pt',
                                             paddingTop: '1pt', fontWeight: 500,
                                         }}
                                     >

--- a/react/src/components/sidebar.tsx
+++ b/react/src/components/sidebar.tsx
@@ -3,18 +3,18 @@ import React, { ReactNode, useId } from 'react'
 import '../style.css'
 import './sidebar.css'
 import { SettingsDictionary, useSetting, useStatisticCategoryMetadataCheckboxes } from '../page_template/settings'
-import { mobileLayout } from '../utils/responsive'
+import { useMobileLayout } from '../utils/responsive'
 
 export function Sidebar(): ReactNode {
     const statistic_category_metadata_checkboxes = useStatisticCategoryMetadataCheckboxes()
     let sidebar_section_content = 'sidebar-section-content'
     let sidebar_section_title = 'sidebar-section-title'
-    if (mobileLayout()) {
+    if (useMobileLayout()) {
         sidebar_section_content += ' sidebar-section-content_mobile'
         sidebar_section_title += ' sidebar-section-title_mobile'
     }
     return (
-        <div className={`serif sidebar${mobileLayout() ? '_mobile' : ''}`}>
+        <div className={`serif sidebar${useMobileLayout() ? '_mobile' : ''}`}>
             <div className="sidebar-section">
                 <div className={sidebar_section_title}>Main Menu</div>
                 <ul className={sidebar_section_content}>

--- a/react/src/components/statistic-panel.tsx
+++ b/react/src/components/statistic-panel.tsx
@@ -6,7 +6,7 @@ import { PageTemplate } from '../page_template/template'
 import '../common.css'
 import './article.css'
 import { useUniverse } from '../universe'
-import { headerTextClass, subHeaderTextClass } from '../utils/responsive'
+import { useHeaderTextClass, useSubHeaderTextClass } from '../utils/responsive'
 import { display_type } from '../utils/text'
 
 import { Percentile, Statistic } from './table'
@@ -97,6 +97,8 @@ export function StatisticPanel(props: {
         return result
     }
 
+    const textHeaderClass = useHeaderTextClass()
+
     return (
         <PageTemplate
             screencap_elements={() => ({
@@ -110,7 +112,7 @@ export function StatisticPanel(props: {
             {() => (
                 <div>
                     <div ref={headers_ref}>
-                        <div className={headerTextClass()}>{props.rendered_statname}</div>
+                        <div className={textHeaderClass}>{props.rendered_statname}</div>
                         {/* // TODO plural */}
                         <StatisticPanelSubhead
                             article_type={props.article_type}
@@ -374,7 +376,7 @@ function ArticleLink(props: { longname: string }): ReactNode {
 function StatisticPanelSubhead(props: { article_type: string, rendered_order: string }): ReactNode {
     const curr_universe = useUniverse()
     return (
-        <div className={subHeaderTextClass()}>
+        <div className={useSubHeaderTextClass()}>
             {display_type(curr_universe, props.article_type)}
             {' '}
             (

--- a/react/src/data-credit.tsx
+++ b/react/src/data-credit.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom/client'
 import './style.css'
 import './common.css'
 import { PageTemplate } from './page_template/template'
-import { headerTextClass } from './utils/responsive'
+import { useHeaderTextClass } from './utils/responsive'
 
 const industry_occupation_table = require('./data/explanation_industry_occupation_table.json') as { industry: [string, string][], occupation: [string, string][] }
 
@@ -63,11 +63,12 @@ function NRef({ children, name, h: Header = 'h2' }: { children: React.ReactNode,
 }
 
 function DataCreditPanel(): ReactNode {
+    const textHeaderClass = useHeaderTextClass()
     return (
         <PageTemplate>
             {() => (
                 <div className="serif">
-                    <div className={headerTextClass()}>Credits</div>
+                    <div className={textHeaderClass}>Credits</div>
 
                     <h1>Code contributors</h1>
                     <p>

--- a/react/src/page_template/template.tsx
+++ b/react/src/page_template/template.tsx
@@ -15,7 +15,7 @@ import { ScreencapElements, create_screenshot } from '../components/screenshot'
 import { Sidebar } from '../components/sidebar'
 import '../common.css'
 import '../components/article.css'
-import { mobileLayout } from '../utils/responsive'
+import { useMobileLayout } from '../utils/responsive'
 
 export function PageTemplate({
     screencap_elements = undefined,
@@ -56,7 +56,7 @@ export function PageTemplate({
     return (
         <Fragment>
             <meta name="viewport" content="width=600" />
-            <div className={mobileLayout() ? 'main_panel_mobile' : 'main_panel'}>
+            <div className={useMobileLayout() ? 'main_panel_mobile' : 'main_panel'}>
                 <Header
                     hamburger_open={hamburger_open}
                     set_hamburger_open={set_hamburger_open}
@@ -116,13 +116,15 @@ function OtherCredits(): ReactNode {
 }
 
 function BodyPanel({ hamburger_open, main_content }: { hamburger_open: boolean, main_content: React.ReactNode }): ReactNode {
+    const mobileLayout = useMobileLayout()
+
     if (hamburger_open) {
         return <LeftPanel />
     }
     return (
         <div className="body_panel">
-            {mobileLayout() ? undefined : <LeftPanel />}
-            <div className={mobileLayout() ? 'content_panel_mobile' : 'right_panel'}>
+            {mobileLayout ? undefined : <LeftPanel />}
+            <div className={mobileLayout ? 'content_panel_mobile' : 'right_panel'}>
                 {main_content}
                 <div className="gap"></div>
                 <TemplateFooter />
@@ -133,7 +135,7 @@ function BodyPanel({ hamburger_open, main_content }: { hamburger_open: boolean, 
 
 function LeftPanel(): ReactNode {
     return (
-        <div className={mobileLayout() ? 'left_panel_mobile' : 'left_panel'}>
+        <div className={useMobileLayout() ? 'left_panel_mobile' : 'left_panel'}>
             <Sidebar />
         </div>
     )

--- a/react/src/quiz/quiz-components.tsx
+++ b/react/src/quiz/quiz-components.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 
 import '../common.css'
 import '../components/quiz.css'
-import { headerTextClass } from '../utils/responsive'
+import { useHeaderTextClass } from '../utils/responsive'
 
 import { nameOfQuizKind } from './quiz'
 import { History } from './statistics'
@@ -12,7 +12,7 @@ export function Header({ quiz }: { quiz: { kind: 'juxtastat' | 'retrostat', name
     if (typeof quiz.name !== 'number') {
         text += ` ${quiz.name}`
     }
-    return (<div className={headerTextClass()}>{text}</div>)
+    return (<div className={useHeaderTextClass()}>{text}</div>)
 }
 
 export function Footer(props: { length: number, history: History[string] }): ReactNode {

--- a/react/src/quiz/quiz-question.tsx
+++ b/react/src/quiz/quiz-question.tsx
@@ -5,7 +5,7 @@ import React, { ReactNode } from 'react'
 import { isFirefox } from 'react-device-detect'
 
 import { MapGeneric, MapGenericProps, Polygons } from '../components/map'
-import { mobileLayout } from '../utils/responsive'
+import { useMobileLayout } from '../utils/responsive'
 
 import { JuxtaQuestion, RetroQuestion, a_correct } from './quiz'
 import { Footer, Header, Help } from './quiz-components'
@@ -79,7 +79,7 @@ function QuizQuestion(props: QuizQuestionProps & {
 
     const row_style = { display: 'flex', justifyContent: 'center', width: '90%', margin: 'auto' }
 
-    let quiztext_css = mobileLayout() ? 'quiztext_mobile' : 'quiztext'
+    let quiztext_css = useMobileLayout() ? 'quiztext_mobile' : 'quiztext'
     if (props.nested) {
         quiztext_css += '_nested'
     }

--- a/react/src/utils/responsive.ts
+++ b/react/src/utils/responsive.ts
@@ -2,8 +2,14 @@ import { useSyncExternalStore } from 'react'
 
 export function useMobileLayout(): boolean {
     return useSyncExternalStore((listener) => {
-        window.addEventListener('resize', listener)
-        return () => { window.removeEventListener('resize', listener) }
+        const myListener = (): void => {
+            if (window.innerWidth !== 1) {
+                // When taking screenshots, testcafe sets the inner width to 1, so we want to throw away those updates
+                listener()
+            }
+        }
+        window.addEventListener('resize', myListener)
+        return () => { window.removeEventListener('resize', myListener) }
     }, () => window.innerWidth <= 1100)
 }
 

--- a/react/src/utils/responsive.ts
+++ b/react/src/utils/responsive.ts
@@ -1,21 +1,26 @@
-export function mobileLayout(): boolean {
-    return window.innerWidth <= 1100
+import { useSyncExternalStore } from 'react'
+
+export function useMobileLayout(): boolean {
+    return useSyncExternalStore((listener) => {
+        window.addEventListener('resize', listener)
+        return () => { window.removeEventListener('resize', listener) }
+    }, () => window.innerWidth <= 1100)
 }
 
-export function headerTextClass(): string {
-    return `centered_text ${mobileLayout() ? 'headertext_mobile' : 'headertext'}`
+export function useHeaderTextClass(): string {
+    return `centered_text ${useMobileLayout() ? 'headertext_mobile' : 'headertext'}`
 }
 
-export function subHeaderTextClass(): string {
-    return `centered_text ${mobileLayout() ? 'subheadertext_mobile' : 'subheadertext'}`
+export function useSubHeaderTextClass(): string {
+    return `centered_text ${useMobileLayout() ? 'subheadertext_mobile' : 'subheadertext'}`
 }
 
-export function comparisonHeadStyle(
+export function useComparisonHeadStyle(
     align: React.CSSProperties['textAlign'] = 'center',
 ): React.CSSProperties {
     // bold
     return {
-        fontSize: mobileLayout() ? '15px' : '20px',
+        fontSize: useMobileLayout() ? '15px' : '20px',
         fontWeight: 500,
         margin: '0',
         padding: '0',


### PR DESCRIPTION
https://github.com/user-attachments/assets/48465505-111c-47f6-8ac9-4c0d0d2acbc7

We should support laying out the page again when the window size changes.

- Change the `mobileLayout` function to a `useMobileLayout` hook. Have it sync with the window size.
- Refactor other layout functions to also be hooks.
- Refactor the usage of these functions to conform to React hook rules.
- **Refactor quiz requests to conform to React rules, so that multiple requests don't get sent on page resize**