### PR TITLE
Fix flaky quiz_friends tests

### DIFF
--- a/react/test/quiz_friends_link_test.ts
+++ b/react/test/quiz_friends_link_test.ts
@@ -44,7 +44,7 @@ test('paste friend link before doing quiz', async (t) => {
         },
     ])
     await clickButtons(t, ['a', 'a', 'a', 'a', 'a'])
-    const friends = await friendsText(t)
+    const friends = friendsText()
     await t.expect(friends.length).eql(2)
     await t.expect(friends[1]).eql('spudwaffleAsk\u00a0spudwaffle\u00a0to add youRemove')
 })
@@ -60,7 +60,7 @@ test('paste friend link after doing quiz', async (t) => {
             url: 'http://localhost:8000/quiz.html',
         },
     ])
-    const friends = await friendsText(t)
+    const friends = friendsText()
     await t.expect(friends.length).eql(2)
     await t.expect(friends[1]).eql('spudwaffleAsk\u00a0spudwaffle\u00a0to add youRemove')
 })

--- a/react/test/quiz_friends_link_test.ts
+++ b/react/test/quiz_friends_link_test.ts
@@ -44,7 +44,7 @@ test('paste friend link before doing quiz', async (t) => {
         },
     ])
     await clickButtons(t, ['a', 'a', 'a', 'a', 'a'])
-    const friends = friendsText()
+    const friends = await friendsText()
     await t.expect(friends.length).eql(2)
     await t.expect(friends[1]).eql('spudwaffleAsk\u00a0spudwaffle\u00a0to add youRemove')
 })
@@ -60,7 +60,7 @@ test('paste friend link after doing quiz', async (t) => {
             url: 'http://localhost:8000/quiz.html',
         },
     ])
-    const friends = friendsText()
+    const friends = await friendsText()
     await t.expect(friends.length).eql(2)
     await t.expect(friends[1]).eql('spudwaffleAsk\u00a0spudwaffle\u00a0to add youRemove')
 })

--- a/react/test/quiz_friends_test.ts
+++ b/react/test/quiz_friends_test.ts
@@ -120,22 +120,22 @@ function testsGeneric(
         // Alice does the quiz
         await createUser(t, 'Alice', '000000a', state)
         await clickButtons(t, ['a', 'a', 'a', 'a', 'a'])
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`])
         await createUser(t, 'Bob', '000000b', state)
         await clickButtons(t, ['b', 'b', 'b', 'b', 'b'])
-        await t.expect(await friendsText(t)).eql([`You${bobPattern}Copy Link`])
+        await t.expect(friendsText()).eql([`You${bobPattern}Copy Link`])
         await addFriend(t, 'Alice', '000000a')
         if (screenshots) {
             await quizScreencap(t) // screencap of pending friend request
         }
-        await t.expect(await friendsText(t)).eql([`You${bobPattern}Copy Link`, 'AliceAsk\u00a0Alice\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${bobPattern}Copy Link`, 'AliceAsk\u00a0Alice\u00a0to add youRemove'])
         await restoreUser(t, 'Alice', state)
         await addFriend(t, 'Bob', '000000b')
         // Alice and Bob are now friends
         if (screenshots) {
             await quizScreencap(t) // screencap of friends' score
         }
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
         return state
     }
 
@@ -146,40 +146,40 @@ function testsGeneric(
         await t.navigateTo(`${target}/${yesterday}`)
         await clickButtons(t, ['a', 'b', 'a', 'b', 'a'])
         await addFriend(t, 'Alice', '000000a')
-        await t.expect(await friendsText(t)).eql([`You${charliePatternPrev}Copy Link`, 'AliceAsk\u00a0Alice\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${charliePatternPrev}Copy Link`, 'AliceAsk\u00a0Alice\u00a0to add youRemove'])
         await restoreUser(t, 'Alice', state)
         await t.navigateTo(`${target}/${today}`)
         await addFriend(t, 'Charlie', '000000c')
         // Alice and Charlie are now friends
         await quizScreencap(t) // screencap of friend who hasn't done the quiz yet
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'CharlieNot Done YetRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'CharlieNot Done YetRemove'])
         // Charlie now does the quiz
         await restoreUser(t, 'Charlie', state)
         await clickButtons(t, ['a', 'b', 'a', 'b', 'a'])
-        await t.expect(await friendsText(t)).eql([`You${charliePattern}Copy Link`, `Alice${alicePattern}Remove`])
+        await t.expect(friendsText()).eql([`You${charliePattern}Copy Link`, `Alice${alicePattern}Remove`])
         await restoreUser(t, 'Alice', state)
         await quizScreencap(t) // multiple friends who have done the quiz
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, `Charlie${charliePattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, `Charlie${charliePattern}Remove`])
         // Alice unfriends Bob
         await removeFriend(t, 0)
         // wait until there's only one Remove button. up to 1 second
         await t.expect(Selector('button').withText('Remove').count).eql(1, { timeout: 1000 })
         await quizScreencap(t) // unfriended Bob
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Charlie${charliePattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Charlie${charliePattern}Remove`])
         // Bob no longer sees Alice's score
         await restoreUser(t, 'Bob', state)
         await quizScreencap(t) // Bob no longer sees Alice's score
-        await t.expect(await friendsText(t)).eql([`You${bobPattern}Copy Link`, 'AliceAsk\u00a0Alice\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${bobPattern}Copy Link`, 'AliceAsk\u00a0Alice\u00a0to add youRemove'])
         // rename Alice to Alice2 by clicking on the Alice name and changing it
         const aliceName = Selector('span').withAttribute('class', 'editable_content').nth(0)
         await t.click(aliceName)
         await t.pressKey('ctrl+a')
         await t.typeText(aliceName, 'Alice2')
         await t.pressKey('enter')
-        await t.expect(await friendsText(t)).eql([`You${bobPattern}Copy Link`, 'Alice2Ask\u00a0Alice2\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${bobPattern}Copy Link`, 'Alice2Ask\u00a0Alice2\u00a0to add youRemove'])
         await safeReload(t)
         await t.wait(1000)
-        await t.expect(await friendsText(t)).eql([`You${bobPattern}Copy Link`, 'Alice2Ask\u00a0Alice2\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${bobPattern}Copy Link`, 'Alice2Ask\u00a0Alice2\u00a0to add youRemove'])
     })
 
     test(`${props.name}-friends-bad-naming-test`, async (t) => {
@@ -188,31 +188,31 @@ function testsGeneric(
         // should error because we are attempting to add the same user under a different name
         await addFriend(t, 'Bob2', '000000b')
         // Bob2 not added
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
         // check that the text 'Friend ID 000000b already exists as Bob' is displayed
         await t.expect(Selector('div').withText('Friend ID 000000b already exists as Bob').exists).ok()
         // should error because we are attempting to add a duplicate name
         await addFriend(t, 'Bob', 'abc')
         // Bob not added
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
         // check that the text 'Friend Name Bob already exists' is displayed
         await t.expect(Selector('div').withText('Friend name already exists').exists).ok()
         // should error because we are attempting to add an empty name
         await addFriend(t, '', 'abc')
         // empty name not added
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
         // check that the text 'Friend name cannot be empty' is displayed
         await t.expect(Selector('div').withText('Friend name cannot be empty').exists).ok()
         // should error because we are attempting to add an empty ID
         await addFriend(t, 'Bob2', '')
         // empty ID not added
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`])
         // check that the text 'Friend ID cannot be empty' is displayed
         await t.expect(Selector('div').withText('Friend ID cannot be empty').exists).ok()
         // add an additional friend
         await addFriend(t, 'Charlie', '000000c')
         // Charlie added
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'CharlieAsk\u00a0Charlie\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'CharlieAsk\u00a0Charlie\u00a0to add youRemove'])
         // attempting to rename Charlie to Bob should error
         const charlieName = Selector('span').withAttribute('class', 'editable_content').nth(1)
         await t.click(charlieName)
@@ -220,7 +220,7 @@ function testsGeneric(
         await t.typeText(charlieName, 'Bob')
         await t.pressKey('enter')
         // Charlie not renamed
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'CharlieAsk\u00a0Charlie\u00a0to add youRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'CharlieAsk\u00a0Charlie\u00a0to add youRemove'])
         // check that the text 'Friend name already exists' is displayed
         await t.expect(Selector('div').withText('Friend name already exists').exists).ok()
     })
@@ -230,22 +230,22 @@ function testsGeneric(
         await restoreUser(t, 'Alice', state)
         await addFriend(t, 'Bob2', 'this id does not work')
         // Bob2 added but shows up as an invalid user
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'Bob2Invalid User IDRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'Bob2Invalid User IDRemove'])
         // after a reload, same invalid user
         await safeReload(t)
         await t.wait(1000)
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'Bob2Invalid User IDRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'Bob2Invalid User IDRemove'])
         await addFriend(t, 'Bob3', '000000b   ')
         // duplicate error
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'Bob2Invalid User IDRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, `Bob${bobPattern}Remove`, 'Bob2Invalid User IDRemove'])
         await t.expect(Selector('div').withText('Friend ID 000000b already exists as Bob').exists).ok()
         // remove Bob
         await removeFriend(t, 0)
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, 'Bob2Invalid User IDRemove'])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, 'Bob2Invalid User IDRemove'])
         // add Bob3
         await addFriend(t, 'Bob3', '000000b    ')
         // Bob3 added
-        await t.expect(await friendsText(t)).eql([`You${alicePattern}Copy Link`, 'Bob2Invalid User IDRemove', `Bob3${bobPattern}Remove`])
+        await t.expect(friendsText()).eql([`You${alicePattern}Copy Link`, 'Bob2Invalid User IDRemove', `Bob3${bobPattern}Remove`])
     })
 
     test(`${props.name}-same-on-juxta-and-retro`, async (t) => {
@@ -253,7 +253,7 @@ function testsGeneric(
         // same on retrostat
         await t.navigateTo(`${target}/${other}`)
         await clickButtons(t, ['a', 'a', 'a', 'a', 'a'])
-        await t.expect(await friendsText(t)).eql([`You${aliceOtherPattern}Copy Link`, 'BobNot Done YetRemove'])
+        await t.expect(friendsText()).eql([`You${aliceOtherPattern}Copy Link`, 'BobNot Done YetRemove'])
     })
 }
 

--- a/react/test/quiz_test_utils.ts
+++ b/react/test/quiz_test_utils.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'fs'
 import { promisify } from 'util'
 
 import { execa, execaSync } from 'execa'
-import { Selector } from 'testcafe'
+import { ClientFunction, Selector } from 'testcafe'
 
 import { safeReload, screencap, urbanstatsFixture } from './test_utils'
 
@@ -153,14 +153,12 @@ export async function withMockedClipboard(t: TestController, runner: () => Promi
     return calls
 }
 
-export async function friendsText(t: TestController): Promise<string[]> {
-    return await t.eval(() => {
-        const elements = document.getElementsByClassName('testing-friends-section')
-        const results: string[] = []
-        // eslint-disable-next-line @typescript-eslint/prefer-for-of -- No need to convert to array
-        for (let i = 0; i < elements.length; i++) {
-            results.push(elements[i].textContent!)
-        }
-        return results
-    }) as string[]
-}
+export const friendsText = ClientFunction<string[], []>(() => {
+    const elements = document.getElementsByClassName('testing-friends-section')
+    const results: string[] = []
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of -- No need to convert to array
+    for (let i = 0; i < elements.length; i++) {
+        results.push(elements[i].textContent!)
+    }
+    return results
+})


### PR DESCRIPTION
Closes #785 

ClientFunctions have built-in retry, while t.eval does not

https://testcafe.io/documentation/402837/guides/basic-guides/assertions#use-assertions-to-extract-page-information