### PR TITLE
Fix stats tree mobile test

### DIFF
--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -203,4 +203,5 @@ export async function arrayFromSelector(selector: Selector): Promise<Selector[]>
 export async function safeReload(t: TestController): Promise<void> {
     // eslint-disable-next-line no-restricted-syntax -- This is the utility that replaces location.reload()
     await t.eval(() => setTimeout(() => { location.reload() }, 0))
+    await t.expect(Selector('[data-test-id=initialLoad]').exists).notOk() // Wait for initial loading to finish
 }


### PR DESCRIPTION
Because we're an SPA, we need to wait for initial loading before doing things on the page