### PR TITLE
Implement better watch script

### DIFF
--- a/react/watch.sh
+++ b/react/watch.sh
@@ -5,4 +5,9 @@ set -e
 cd ..
 python create_website.py $1 --mode=dev --no-data --no-geo --no-juxta
 cd react
-rspack serve --mode=development --watch --env directory=$1
+
+while true; do
+    rspack serve --mode=development --watch --env directory=$1
+    echo 'Restarting watcher... Press ^C again to stop watching.'
+    sleep 1
+done


### PR DESCRIPTION
The python build step for the site can take a while, but sometimes you just want to restart the rspack watcher

So, press ^C once and wait 1 second to just restart the watcher, press ^C again once the watcher shuts down to stop watching entirely.