### PR TITLE
Split dockerfiles in two

### DIFF
--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -4,15 +4,20 @@ inputs:
   dockerfile:
     description: "Path to the Dockerfile"
     required: true
+  repository:
+    description: "The docker respository"
+    required: false
+    default: ${{ github.repository }}/dockerfile-hash
+  registry:
+    description: "The docker registry"
+    required: false
+    default: ghcr.io
 outputs:
   image:
     description: "The fully qualified image generated"
     value: ${{ steps.image.outputs.image }}
 runs:
   using: "composite"
-  env:
-    DOCKER_REGISTRY: ghcr.io
-    DOCKER_REPOSITORY: ${{ github.repository }}/dockerfile-hash
   steps:
     - name: Create the tag by hashing the dockerfile
       id: tag
@@ -21,21 +26,21 @@ runs:
 
     - name: concat the Docker image name
       id: image
-      run: echo "image=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
+      run: echo "image=${{ inputs.registry }}/${{ inputs.repository }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Check for existing image
       id: existing-image
       run: |
         GHCR_TOKEN=$(echo -n ${{ secrets.GITHUB_TOKEN }} | base64)
-        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ env.DOCKER_REGISTRY }}/v2/${{ env.DOCKER_REPOSITORY }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
+        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Log in to the Container registry
       if: ${{ steps.existing-image.outputs.response == '404' }}
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.DOCKER_REGISTRY }}
+        registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -14,8 +14,7 @@ inputs:
     default: ghcr.io
   token:
     description: "The Github token to access ghcr"
-    required: false
-    default: ${{ secrets.GITHUB_TOKEN }}
+    required: true
 outputs:
   image:
     description: "The fully qualified image generated"

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -4,15 +4,24 @@ inputs:
   dockerfile:
     description: "Path to the Dockerfile"
     required: true
+  repository:
+    description: "The docker respository"
+    required: false
+    default: ${{ github.repository }}/dockerfile-hash
+  registry:
+    description: "The docker registry"
+    required: false
+    default: ghcr.io
+  token:
+    description: "The Github token to access ghcr"
+    required: false
+    default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   image:
     description: "The fully qualified image generated"
     value: ${{ steps.image.outputs.image }}
 runs:
   using: "composite"
-  env:
-    DOCKER_REGISTRY: ghcr.io
-    DOCKER_REPOSITORY: ${{ github.repository }}/dockerfile-hash
   steps:
     - name: Create the tag by hashing the dockerfile
       id: tag
@@ -21,23 +30,23 @@ runs:
 
     - name: concat the Docker image name
       id: image
-      run: echo "image=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
+      run: echo "image=${{ inputs.registry }}/${{ inputs.repository }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Check for existing image
       id: existing-image
       run: |
-        GHCR_TOKEN=$(echo -n ${{ secrets.GITHUB_TOKEN }} | base64)
-        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ env.DOCKER_REGISTRY }}/v2/${{ env.DOCKER_REPOSITORY }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
+        GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
+        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Log in to the Container registry
       if: ${{ steps.existing-image.outputs.response == '404' }}
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.DOCKER_REGISTRY }}
+        registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ inputs.token }}
 
     - name: Build and push Docker image
       if: ${{ steps.existing-image.outputs.response == '404' }}

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -4,24 +4,15 @@ inputs:
   dockerfile:
     description: "Path to the Dockerfile"
     required: true
-  repository:
-    description: "The docker respository"
-    required: false
-    default: ${{ github.repository }}/dockerfile-hash
-  registry:
-    description: "The docker registry"
-    required: false
-    default: ghcr.io
-  token:
-    description: "The Github token to access ghcr"
-    required: false
-    default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   image:
     description: "The fully qualified image generated"
     value: ${{ steps.image.outputs.image }}
 runs:
   using: "composite"
+  env:
+    DOCKER_REGISTRY: ghcr.io
+    DOCKER_REPOSITORY: ${{ github.repository }}/dockerfile-hash
   steps:
     - name: Create the tag by hashing the dockerfile
       id: tag
@@ -30,23 +21,23 @@ runs:
 
     - name: concat the Docker image name
       id: image
-      run: echo "image=${{ inputs.registry }}/${{ inputs.repository }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
+      run: echo "image=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Check for existing image
       id: existing-image
       run: |
-        GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
-        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
+        GHCR_TOKEN=$(echo -n ${{ secrets.GITHUB_TOKEN }} | base64)
+        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ env.DOCKER_REGISTRY }}/v2/${{ env.DOCKER_REPOSITORY }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Log in to the Container registry
       if: ${{ steps.existing-image.outputs.response == '404' }}
       uses: docker/login-action@v3
       with:
-        registry: ${{ inputs.registry }}
+        registry: ${{ env.DOCKER_REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ inputs.token }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker image
       if: ${{ steps.existing-image.outputs.response == '404' }}

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "The docker registry"
     required: false
     default: ghcr.io
+  token:
+    description: "The Github token to access ghcr"
+    required: false
+    default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   image:
     description: "The fully qualified image generated"
@@ -32,7 +36,7 @@ runs:
     - name: Check for existing image
       id: existing-image
       run: |
-        GHCR_TOKEN=$(echo -n ${{ secrets.GITHUB_TOKEN }} | base64)
+        GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
         echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
       shell: bash
 
@@ -42,7 +46,7 @@ runs:
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ inputs.token }}
 
     - name: Build and push Docker image
       if: ${{ steps.existing-image.outputs.response == '404' }}

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -1,0 +1,48 @@
+name: "docker_image"
+description: "Based on a Dockerfile hash, checks if an image exists, if not, builds and pushes it"
+inputs:
+  dockerfile:
+    description: "Path to the Dockerfile"
+    required: true
+outputs:
+  image: ${{ steps.image.outputs.image }}
+runs:
+  using: "composite"
+  env:
+    DOCKER_REGISTRY: ghcr.io
+    DOCKER_REPOSITORY: ${{ github.repository }}/dockerfile-hash
+    BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  steps:
+    - name: Create the tag by hashing the dockerfile
+      id: tag
+      run: echo "tag=$(shasum -a 256 ${{ inputs.dockerfile }} | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: concat the Docker image name
+      id: image
+      run: echo "image=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Check for existing image
+      id: existing-image
+      run: |
+        GHCR_TOKEN=$(echo -n ${{ secrets.GITHUB_TOKEN }} | base64)
+        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ env.DOCKER_REGISTRY }}/v2/${{ env.DOCKER_REPOSITORY }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Log in to the Container registry
+      if: ${{ steps.existing-image.outputs.response == '404' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      if: ${{ steps.existing-image.outputs.response == '404' }}
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: true
+        tags: ${{ steps.image.outputs.image }}

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -5,13 +5,14 @@ inputs:
     description: "Path to the Dockerfile"
     required: true
 outputs:
-  image: ${{ steps.image.outputs.image }}
+  image:
+    description: "The fully qualified image generated"
+    value: ${{ steps.image.outputs.image }}
 runs:
   using: "composite"
   env:
     DOCKER_REGISTRY: ghcr.io
     DOCKER_REPOSITORY: ${{ github.repository }}/dockerfile-hash
-    BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   steps:
     - name: Create the tag by hashing the dockerfile
       id: tag

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,6 @@ jobs:
     outputs:
       image: ${{ steps.image.outputs.image }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repository
@@ -34,7 +33,6 @@ jobs:
     outputs:
       image: ${{ steps.image.outputs.image }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,5 @@
 name: check
 on: [push]
-env:
-  DOCKER_REGISTRY: ghcr.io
-  DOCKER_REPOSITORY: ${{ github.repository }}/e2e
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 jobs:
   lint:
     runs-on: ubuntu-22.04
@@ -16,54 +12,40 @@ jobs:
       - run: npx eslint .
         working-directory: react
 
-  build-and-push-image:
+  build-and-push-common-image:
     runs-on: ubuntu-22.04
     outputs:
       image: ${{ steps.image.outputs.image }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Create the tag by hashing react/test/Dockerfile
-        id: tag
-        run: echo "tag=$(shasum -a 256 react/test/Dockerfile | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-
-      - name: concat the Docker image name
+      - uses: ./.github/actions/docker_image
+        with: Dockerfile
         id: image
-        run: echo "image=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY }}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
 
-      - name: Check for existing image
-        id: existing-image
-        run: |
-          GHCR_TOKEN=$(echo -n ${{ secrets.GITHUB_TOKEN }} | base64)
-          echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ env.DOCKER_REGISTRY }}/v2/${{ env.DOCKER_REPOSITORY }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
+  build-and-push-e2e-image:
+    runs-on: ubuntu-22.04
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
-        if: ${{ steps.existing-image.outputs.response == '404' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        if: ${{ steps.existing-image.outputs.response == '404' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: react/test/Dockerfile
-          push: true
-          tags: ${{ steps.image.outputs.image }}
+      - uses: ./.github/actions/docker_image
+        with: react/test/Dockerfile
+        id: image
 
   lint-python:
     runs-on: ubuntu-22.04
 
-    needs: build-and-push-image
+    needs: build-and-push-common-image
     container:
-      image: ${{ needs.build-and-push-image.outputs.image }}
+      image: ${{ needs.build-and-push-common-image.outputs.image }}
 
     steps:
       - uses: actions/checkout@v4
@@ -84,9 +66,9 @@ jobs:
 
   build-frontend:
     runs-on: ubuntu-22.04
-    needs: build-and-push-image
+    needs: build-and-push-common-image
     container:
-      image: ${{ needs.build-and-push-image.outputs.image }}
+      image: ${{ needs.build-and-push-common-image.outputs.image }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python_environment
@@ -109,9 +91,9 @@ jobs:
 
   run-e2e-tests:
     runs-on: ubuntu-22.04
-    needs: [build-and-push-image, build-frontend, list-e2e-tests]
+    needs: [build-and-push-e2e-image, build-frontend, list-e2e-tests]
     container:
-      image: ${{ needs.build-and-push-image.outputs.image }}
+      image: ${{ needs.build-and-push-e2e-image.outputs.image }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/docker_image
-        with: Dockerfile
+        with:
+          dockerfile: Dockerfile
         id: image
 
   build-and-push-e2e-image:
@@ -37,7 +38,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/docker_image
-        with: react/test/Dockerfile
+        with:
+          dockerfile: react/test/Dockerfile
         id: image
 
   lint-python:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       image: ${{ steps.image.outputs.image }}
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Checkout repository
@@ -32,6 +33,7 @@ jobs:
     outputs:
       image: ${{ steps.image.outputs.image }}
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: ./.github/actions/docker_image
         with:
           dockerfile: Dockerfile
+          token: ${{ secrets.GITHUB_TOKEN }}
         id: image
 
   build-and-push-e2e-image:
@@ -42,6 +43,7 @@ jobs:
       - uses: ./.github/actions/docker_image
         with:
           dockerfile: react/test/Dockerfile
+          token: ${{ secrets.GITHUB_TOKEN }}
         id: image
 
   lint-python:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# You may want to update react/test/Dockerfile when updating this file
+# This version for compatibility with pandas
+FROM python:3.10
+
+# 😭
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt-get install -y nodejs
+
+RUN pip3 install --upgrade pip virtualenv
+RUN pip3 cache purge
+
+ENTRYPOINT [ "/bin/bash" ] 

--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -1,9 +1,13 @@
+# You may want to update ../../Dockerfile when updating this file
 # This version for compatibility with pandas
 FROM python:3.10
 
 # 😭
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs
+
+RUN pip3 install --upgrade pip virtualenv
+RUN pip3 cache purge
 
 RUN dpkg --add-architecture i386
 RUN apt-get -y update
@@ -20,9 +24,5 @@ RUN apt-get -y install fluxbox
 
 # needed for downloads directory in TestCafe
 RUN apt-get -y install xdg-user-dirs
-
-COPY ./requirements.txt ./
-RUN pip3 install --upgrade pip virtualenv
-RUN pip3 cache purge
 
 ENTRYPOINT [ "/bin/bash" ] 


### PR DESCRIPTION
We had just one Dockerfile for all jobs, which was overkill, as some jobs (e.g. linting) don't need packages (e.g. Chromium) that only are used for e2e testing.

The Dockerfile without chromium is smaller and faster.