### PR TITLE
Improve SPA

### DIFF
--- a/react/src/components/QuerySettingsConnection.tsx
+++ b/react/src/components/QuerySettingsConnection.tsx
@@ -101,9 +101,6 @@ export function settingsConnectionConfig({ pageKind, statPaths, settings }: { pa
 export function applySettingsParam(settingsVector: string, settings: Settings, availableStatPaths: StatPath[][], { stagedSettingsKeys, applySettingsKeys }: SettingsConnectionConfig): void {
     const settingsFromQueryParams = fromVector(settingsVector, settings)
     if (stagedSettingsKeys.some(key => JSON.stringify(settingsFromQueryParams[key]) !== JSON.stringify(settings.get(key)))) {
-        if (settings.getStagedKeys() !== undefined) {
-            settings.exitStagedMode('discard')
-        }
         settings.enterStagedMode(Object.fromEntries(stagedSettingsKeys.map(key => [key, settingsFromQueryParams[key]])) as unknown as Partial<SettingsDictionary>)
         // If we haven't saved any previous settings, just save these staged settings
         // This ensures that the new user doesn't get non-default values for settings that aren't relevant to their linked page

--- a/react/src/components/QuerySettingsConnection.tsx
+++ b/react/src/components/QuerySettingsConnection.tsx
@@ -101,6 +101,9 @@ export function settingsConnectionConfig({ pageKind, statPaths, settings }: { pa
 export function applySettingsParam(settingsVector: string, settings: Settings, availableStatPaths: StatPath[][], { stagedSettingsKeys, applySettingsKeys }: SettingsConnectionConfig): void {
     const settingsFromQueryParams = fromVector(settingsVector, settings)
     if (stagedSettingsKeys.some(key => JSON.stringify(settingsFromQueryParams[key]) !== JSON.stringify(settings.get(key)))) {
+        if (settings.getStagedKeys() !== undefined) {
+            settings.exitStagedMode('discard')
+        }
         settings.enterStagedMode(Object.fromEntries(stagedSettingsKeys.map(key => [key, settingsFromQueryParams[key]])) as unknown as Partial<SettingsDictionary>)
         // If we haven't saved any previous settings, just save these staged settings
         // This ensures that the new user doesn't get non-default values for settings that aren't relevant to their linked page

--- a/react/src/navigation/navigator.tsx
+++ b/react/src/navigation/navigator.tsx
@@ -113,7 +113,7 @@ const historyStateSchema = z.object({
     scrollPosition: z.number(),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- This is a typecheck. Ensures that history does not have effects
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Ensures that history does not have effects. (aka that stored history state will be able to be parsed)
 ((typeCheck: z.ZodType<HistoryState, z.ZodTypeDef, HistoryState>): void => undefined)(historyStateSchema)
 
 type HistoryState = z.infer<typeof historyStateSchema>

--- a/react/src/navigation/navigator.tsx
+++ b/react/src/navigation/navigator.tsx
@@ -564,8 +564,11 @@ export class Navigator {
                 this.effects.push(() => { window.scrollTo({ top: scrollPosition }) })
             }
             else if (url.hash !== '') {
-                window.location.replace(url.hash)
-                history.replaceState({ pageDescriptor: newPageDescriptor, scrollPosition: window.scrollY }, '')
+                this.effects.push(() => {
+                    window.location.replace(url.hash)
+                    // Above statement clears state
+                    history.replaceState({ pageDescriptor: newPageDescriptor, scrollPosition: window.scrollY }, '')
+                })
             }
             else if (oldData.kind !== this.pageState.current.data.kind) {
                 this.effects.push(() => { window.scrollTo({ top: 0 }) })

--- a/react/src/navigation/navigator.tsx
+++ b/react/src/navigation/navigator.tsx
@@ -122,6 +122,7 @@ window.history.scrollRestoration = 'manual'
 const history = window.history as {
     replaceState: (data: HistoryState, unused: string, url?: string | URL | null) => void
     pushState: (data: HistoryState, unused: string, url?: string | URL | null) => void
+    state: HistoryState
 }
 
 export type PageDescriptor = z.infer<typeof pageDescriptorSchema>
@@ -513,21 +514,16 @@ export class Navigator {
                 location.reload()
             }
         })
+        window.addEventListener('scroll', () => {
+            history.replaceState({ ...history.state, scrollPosition: window.scrollY }, '')
+        })
     }
 
     async navigate(newDescriptor: PageDescriptor, kind: 'push' | 'replace' | null, scrollPosition?: number): Promise<void> {
-        this.effects = [] // If we're starting another navigation, don't clear previous effects
+        this.effects = [] // If we're starting another navigation, don't use previous effects
 
         switch (kind) {
             case 'push':
-                switch (this.pageState.current.descriptor.kind) {
-                    case 'initialLoad':
-                    case 'error':
-                        break
-                    default:
-                        // Save old scroll position as we navigate away
-                        history.replaceState({ pageDescriptor: this.pageState.current.descriptor, scrollPosition: window.scrollY }, '')
-                }
                 history.pushState({ pageDescriptor: newDescriptor, scrollPosition: scrollPosition ?? window.scrollY }, '', urlFromPageDescriptor(newDescriptor))
                 break
             case 'replace':

--- a/react/src/navigation/routers.tsx
+++ b/react/src/navigation/routers.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useContext } from 'react'
+import React, { CSSProperties, ReactNode, useContext, useEffect } from 'react'
 import { ZodError } from 'zod'
 
 import { AboutPanel } from '../components/AboutPanel'
@@ -18,6 +18,12 @@ import { Navigator, PageData } from './navigator'
 export function Router(): ReactNode {
     const navigator = useContext(Navigator.Context)
     const pageState = navigator.usePageState()
+
+    useEffect(() => {
+        // Execute the navigator's effects
+        navigator.effects.forEach((effect) => { effect() })
+        navigator.effects = []
+    })
 
     return (
         <>

--- a/react/src/navigation/routers.tsx
+++ b/react/src/navigation/routers.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useContext, useEffect } from 'react'
+import React, { CSSProperties, ReactNode, useContext } from 'react'
 import { ZodError } from 'zod'
 
 import { AboutPanel } from '../components/AboutPanel'
@@ -13,37 +13,11 @@ import { useColors } from '../page_template/colors'
 import { PageTemplate } from '../page_template/template'
 
 import { InitialLoad, SubsequentLoad } from './loading'
-import { Navigator, PageData, PageDescriptor, urlFromPageDescriptor } from './navigator'
+import { Navigator, PageData } from './navigator'
 
 export function Router(): ReactNode {
     const navigator = useContext(Navigator.Context)
-
-    useEffect(() => {
-        // Hook into the browser back/forward buttons
-        const listener = (popStateEvent: PopStateEvent): void => {
-            if (popStateEvent.state === null) {
-                // When we use window.location.replace below
-                return
-            }
-            void navigator.navigate(popStateEvent.state as PageDescriptor, null)
-        }
-        window.addEventListener('popstate', listener)
-        return () => { window.removeEventListener('popstate', listener) }
-    }, [navigator])
-
     const pageState = navigator.usePageState()
-
-    const url = urlFromPageDescriptor(pageState.current.descriptor)
-
-    useEffect(() => {
-        if (url.hash !== '' && !['initialLoad', 'error'].includes(pageState.current.descriptor.kind)) {
-            /* eslint-disable no-restricted-syntax -- Core navigation functionality */
-            window.location.replace(url.hash)
-            history.replaceState(pageState.current.descriptor, '')
-            /* eslint-enable no-restricted-syntax */
-        }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Should only execute when the hash changes
-    }, [url.hash])
 
     return (
         <>

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -30,6 +30,7 @@ test('maintain and restore scroll position back/forward', async (t) => {
     await t.scroll(0, 100)
     await t.click(Selector('a').withText('New York'))
     await t.scroll(0, 400)
+    await screencap(t)
     await t.click(Selector('a').withText('Connecticut'))
     await t.expect(getScroll()).eql(400) // Does not reset scroll on same page type
     await t.scroll(0, 500)

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -22,7 +22,7 @@ const goBack = ClientFunction(() => { window.history.back() })
 const goForward = ClientFunction(() => { window.history.forward() })
 const getScroll = ClientFunction(() => window.scrollY)
 
-test('maintain and restore scroll position back/forward', async (t) => {
+test('maintain and restore scroll position back-forward', async (t) => {
     await t.navigateTo('/article.html?longname=Texas%2C+USA')
     await t.scroll(0, 200)
     await t.click(Selector('a').withExactText('Population'))

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -26,12 +26,14 @@ test('maintain and restore scroll position back-forward', async (t) => {
     await t.navigateTo('/article.html?longname=Texas%2C+USA')
     await t.scroll(0, 200)
     await t.click(Selector('a').withExactText('Population'))
+    await t.expect(Selector('.headertext').withText('Population').exists).ok()
     await t.expect(getScroll()).eql(0) // Resets scroll on different page type
     await t.scroll(0, 100)
     await t.click(Selector('a').withText('New York'))
+    await t.expect(Selector('.headertext').withText('New York').exists).ok()
     await t.scroll(0, 400)
-    await screencap(t, { fullPage: false })
     await t.click(Selector('a').withText('Connecticut'))
+    await t.expect(Selector('.headertext').withText('Connecticut').exists).ok()
     await t.expect(getScroll()).eql(400) // Does not reset scroll on same page type
     await t.scroll(0, 500)
     await goBack()

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -30,7 +30,7 @@ test('maintain and restore scroll position back/forward', async (t) => {
     await t.scroll(0, 100)
     await t.click(Selector('a').withText('New York'))
     await t.scroll(0, 400)
-    await screencap(t)
+    await screencap(t, { fullPage: false })
     await t.click(Selector('a').withText('Connecticut'))
     await t.expect(getScroll()).eql(400) // Does not reset scroll on same page type
     await t.scroll(0, 500)

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -14,6 +14,7 @@ test('two randoms mobile', async (t) => {
     await t.expect(Selector('a').withText('Weighted by Population (US only)').exists).notOk()
     await t.click('.hamburgermenu')
     await t.click(Selector('a').withText('Weighted by Population (US only)'))
+    await t.wait(5000) // Wait for random
     await t.expect(Selector('a').withText('Weighted by Population (US only)').exists).notOk()
 })
 


### PR DESCRIPTION
- Get out of staging mode if we go to a non-settings-vector page.
- Changes to scroll position handling
  - Save scroll position as part of the history state
  - Restore scroll position on back/forward
  - Scroll to top when navigating to different kinds of pages
- Add somewhat graceful handling of history state evolution, use zod schemas to parse it, and reload if failure.
- Add an effect system for navigator page loads, so that loading a page can have effects that are executed after it renders. (This is used for scrolling ,etc)
- Move around some event listeners into the navigator rather than in the router.

Closes #715 
Closes #716 