### PR TITLE
Fix the e2e test runner on files with “ts” in the name

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
-        run: echo "matrix=$(find . -name '*_test.ts' | jq -R -s -c 'gsub("./"; "") | gsub(".ts"; "") | split("\n")[:-1]')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(find . -name '*_test.ts' | jq -R -s -c 'gsub("\\./"; "") | gsub("\\.ts"; "") | split("\n")[:-1]')" >> $GITHUB_OUTPUT
         working-directory: react/test
 
   run-e2e-tests:


### PR DESCRIPTION
Forgot to escape regexes in jq gsub