### PR TITLE
Explicitly specify scroll on every navigation

### DIFF
--- a/react/src/components/IndexPanel.tsx
+++ b/react/src/components/IndexPanel.tsx
@@ -24,7 +24,7 @@ export function IndexPanel(): ReactNode {
                         interested in these topics. The data is collected from a variety of sources, including the US Census,
                         the GHSL dataset, VEST, and several US government agencies. See
                         {' '}
-                        <a {...navContext.link({ kind: 'dataCredit', hash: '' })}>Data Credit</a>
+                        <a {...navContext.link({ kind: 'dataCredit', hash: '' }, { scroll: 0 })}>Data Credit</a>
                         {' '}
                         for more information.
                     </p>

--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -116,7 +116,7 @@ function ComparisonSearchBox({ longname }: { longname: string }): ReactNode {
                 kind: 'comparison',
                 universe: currentUniverse,
                 longnames: [longname, x],
-            })}
+            }, { scroll: 0 })}
             autoFocus={false}
         />
     )
@@ -150,7 +150,7 @@ function StatisticTableRow(props: { shortname: string, longname: string, row: Ar
                             kind: 'article',
                             longname: newArticle,
                             universe: currentUniverse,
-                        }, 'push')
+                        }, { history: 'push', scroll: null })
                     }}
                     simpleOrdinals={simpleOrdinals}
                 />

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -150,7 +150,7 @@ export function ComparisonPanel(props: { universes: string[], articles: Article[
                                         kind: 'comparison',
                                         universe: currentUniverse,
                                         longnames: [...names, x],
-                                    })}
+                                    }, { scroll: null })}
                                 autoFocus={false}
                             />
                         </div>
@@ -174,14 +174,14 @@ export function ComparisonPanel(props: { universes: string[], articles: Article[
                                                         kind: 'comparison',
                                                         universe: currentUniverse,
                                                         longnames: names.filter((_, index) => index !== i),
-                                                    }, 'push')
+                                                    }, { history: 'push', scroll: null })
                                                 }}
                                                 onReplace={x =>
                                                     navContext.link({
                                                         kind: 'comparison',
                                                         universe: currentUniverse,
                                                         longnames: names.map((value, index) => index === i ? x : value),
-                                                    })}
+                                                    }, { scroll: null })}
                                             />
                                         </div>,
                                     ),
@@ -311,7 +311,7 @@ function ComparisonCells({ names, rows, onlyColumns, blankColumns }: {
                         kind: 'comparison',
                         universe: navContext.universe,
                         longnames: names.map((value, index) => index === i ? x : value),
-                    }, 'push')
+                    }, { history: 'push', scroll: null })
                 }}
                 totalWidth={each(rows)}
             />
@@ -410,7 +410,7 @@ function HeadingDisplay({ longname, includeDelete, onDelete, onReplace }: { long
                         kind: 'article',
                         longname,
                         universe: currentUniverse,
-                    })
+                    }, { scroll: 0 })
                 }
                 style={{ textDecoration: 'none' }}
             >

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -65,7 +65,7 @@ export function Header(props: {
                                     kind: 'article',
                                     universe: currentUniverse,
                                     longname: newLocation,
-                                })
+                                }, { scroll: 0 })
                             }
                             placeholder="Search Urban Stats"
                             style={{
@@ -122,7 +122,7 @@ function HeaderImage(): ReactNode {
     const navContext = useContext(Navigator.Context)
     return (
         <a
-            {...navContext.link({ kind: 'index' })}
+            {...navContext.link({ kind: 'index' }, { scroll: 0 })}
         >
             <img
                 src={path}

--- a/react/src/components/map.tsx
+++ b/react/src/components/map.tsx
@@ -328,7 +328,7 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
                         kind: 'article',
                         universe: this.context.universe,
                         longname: name,
-                    }, { history: 'push', scroll: 0 })
+                    }, { history: 'push', scroll: null })
                 })
             }
 

--- a/react/src/components/map.tsx
+++ b/react/src/components/map.tsx
@@ -328,7 +328,7 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
                         kind: 'article',
                         universe: this.context.universe,
                         longname: name,
-                    }, 'push')
+                    }, { history: 'push', scroll: 0 })
                 })
             }
 

--- a/react/src/components/related-button.tsx
+++ b/react/src/components/related-button.tsx
@@ -45,7 +45,7 @@ function RelatedButton(props: { region: Region }): ReactNode {
             <a
                 className={classes}
                 style={{ color: colors.textMain, backgroundColor: mixWithBackground(color, colors.mixPct / 100, colors.background) }}
-                {...navContext.link({ kind: 'article', longname: props.region.longname, universe: currentUniverse })}
+                {...navContext.link({ kind: 'article', longname: props.region.longname, universe: currentUniverse }, { scroll: 0 })}
             >
                 {props.region.shortname}
             </a>

--- a/react/src/components/sidebar.tsx
+++ b/react/src/components/sidebar.tsx
@@ -55,16 +55,16 @@ export function Sidebar({ onNavigate }: { onNavigate: () => void }): ReactNode {
                 <div style={sidebarSectionTitle}>Main Menu</div>
                 <ul className={sidebarSectionContent}>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'index' }, onNavigate)}>Home</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'index' }, { scroll: 0, postNavigationCallback: onNavigate })}>Home</a>
                     </li>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'about' }, onNavigate)}>About Urban Stats</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'about' }, { scroll: 0, postNavigationCallback: onNavigate })}>About Urban Stats</a>
                     </li>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'dataCredit', hash: '' }, onNavigate)}>Data Credit</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'dataCredit', hash: '' }, { scroll: 0, postNavigationCallback: onNavigate })}>Data Credit</a>
                     </li>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'mapper', view: false }, onNavigate)}>Mapper (beta)</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'mapper', view: false }, { scroll: 0, postNavigationCallback: onNavigate })}>Mapper (beta)</a>
                     </li>
                 </ul>
             </div>
@@ -72,13 +72,13 @@ export function Sidebar({ onNavigate }: { onNavigate: () => void }): ReactNode {
                 <div style={sidebarSectionTitle}>Random</div>
                 <ul className={sidebarSectionContent}>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'random', sampleby: 'uniform', us_only: false }, onNavigate)}>Unweighted</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'random', sampleby: 'uniform', us_only: false }, { scroll: 0, postNavigationCallback: onNavigate })}>Unweighted</a>
                     </li>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'random', sampleby: 'population', us_only: false }, onNavigate)}>Weighted by Population</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'random', sampleby: 'population', us_only: false }, { scroll: 0, postNavigationCallback: onNavigate })}>Weighted by Population</a>
                     </li>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'random', sampleby: 'population', us_only: true }, onNavigate)}>Weighted by Population (US only)</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'random', sampleby: 'population', us_only: true }, { scroll: 0, postNavigationCallback: onNavigate })}>Weighted by Population (US only)</a>
                     </li>
                 </ul>
             </div>
@@ -86,10 +86,10 @@ export function Sidebar({ onNavigate }: { onNavigate: () => void }): ReactNode {
                 <div style={sidebarSectionTitle}>Games</div>
                 <ul className={sidebarSectionContent}>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'quiz' }, onNavigate)}>Juxtastat</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'quiz' }, { scroll: 0, postNavigationCallback: onNavigate })}>Juxtastat</a>
                     </li>
                     <li>
-                        <a style={linkStyle} {...navContext.link({ kind: 'quiz', mode: 'retro' }, onNavigate)}>Retrostat</a>
+                        <a style={linkStyle} {...navContext.link({ kind: 'quiz', mode: 'retro' }, { scroll: 0, postNavigationCallback: onNavigate })}>Retrostat</a>
                     </li>
                 </ul>
             </div>

--- a/react/src/components/statistic-panel.tsx
+++ b/react/src/components/statistic-panel.tsx
@@ -80,7 +80,10 @@ export function StatisticPanel(props: StatisticPanelProps): ReactNode {
             start: 1,
             amount: props.amount,
             order: newOrder,
-        }), 'push')
+        }), {
+            history: 'push',
+            scroll: null,
+        })
     }
 
     const backgroundColor = (rowIdx: number): string => {
@@ -221,7 +224,10 @@ function Pagination(props: {
             universe: currentUniverse,
             ...props,
             start: newStart,
-        }), 'push')
+        }), {
+            history: 'push',
+            scroll: null,
+        })
     }
 
     const changeAmount = (newAmount: string | number): void => {
@@ -247,7 +253,10 @@ function Pagination(props: {
             start,
             amount: newAmount === 'All' ? 'All' : newAmountNum,
             order: props.order,
-        }), 'push')
+        }), {
+            history: 'push',
+            scroll: null,
+        })
     }
 
     const current = props.start
@@ -268,7 +277,10 @@ function Pagination(props: {
                 amount: props.amount,
                 order: props.order,
                 start: (newPage - 1) * perPage + 1,
-            }), 'replace')
+            }), {
+                history: 'replace',
+                scroll: null,
+            })
         }
 
         if (currentPage > maxPages) {
@@ -302,7 +314,14 @@ function Pagination(props: {
         >
             <div style={{ width: '25%' }}>
                 <div style={{ margin: 'auto', textAlign: 'center' }}>
-                    <a {...navContext.link({ kind: 'dataCredit', hash: `#explanation_${sanitize(props.explanationPage)}` })}>Data Explanation and Credit</a>
+                    <a
+                        {...navContext.link(
+                            { kind: 'dataCredit', hash: `#explanation_${sanitize(props.explanationPage)}` },
+                            { scroll: null },
+                        )}
+                    >
+                        Data Explanation and Credit
+                    </a>
                 </div>
             </div>
             <div style={{ width: '50%' }}>
@@ -453,7 +472,7 @@ function ArticleLink(props: { longname: string }): ReactNode {
                 kind: 'article',
                 longname: props.longname,
                 universe: currentUniverse,
-            })}
+            }, { scroll: 0 })}
             style={{ fontWeight: 500, color: colors.textMain, textDecoration: 'none' }}
         >
             {props.longname}

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -445,7 +445,7 @@ function StatisticName(props: {
                     amount: 20,
                     order: 'descending',
                     highlight: props.longname,
-                }))
+                }), { scroll: 0 })
             }
         >
             {props.row.renderedStatname}
@@ -986,7 +986,7 @@ function PointerButtonIndex(props: {
                     kind: 'article',
                     longname: name,
                     universe,
-                }, 'push')
+                }, { history: 'push', scroll: null })
                 return
             }
         }

--- a/react/src/navigation/navigator.tsx
+++ b/react/src/navigation/navigator.tsx
@@ -463,6 +463,11 @@ function loadingStateFromPageState(pageState: PageState): SubsequentLoadingState
     return Date.now() - pageState.loadStartTime >= quickThresholdDuration ? { kind: 'longLoad', updateAt: undefined } : { kind: 'quickLoad', updateAt: pageState.loadStartTime + quickThresholdDuration }
 }
 
+export interface NavigationOptions {
+    history: 'push' | 'replace' | null // What should we do with this browser history? `null` means nothing, usually you want 'push' or 'replace'
+    scroll: number | null // Where should we scroll to after the navigation? `null` maintains the current scroll position, a number scrolls to that position (0 for top of page). If you're navigating to a hash, passing `null` means we'll scroll to the hash anchor
+}
+
 export class Navigator {
     /* eslint-disable react-hooks/rules-of-hooks, no-restricted-syntax -- This is a logic class with custom hooks and core navigation functions */
     static Context = createContext(new Navigator())
@@ -483,7 +488,7 @@ export class Navigator {
                 current: { descriptor: { kind: 'initialLoad', url }, data: { kind: 'initialLoad' } },
                 loadStartTime: Date.now(),
             }
-            void this.navigate(this.pageState.loading.descriptor, 'replace')
+            void this.navigate(this.pageState.loading.descriptor, { history: 'replace', scroll: null })
         }
         catch (error) {
             const url = new URL(window.location.href)
@@ -496,7 +501,7 @@ export class Navigator {
             }
         }
         window.addEventListener('hashchange', () => {
-            void this.navigate(pageDescriptorFromURL(new URL(discordFix(window.location.href))), 'replace')
+            void this.navigate(pageDescriptorFromURL(new URL(discordFix(window.location.href))), { history: 'replace', scroll: null })
         })
         window.addEventListener('popstate', (popStateEvent: PopStateEvent): void => {
             if (popStateEvent.state === null) {
@@ -505,7 +510,10 @@ export class Navigator {
             }
             const parseResult = historyStateSchema.safeParse(popStateEvent.state)
             if (parseResult.success) {
-                void this.navigate(parseResult.data.pageDescriptor, null, parseResult.data.scrollPosition)
+                void this.navigate(parseResult.data.pageDescriptor, {
+                    history: null,
+                    scroll: parseResult.data.scrollPosition,
+                })
             }
             else {
                 console.warn(`Failed to parse history state! ${parseResult.error}`)
@@ -523,20 +531,20 @@ export class Navigator {
         window.addEventListener('visibilitychange', () => {
             if (document.visibilityState === 'visible' && this.pageState.kind === 'loading') {
                 console.warn('focused during loading, navigating again')
-                void this.navigate(this.pageState.loading.descriptor, null)
+                void this.navigate(this.pageState.loading.descriptor, { history: null, scroll: null })
             }
         })
     }
 
-    async navigate(newDescriptor: PageDescriptor, kind: 'push' | 'replace' | null, scrollPosition?: number): Promise<void> {
+    async navigate(newDescriptor: PageDescriptor, options: NavigationOptions): Promise<void> {
         this.effects = [] // If we're starting another navigation, don't use previous effects
 
-        switch (kind) {
+        switch (options.history) {
             case 'push':
-                history.pushState({ pageDescriptor: newDescriptor, scrollPosition: scrollPosition ?? window.scrollY }, '', urlFromPageDescriptor(newDescriptor))
+                history.pushState({ pageDescriptor: newDescriptor, scrollPosition: options.scroll ?? window.scrollY }, '', urlFromPageDescriptor(newDescriptor))
                 break
             case 'replace':
-                history.replaceState({ pageDescriptor: newDescriptor, scrollPosition: scrollPosition ?? window.scrollY }, '', urlFromPageDescriptor(newDescriptor))
+                history.replaceState({ pageDescriptor: newDescriptor, scrollPosition: options.scroll ?? window.scrollY }, '', urlFromPageDescriptor(newDescriptor))
                 break
             case null:
                 break
@@ -554,7 +562,7 @@ export class Navigator {
                 return
             }
             const url = urlFromPageDescriptor(newPageDescriptor)
-            history.replaceState({ pageDescriptor: newPageDescriptor, scrollPosition: scrollPosition ?? window.scrollY }, '', url)
+            history.replaceState({ pageDescriptor: newPageDescriptor, scrollPosition: options.scroll ?? window.scrollY }, '', url)
             this.pageState = { kind: 'loaded', current: { data: pageData, descriptor: newPageDescriptor } }
             this.pageStateObservers.forEach((observer) => { observer() })
 
@@ -568,9 +576,9 @@ export class Navigator {
             }
 
             // Jump to
-            if (scrollPosition !== undefined) {
+            if (options.scroll !== null) {
                 // higher priority than hash because we're going back to a page that might have a hash, and we don't want the hash to override the saved scroll position
-                this.effects.push(() => { window.scrollTo({ top: scrollPosition }) })
+                this.effects.push(() => { window.scrollTo({ top: options.scroll! }) })
             }
             else if (url.hash !== '') {
                 this.effects.push(() => {
@@ -608,9 +616,6 @@ export class Navigator {
                     }, { once: true })
                 })
             }
-            else if (oldData.kind !== this.pageState.current.data.kind) {
-                this.effects.push(() => { window.scrollTo({ top: 0 }) })
-            }
         }
         catch (error) {
             if (this.pageState.kind !== 'loading' || this.pageState.loading.descriptor !== newDescriptor) {
@@ -627,7 +632,10 @@ export class Navigator {
         }
     }
 
-    link(pageDescriptor: PageDescriptor, postNavigationCallback?: () => void): { href: string, onClick: (e?: React.MouseEvent) => Promise<void> } {
+    link(pageDescriptor: PageDescriptor, options: {
+        scroll: NavigationOptions['scroll']
+        postNavigationCallback?: () => void
+    }): { href: string, onClick: (e?: React.MouseEvent) => Promise<void> } {
         const url = urlFromPageDescriptor(pageDescriptor)
         return {
             href: url.pathname + url.search,
@@ -637,8 +645,11 @@ export class Navigator {
                     return
                 }
                 e?.preventDefault()
-                await this.navigate(pageDescriptor, 'push')
-                postNavigationCallback?.()
+                await this.navigate(pageDescriptor, {
+                    history: 'push',
+                    scroll: options.scroll,
+                })
+                options.postNavigationCallback?.()
             },
         }
     }
@@ -691,7 +702,10 @@ export class Navigator {
                 void this.navigate({
                     ...this.pageState.current.descriptor,
                     universe: newUniverse,
-                }, 'push')
+                }, {
+                    history: 'push',
+                    scroll: null,
+                })
                 break
             default:
                 throw new Error(`Page descriptor kind ${this.pageState.current.descriptor.kind} does not have a universe`)

--- a/react/src/navigation/navigator.tsx
+++ b/react/src/navigation/navigator.tsx
@@ -550,8 +550,6 @@ export class Navigator {
                 break
         }
 
-        const oldData = this.pageState.current.data
-
         this.pageState = { kind: 'loading', loading: { descriptor: newDescriptor }, current: this.pageState.current, loadStartTime: Date.now() }
         this.pageStateObservers.forEach((observer) => { observer() })
         try {

--- a/react/src/quiz/quiz-result.tsx
+++ b/react/src/quiz/quiz-result.tsx
@@ -460,7 +460,7 @@ function ComparisonLink({ question, children }: { question: JuxtaQuestion, child
                 kind: 'comparison',
                 longnames: [question.longname_a, question.longname_b],
                 s: getVector(settings, settingsOverrides(question.stat_path)),
-            })}
+            }, { scroll: 0 })}
             style={{ textDecoration: 'none', color: colors.textMain }}
         >
             {children}

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -62,18 +62,16 @@ test('control click new tab', async (t) => {
     await t.expect(getLocation()).eql(`${target}/`)
 })
 
-urbanstatsFixture('stats page', '/statistic.html?statname=Population&article_type=Judicial+District&start=1&amount=20&universe=USA')
-
-test('data credit hash from stats page', async (t) => {
-    await t.click(Selector('a').withText('Data Explanation and Credit'))
+test('navigates to hash', async (t) => {
+    await t.navigateTo('data-credit.html#explanation_population')
     await t.expect(getLocation()).eql(`${target}/data-credit.html#explanation_population`)
     await screencap(t, { fullPage: false })
 })
 
-urbanstatsFixture('data credit page direct', '/')
+urbanstatsFixture('stats page', '/statistic.html?statname=Population&article_type=Judicial+District&start=1&amount=20&universe=USA')
 
-test('navigates to hash', async (t) => {
-    await t.navigateTo('data-credit.html#explanation_population')
+test('data credit hash from stats page', async (t) => {
+    await t.click(Selector('a').withText('Data Explanation and Credit'))
     await t.expect(getLocation()).eql(`${target}/data-credit.html#explanation_population`)
     await screencap(t, { fullPage: false })
 })

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -76,6 +76,13 @@ test('data credit hash from stats page', async (t) => {
     await screencap(t, { fullPage: false })
 })
 
+urbanstatsFixture('article page', '/article.html?longname=MN-08+in+Washington+County%2C+USA&s=CD6Y2tC2TDNZtJLeYUq')
+
+test('going to related resets scroll', async (t) => {
+    await t.click(Selector('a').withText('WI-07'))
+    await t.expect(t.eval(() => window.scrollY)).eql(0)
+})
+
 // Artificially induce lag for cetrain requests for testing purposes
 
 type Filter = (options: RequestMockOptions) => boolean

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -33,9 +33,9 @@ test('maintain and restore scroll position back-forward', async (t) => {
     await t.click(Selector('a').withText('New York'))
     await t.expect(Selector('.headertext').withText('New York').exists).ok()
     await t.scroll(0, 400)
-    await t.click(Selector('a').withText('Connecticut'))
+    await t.click(Selector('path[class*="Connecticut"]'))
     await t.expect(Selector('.headertext').withText('Connecticut').exists).ok()
-    await t.expect(getScroll()).eql(400) // Does not reset scroll on same page type
+    await t.expect(getScroll()).eql(400) // Does not reset scroll on map navigation
     await t.scroll(0, 500)
     await goBack()
     await t.expect(Selector('.headertext').withText('New York').exists).ok()

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -83,7 +83,7 @@ test('going to related resets scroll', async (t) => {
     await t.expect(t.eval(() => window.scrollY)).eql(0)
 })
 
-test.only('using pointers preserves scroll', async (t) => {
+test('using pointers preserves scroll', async (t) => {
     const lastPointer = Selector('button[data-test-id="1"]').nth(-1)
     await t.hover(lastPointer)
     const scrollBefore: unknown = await t.eval(() => window.scrollY)

--- a/react/test/navigation_test.ts
+++ b/react/test/navigation_test.ts
@@ -1,6 +1,6 @@
 import { ClientFunction, RequestHook, Selector } from 'testcafe'
 
-import { getLocation, openInNewTabModifiers, screencap, searchField, target, urbanstatsFixture } from './test_utils'
+import { getLocation, openInNewTabModifiers, screencap, searchField, target, urbanstatsFixture, waitForPageLoaded } from './test_utils'
 
 urbanstatsFixture('navigation test', '/')
 
@@ -76,11 +76,20 @@ test('data credit hash from stats page', async (t) => {
     await screencap(t, { fullPage: false })
 })
 
-urbanstatsFixture('article page', '/article.html?longname=MN-08+in+Washington+County%2C+USA&s=CD6Y2tC2TDNZtJLeYUq')
+urbanstatsFixture('article page', '/article.html?longname=MN-08+in+Washington+County%2C+USA&s=CPiCUKKL5WuCCLpM24V')
 
 test('going to related resets scroll', async (t) => {
     await t.click(Selector('a').withText('WI-07'))
     await t.expect(t.eval(() => window.scrollY)).eql(0)
+})
+
+test.only('using pointers preserves scroll', async (t) => {
+    const lastPointer = Selector('button[data-test-id="1"]').nth(-1)
+    await t.hover(lastPointer)
+    const scrollBefore: unknown = await t.eval(() => window.scrollY)
+    await t.click(lastPointer)
+    await waitForPageLoaded(t)
+    await t.expect(t.eval(() => window.scrollY)).eql(scrollBefore)
 })
 
 // Artificially induce lag for cetrain requests for testing purposes

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -200,10 +200,14 @@ export async function arrayFromSelector(selector: Selector): Promise<Selector[]>
     return Array.from({ length: await selector.count }, (_, n) => selector.nth(n))
 }
 
+export async function waitForPageLoaded(t: TestController): Promise<void> {
+    await t.expect(Selector('#pageState_kind').value).eql('loaded') // Wait for initial loading to finish
+}
+
 export async function safeReload(t: TestController): Promise<void> {
     // eslint-disable-next-line no-restricted-syntax -- This is the utility that replaces location.reload()
     await t.eval(() => setTimeout(() => { location.reload() }, 0))
-    await t.expect(Selector('#pageState_kind').value).eql('loaded') // Wait for initial loading to finish
+    await waitForPageLoaded(t)
 }
 
 export const openInNewTabModifiers = process.platform === 'darwin' ? { meta: true } : { ctrl: true }


### PR DESCRIPTION
Makes reasoning about where the page will end up after the navigation very easy

Allows features like "Related" articles on articles page scrolling to top, while pointer arrows keep position