### PR TITLE
optimize the loading of polygons in the mapper

### DIFF
--- a/react/src/components/map.tsx
+++ b/react/src/components/map.tsx
@@ -416,12 +416,19 @@ export class MapGeneric<P extends MapGenericProps> extends React.Component<P, Ma
         setBasemap(this.map!, this.props.basemap)
     }
 
+    progressivelyLoadPolygons(): boolean {
+        // Whether to attempt to refresh the map as polygons are added
+        return true
+    }
+
     async addPolygons(polygons: Polygon[], zoom_to: number): Promise<void> {
         const time = Date.now()
         debugPerformance('Adding polygons...')
         await Promise.all(polygons.map(async (polygon, i) => {
             await this.addPolygon(polygon, i === zoom_to)
-            await this.updateSources()
+            if (this.progressivelyLoadPolygons()) {
+                await this.updateSources()
+            }
         }))
         debugPerformance(`Added polygons [addPolygons]; at ${Date.now() - time}ms`)
         await this.updateSources(true)

--- a/react/src/components/mapper-panel.tsx
+++ b/react/src/components/mapper-panel.tsx
@@ -100,6 +100,10 @@ class DisplayedMap extends MapGeneric<DisplayedMapProps> {
         }
     }
 
+    override progressivelyLoadPolygons(): boolean {
+        return false
+    }
+
     override mapDidRender(): Promise<void> {
         // zoom map to fit united states
         // do so instantly


### PR DESCRIPTION
do not attempt to load after every polygon is adedd