### PR TITLE
Implement safe reload

### DIFF
--- a/react/eslint.config.mjs
+++ b/react/eslint.config.mjs
@@ -94,7 +94,11 @@ export default tseslint.config(
             'eqeqeq': 'error',
             'guard-for-in': 'error',
             'object-shorthand': 'error',
-            'no-restricted-syntax': ['error', 'ExportNamedDeclaration:not([declaration])'],
+            'no-restricted-syntax': [
+                'error', 
+                'ExportNamedDeclaration:not([declaration])', 
+                'MemberExpression[object.name=location][property.name=reload]'
+            ],
             'react/prop-types': 'off',
             'no-shadow': 'error',
             'eslint-comments/require-description': ['error', {

--- a/react/test/article_test.ts
+++ b/react/test/article_test.ts
@@ -2,7 +2,7 @@ import { Selector } from 'testcafe'
 
 import {
     TARGET, check_all_category_boxes, check_textboxes, comparison_page, download_image,
-    getLocationWithoutSettings, screencap,
+    getLocationWithoutSettings, safeReload, screencap,
     urbanstatsFixture,
 } from './test_utils'
 
@@ -102,7 +102,7 @@ test('uncheck-box-mobile', async (t) => {
 
     await screencap(t)
     // refresh
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await screencap(t)
 })
 
@@ -113,7 +113,7 @@ test('uncheck-box-desktop', async (t) => {
 
     await screencap(t)
     // refresh
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await screencap(t)
 })
 

--- a/react/test/link_settings_test_template.ts
+++ b/react/test/link_settings_test_template.ts
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe'
 
-import { arrayFromSelector, getLocation, screencap, TARGET, urbanstatsFixture } from './test_utils'
+import { arrayFromSelector, getLocation, safeReload, screencap, TARGET, urbanstatsFixture } from './test_utils'
 
 export function linkSettingsTests(baseLink: string): void {
     urbanstatsFixture('generate link', baseLink, async (t) => {
@@ -119,7 +119,7 @@ export function linkSettingsTests(baseLink: string): void {
             year_2010: false,
         })
 
-        await t.eval(() => { location.reload() })
+        await safeReload(t)
 
         // Settings persist after reload without staging
         await t.expect(Selector('[data-test-id=staging_controls]').exists).notOk()

--- a/react/test/quiz_test.ts
+++ b/react/test/quiz_test.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util'
 import { execa } from 'execa'
 import { RequestHook, Selector } from 'testcafe'
 
-import { TARGET, screencap, urbanstatsFixture } from './test_utils'
+import { TARGET, safeReload, screencap, urbanstatsFixture } from './test_utils'
 
 async function quiz_screencap(t: TestController): Promise<void> {
     await t.eval(() => {
@@ -152,7 +152,7 @@ quiz_fixture(
 )
 
 test('quiz-report-old-results', async (t) => {
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await click_buttons(t, ['a', 'a', 'a', 'a', 'a'])
     const quiz_history: unknown = await t.eval(() => {
         return JSON.parse(localStorage.getItem('quiz_history')!) as unknown
@@ -181,7 +181,7 @@ quiz_fixture(
 )
 
 test('quiz-do-not-report-stale-results', async (t) => {
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await click_buttons(t, ['a', 'a', 'a', 'a', 'a'])
     const quiz_history: unknown = await t.eval(() => {
         return JSON.parse(localStorage.getItem('quiz_history')!) as unknown
@@ -213,7 +213,7 @@ quiz_fixture(
 )
 
 test('quiz-percentage-correct', async (t) => {
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await click_buttons(t, ['a', 'a', 'a', 'a', 'a'])
     await quiz_screencap(t)
     await t.expect(await juxtastat_table()).eql(
@@ -227,7 +227,7 @@ test('quiz-percentage-correct', async (t) => {
         localStorage.setItem('persistent_id', '000000000000008')
         localStorage.setItem('testHostname', 'urbanstats.org')
     })
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await click_buttons(t, ['a', 'a', 'a', 'a', 'a'])
     await quiz_screencap(t)
     await t.expect(await juxtastat_table()).eql(
@@ -285,7 +285,7 @@ quiz_fixture(
 )
 
 test('quiz-retrostat-regular-quiz-reporting', async (t) => {
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await click_buttons(t, ['a', 'a', 'a', 'a', 'a'])
     const quiz_history: unknown = await t.eval(() => {
         return JSON.parse(localStorage.getItem('quiz_history')!) as unknown
@@ -303,7 +303,7 @@ test('quiz-retrostat-regular-quiz-reporting', async (t) => {
 test('quiz-retrostat-retrostat-reporting', async (t) => {
     const url = `${TARGET}/quiz.html?mode=retro&date=38`
     await t.navigateTo(url)
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await click_buttons(t, ['a', 'a', 'a', 'a', 'a'])
     const quiz_history: unknown = await t.eval(() => {
         return JSON.parse(localStorage.getItem('quiz_history')!) as unknown
@@ -334,7 +334,7 @@ async function check_text(t: TestController, words: string, emoji: string): Prom
 
 test('quiz-results-test', async (t) => {
     await t.resizeWindow(1400, 800)
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await quiz_screencap(t)
     await check_text(t, 'Excellent! 😊 4/5', '🟩🟩🟩🟩🟥')
 })
@@ -372,7 +372,7 @@ quiz_fixture('several quiz results', `${TARGET}/quiz.html?date=90`,
 )
 
 test('several-quiz-results-test', async (t) => {
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await quiz_screencap(t)
     // true true true true false
     await check_text(t, 'Excellent! 😊 4/5', '🟩🟩🟩🟩🟥')

--- a/react/test/settings_test.ts
+++ b/react/test/settings_test.ts
@@ -4,6 +4,7 @@ import { Selector } from 'testcafe'
 
 import {
     SEARCH_FIELD, TARGET, check_textboxes, getLocation,
+    safeReload,
     screencap,
     urbanstatsFixture,
 } from './test_utils'
@@ -47,7 +48,7 @@ test('check-settings-persistent', async (t) => {
     // assert mi not in page
     await t.expect(Selector('span').withText('mi').exists).notOk()
     // go back to San Marino
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
     await t.expect(Selector('span').withText('mi').exists).notOk()
 })
 

--- a/react/test/stats_tree_test_template.ts
+++ b/react/test/stats_tree_test_template.ts
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe'
 
-import { arrayFromSelector, screencap, TARGET, urbanstatsFixture, withHamburgerMenu } from './test_utils'
+import { arrayFromSelector, safeReload, screencap, TARGET, urbanstatsFixture, withHamburgerMenu } from './test_utils'
 
 const mainCheck = 'input[data-test-id=category_main]'
 const mainExpand = '.expandButton[data-category-id=main]'
@@ -212,7 +212,7 @@ export function statsTreeTest(platform: 'mobile' | 'desktop'): void {
         await withHamburgerMenu(t, async () => {
             await t.click(mainExpand)
         })
-        await t.eval(() => { location.reload() })
+        await safeReload(t)
         await withHamburgerMenu(t, async () => {
             await t.expect(Selector(populationCheck).visible).eql(true)
         })
@@ -223,7 +223,7 @@ export function statsTreeTest(platform: 'mobile' | 'desktop'): void {
             await t.click(mainExpand)
             await t.click(populationCheck)
         })
-        await t.eval(() => { location.reload() })
+        await safeReload(t)
         await withHamburgerMenu(t, async () => {
             await t.expect(Selector(populationCheck).checked).eql(false)
             await t.expect(await checkIsIndeterminate(t, mainCheck)).eql(true)
@@ -240,7 +240,7 @@ export function statsTreeTest(platform: 'mobile' | 'desktop'): void {
             await t.click(populationCheck)
             await t.click(mainCheck)
         })
-        await t.eval(() => { location.reload() })
+        await safeReload(t)
         await withHamburgerMenu(t, async () => {
             await t.expect(Selector(mainCheck).checked).eql(true)
             await t.expect(await checkIsIndeterminate(t, mainCheck)).eql(false)

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -194,5 +194,6 @@ export async function arrayFromSelector(selector: Selector): Promise<Selector[]>
 }
 
 export async function safeReload(t: TestController): Promise<void> {
+    // eslint-disable-next-line no-restricted-syntax -- This is the utility that replaces location.reload()
     await t.eval(() => setTimeout(() => { location.reload() }, 0))
 }

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -64,7 +64,7 @@ export async function check_all_category_boxes(t: TestController): Promise<void>
         }
     })
     // reload
-    await t.eval(() => { location.reload() })
+    await safeReload(t)
 }
 
 export async function waitForLoading(t: TestController): Promise<void> {
@@ -191,4 +191,8 @@ export function urbanstatsFixture(name: string, url: string, beforeEach: undefin
 
 export async function arrayFromSelector(selector: Selector): Promise<Selector[]> {
     return Array.from({ length: await selector.count }, (_, n) => selector.nth(n))
+}
+
+export async function safeReload(t: TestController): Promise<void> {
+    await t.eval(() => setTimeout(() => { location.reload() }, 0))
 }


### PR DESCRIPTION
We still see occasional test failures due to "navigation interrupted eval"

This should fix this by ensuring the navigation happens after the eval

Add eslint rule to ensure that we don't accidentally use location.reload