### PR TITLE
Use a timer to kill e2e tests if taking too long

### DIFF
--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises'
 
+import chalkTemplate from 'chalk-template'
 import { execa } from 'execa'
 import { globSync } from 'glob'
 import createTestCafe from 'testcafe'
@@ -77,7 +78,7 @@ const runTest = async (): Promise<number> => {
 
 const killTimer = options.timeLimitSeconds
     ? setTimeout(() => {
-        console.error(`Test suite took too long! Killing tests. (allowed duration ${options.timeLimitSeconds}s)`)
+        console.error(chalkTemplate`{red.bold Test suite took too long! Killing tests. (allowed duration ${options.timeLimitSeconds}s)}`)
         process.exit(1)
     }, options.timeLimitSeconds * 1000)
     : undefined


### PR DESCRIPTION
This allows us to write loops in e2e tests without having to worry about timeout