### PR TITLE
use data index for overall ordinal

### DIFF
--- a/react/test/article_test.ts
+++ b/react/test/article_test.ts
@@ -153,6 +153,7 @@ test('lr-overall-other-stat', async (t) => {
         .click(prevOverallArea)
     await t.expect(getLocationWithoutSettings())
         .eql(`${target}/article.html?longname=49633%2C+USA&universe=world`)
+    await screencap(t)
     await t
         .click(nextOverallArea)
     await t.expect(getLocationWithoutSettings())

--- a/react/test/article_test.ts
+++ b/react/test/article_test.ts
@@ -153,10 +153,10 @@ test('lr-overall-other-stat', async (t) => {
         .click(prevOverallArea)
     await t.expect(getLocationWithoutSettings())
         .eql(`${target}/article.html?longname=49633%2C+USA&universe=world`)
-    await screencap(t)
+    await t.wait(100)
     await t
         .click(nextOverallArea)
-    await screencap(t)
+    await t.wait(100)
     await t.expect(getLocationWithoutSettings())
         .eql(`${target}/article.html?longname=Nairobi+%28Center%29+5MPC%2C+Kenya`)
     // check that prevOverallCompactness is disabled

--- a/react/test/article_test.ts
+++ b/react/test/article_test.ts
@@ -140,6 +140,58 @@ test('create-comparison-from-article', async (t) => {
         .eql(comparisonPage(['San Marino city, California, USA', 'Pasadena city, California, USA']))
 })
 
+// just area and compactness
+urbanstatsFixture('lr overall', `/article.html?longname=Nairobi+%28Center%29+5MPC%2C+Kenya&s=D9dego8tisfjWgh`)
+
+test('lr-overall-other-stat', async (t) => {
+    // button with a < on it
+    const prevOverallArea = Selector('button[data-test-id="-1"]').nth(1)
+    const nextOverallArea = Selector('button[data-test-id="1"]').nth(1)
+    const prevOverallCompactness = Selector('button[data-test-id="-1"]').nth(3)
+    const nextOverallCompactness = Selector('button[data-test-id="1"]').nth(3)
+    await t
+        .click(prevOverallArea)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=49633%2C+USA&universe=world`)
+    await t
+        .click(nextOverallArea)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Nairobi+%28Center%29+5MPC%2C+Kenya`)
+    // check that prevOverallCompactness is disabled
+    await t.expect(prevOverallCompactness.hasAttribute('disabled')).ok()
+    // check that prevOverallCompactness does nothing when clicked
+    await t.click(prevOverallCompactness)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Nairobi+%28Center%29+5MPC%2C+Kenya`)
+
+    await t.click(nextOverallCompactness)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Singapore+%28Center%29+5MPC%2C+Singapore`)
+    // check that prevOverallCompactness is enabled
+    await t.expect(prevOverallCompactness.hasAttribute('disabled')).notOk()
+    await t.click(prevOverallCompactness)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Nairobi+%28Center%29+5MPC%2C+Kenya`)
+    // least compact region
+    await t.navigateTo('/article.html?longname=Fiji&s=D9dego8tisfjWgh')
+    // check that nextOverallCompactness is disabled
+    await t.expect(nextOverallCompactness.hasAttribute('disabled')).ok()
+    // check that nextOverallCompactness does nothing when clicked
+    await t.click(nextOverallCompactness)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Fiji`)
+    // check that prevOverallCompactness is enabled
+    await t.expect(prevOverallCompactness.hasAttribute('disabled')).notOk()
+    await t.click(prevOverallCompactness)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Northern%2C+Fiji`)
+    // check that nextOverallCompactness is enabled
+    await t.expect(nextOverallCompactness.hasAttribute('disabled')).notOk()
+    await t.click(nextOverallCompactness)
+    await t.expect(getLocationWithoutSettings())
+        .eql(`${target}/article.html?longname=Fiji`)
+})
+
 urbanstatsFixture('all stats test', `/article.html?longname=California%2C+USA`)
 
 test('california-all-stats', async (t) => {

--- a/react/test/article_test.ts
+++ b/react/test/article_test.ts
@@ -156,6 +156,7 @@ test('lr-overall-other-stat', async (t) => {
     await screencap(t)
     await t
         .click(nextOverallArea)
+    await screencap(t)
     await t.expect(getLocationWithoutSettings())
         .eql(`${target}/article.html?longname=Nairobi+%28Center%29+5MPC%2C+Kenya`)
     // check that prevOverallCompactness is disabled


### PR DESCRIPTION
this is in prep for a later change that entirely removes the overall ordinal. It is kept for now but all it is used for is determining whether to show the pointers

I did just do this for both ordinals to avoid more complicated logic. On my laptop it consistently adds <1ms (two Date.now() calls do not record any timing difference at all), so it's fine imo to just do it even if its a bit redundant in some cases

Adds a bit of delay because otherwise the test was flaking. Not sure why this just came up (as described above there isn't really any reason this should be slowing things down?)