### PR TITLE
Fix quiz friends test flakiness

### DIFF
--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -856,15 +856,17 @@ export function EditableString(props: { content: string, onNewContent: (content:
      */
 
     const contentEditable: React.Ref<HTMLElement> = useRef(null)
-    const [html, setHtml] = useState(props.content.toString())
+    const html = useRef(props.content.toString())
+    const [, setCounter] = useState(0)
 
     // Otherwise, this component can display the wrong number when props change
     useEffect(() => {
-        setHtml(props.content.toString())
+        html.current = props.content.toString()
+        setCounter(count => count + 1)
     }, [props.content])
 
     const handleChange = (evt: ContentEditableEvent): void => {
-        setHtml(evt.target.value)
+        html.current = evt.target.value
     }
 
     const handleSubmit = (): void => {
@@ -889,7 +891,7 @@ export function EditableString(props: { content: string, onNewContent: (content:
             className="editable_content"
             style={props.style}
             innerRef={contentEditable}
-            html={html}
+            html={html.current}
             disabled={false}
             onChange={handleChange}
             onKeyDown={(e: React.KeyboardEvent) => {


### PR DESCRIPTION
Was running into a modified version of https://www.npmjs.com/package/react-contenteditable#known-issues

where react will batch re-rendering from useState as a performance optimization

the problem was that an old state that was batched would get rendered in while typing, overwriting a newer one

Debug version of react-contenteditable (place in node_modules/react-contenteditable/lib)

[react-contenteditable.js.zip](https://github.com/user-attachments/files/18176498/react-contenteditable.js.zip)
