### PR TITLE
Improve map loading performance on high-latency connections

### DIFF
--- a/react/src/components/map.tsx
+++ b/react/src/components/map.tsx
@@ -311,7 +311,7 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
         this.exist_this_time.push(name)
         if (this.polygon_by_name.has(name)) {
             this.polygon_by_name.get(name)!.setStyle(style)
-            return () => {}
+            return () => undefined
         }
         const geojson = await this.polygon_geojson(name)
         return () => {

--- a/react/src/components/map.tsx
+++ b/react/src/components/map.tsx
@@ -245,9 +245,7 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
     }
 
     async add_polygons(map: L.Map, names: string[], styles: Record<string, unknown>[], zoom_to: number): Promise<void> {
-        for (let i = 0; i < names.length; i++) {
-            await this.add_polygon(map, names[i], i === zoom_to, styles[i])
-        }
+        await Promise.all(names.map((name, i) => this.add_polygon(map, name, i === zoom_to, styles[i])))
     }
 
     async polygon_geojson(name: string): Promise<GeoJSON.Feature> {

--- a/react/src/components/map.tsx
+++ b/react/src/components/map.tsx
@@ -245,7 +245,25 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
     }
 
     async add_polygons(map: L.Map, names: string[], styles: Record<string, unknown>[], zoom_to: number): Promise<void> {
-        await Promise.all(names.map((name, i) => this.add_polygon(map, name, i === zoom_to, styles[i])))
+        /*
+         * We want to parallelize polygon loading, but we also need to add the polygons in a deterministic order for testing purposes (as well as to show contained polygons atop their parent)
+         * So, we start all the loads asynchronously, but actually add the polygons to the map only as they finish loading in order
+         * Waiting for all the polygons to load before adding them produces an unacceptable delay
+         */
+        let adderIndex = 0
+        const adders = new Map<number, () => void>()
+        const addDone = (): void => {
+            while (adders.has(adderIndex)) {
+                adders.get(adderIndex)!()
+                adders.delete(adderIndex)
+                adderIndex++
+            }
+        }
+        await Promise.all(names.map(async (name, i) => {
+            const adder = await this.add_polygon(map, name, i === zoom_to, styles[i])
+            adders.set(i, adder)
+            addDone()
+        }))
     }
 
     async polygon_geojson(name: string): Promise<GeoJSON.Feature> {
@@ -285,37 +303,43 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
         return geojson
     }
 
-    async add_polygon(map: L.Map, name: string, fit_bounds: boolean, style: Record<string, unknown>, add_callback = true, add_to_bottom = false): Promise<void> {
+    /*
+     * Returns a function that adds the polygon.
+     * The reason for this is so that we can add the polygons in a specific order independent of the order in which they end up loading
+     */
+    async add_polygon(map: L.Map, name: string, fit_bounds: boolean, style: Record<string, unknown>, add_callback = true, add_to_bottom = false): Promise<() => void> {
         this.exist_this_time.push(name)
         if (this.polygon_by_name.has(name)) {
             this.polygon_by_name.get(name)!.setStyle(style)
-            return
+            return () => {}
         }
         const geojson = await this.polygon_geojson(name)
-        const group = L.featureGroup()
-        let polygon = L.geoJson(geojson, {
-            style,
-            // @ts-expect-error smoothFactor not included in library type definitions
-            smoothFactor: 0.1,
-            className: `tag-${name.replace(/ /g, '_')}`,
-        })
-        if (add_callback) {
-            polygon = polygon.on('click', () => {
-                void this.context.navigate({
-                    kind: 'article',
-                    universe: this.context.universe,
-                    longname: name,
-                }, 'push')
+        return () => {
+            const group = L.featureGroup()
+            let polygon = L.geoJson(geojson, {
+                style,
+                // @ts-expect-error smoothFactor not included in library type definitions
+                smoothFactor: 0.1,
+                className: `tag-${name.replace(/ /g, '_')}`,
             })
-        }
+            if (add_callback) {
+                polygon = polygon.on('click', () => {
+                    void this.context.navigate({
+                        kind: 'article',
+                        universe: this.context.universe,
+                        longname: name,
+                    }, 'push')
+                })
+            }
 
-        // @ts-expect-error Second parameter not included in library type definitions
-        group.addLayer(polygon, add_to_bottom)
-        if (fit_bounds) {
-            map.fitBounds(group.getBounds(), { animate: false })
+            // @ts-expect-error Second parameter not included in library type definitions
+            group.addLayer(polygon, add_to_bottom)
+            if (fit_bounds) {
+                map.fitBounds(group.getBounds(), { animate: false })
+            }
+            map.addLayer(group)
+            this.polygon_by_name.set(name, group)
         }
-        map.addLayer(group)
-        this.polygon_by_name.set(name, group)
     }
 
     zoom_to_all(): void {

--- a/react/src/navigation/navigator.tsx
+++ b/react/src/navigation/navigator.tsx
@@ -284,8 +284,8 @@ async function loadPageDescriptor(newDescriptor: PageDescriptor, settings: Setti
             const statcol = stats[statIndex]
             const explanation_page = explanation_pages[statIndex]
 
+            const data = load_ordering_protobuf(statUniverse, statpath, newDescriptor.article_type, true).then(result => result as NormalizeProto<IDataList>)
             const article_names = await load_ordering(statUniverse, statpath, newDescriptor.article_type)
-            const data = await load_ordering_protobuf(statUniverse, statpath, newDescriptor.article_type, true) as NormalizeProto<IDataList>
 
             let parsedAmount: number
             if (newDescriptor.amount === 'All') {
@@ -309,7 +309,7 @@ async function loadPageDescriptor(newDescriptor: PageDescriptor, settings: Setti
                     start: newDescriptor.start,
                     amount: parsedAmount,
                     article_names,
-                    data,
+                    data: await data,
                     rendered_statname: newDescriptor.statname,
                     universe: statUniverse,
 


### PR DESCRIPTION
Do this by parallelizing shapefile requests

Also, parallelize requests when loading stats page

Before (artificial 100ms latency)


https://github.com/user-attachments/assets/2f004b93-c2ec-4c02-9281-31dbdcd611d3


After (artificial 100ms latency)

https://github.com/user-attachments/assets/536186b8-f17a-414f-82ae-69e442dbfcae