### PR TITLE
cache node_modules

### DIFF
--- a/.github/actions/node_modules/action.yml
+++ b/.github/actions/node_modules/action.yml
@@ -1,7 +1,5 @@
 name: 'node_modules'
 description: 'Ensures that node_modules is installed'
-inputs:
-outputs:
 runs:
   using: "composite"
   steps:

--- a/.github/actions/node_modules/action.yml
+++ b/.github/actions/node_modules/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Hash package-lock.json
       run: echo "cache_key=node_modules_$(shasum -a 256 react/package-lock.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+      shell: bash
       id: hash
 
     - name: Cache node_modules
@@ -16,5 +17,6 @@ runs:
     
     - name: Install node modules
       run: npm ci
+      shell: bash
       working-directory: react
       if: steps.cache-node_modules.outputs.cache-hit != 'true'

--- a/.github/actions/node_modules/action.yml
+++ b/.github/actions/node_modules/action.yml
@@ -1,0 +1,22 @@
+name: 'node_modules'
+description: 'Ensures that node_modules is installed'
+inputs:
+outputs:
+runs:
+  using: "composite"
+  steps:
+    - name: Hash package-lock.json
+      run: echo "cache_key=node_modules_$(shasum -a 256 react/package-lock.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+      id: hash
+
+    - name: Cache node_modules
+      id: cache-node_modules
+      uses: actions/cache@v4
+      with:
+        path: react/node_modules
+        key: ${{ steps.hash.outputs.cache_key }}
+    
+    - name: Install node modules
+      run: npm ci
+      working-directory: react
+      if: steps.cache-node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,8 +12,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-        working-directory: react
+      - uses: ./.github/actions/node_modules
       - run: npx eslint .
         working-directory: react
 
@@ -89,6 +88,7 @@ jobs:
       image: ${{ needs.build-and-push-image.outputs.image }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/node_modules
       - run: python3 create_website.py react/test/density-db --no-data --no-geo --no-juxta
       - uses: actions/upload-artifact@v4
         with:
@@ -120,9 +120,9 @@ jobs:
         with:
           name: frontend-build
           path: react/test/density-db
+      - uses: ./.github/actions/node_modules
       - name: Run tests
         run: |
-          npm ci
           npm run test:e2e -- \
             --proxy=true \
             --browser=chromium \

--- a/urbanstats/website_data/build.py
+++ b/urbanstats/website_data/build.py
@@ -115,8 +115,6 @@ def create_react_jsons():
 
 
 def build_react_site(site_folder, dev):
-    subprocess.run(f"cd react; npm {'i' if dev else 'ci'}", shell=True, check=True)
-
     create_react_jsons()
 
     subprocess.run(


### PR DESCRIPTION
Use Github cache instead of reinstalling the modules
Saves about 10s each time they need to install
Which totals to about 30s every run