### PR TITLE
bump versions of shapefiles

### DIFF
--- a/urbanstats/geometry/shapefiles/shapefiles/continents.py
+++ b/urbanstats/geometry/shapefiles/shapefiles/continents.py
@@ -9,7 +9,7 @@ from urbanstats.universe.universe_provider.constant_provider import (
 from urbanstats.universe.universe_provider.self_provider import SelfUniverseProvider
 
 CONTINENTS = Shapefile(
-    hash_key="continents_3",
+    hash_key="continents_6",
     path=continents,
     shortname_extractor=lambda x: x.name_1,
     longname_extractor=lambda x: x.name_1,

--- a/urbanstats/geometry/shapefiles/shapefiles/countries.py
+++ b/urbanstats/geometry/shapefiles/shapefiles/countries.py
@@ -20,7 +20,7 @@ def extract_country_longname(x):
 
 
 COUNTRIES = Shapefile(
-    hash_key="countries_10",
+    hash_key="countries_12",
     path=countries,
     shortname_extractor=extract_country_longname,
     longname_extractor=extract_country_longname,

--- a/urbanstats/geometry/shapefiles/shapefiles/subnational_regions.py
+++ b/urbanstats/geometry/shapefiles/shapefiles/subnational_regions.py
@@ -23,7 +23,7 @@ def valid_state(x):
 
 
 SUBNATIONAL_REGIONS = Shapefile(
-    hash_key="subnational_regions_12",
+    hash_key="subnational_regions_15",
     path=subnational_regions,
     shortname_extractor=lambda x: x["NAME"],
     longname_extractor=lambda x: x["fullname"],


### PR DESCRIPTION
because a lot of the intermediate versions are in caches with the shapefile boundaries