### PR TITLE
Add “.local” as allowed host on dev server

### DIFF
--- a/react/rspack.config.js
+++ b/react/rspack.config.js
@@ -65,6 +65,9 @@ export default env => ({
         devMiddleware: {
             writeToDisk: true,
         },
+        allowedHosts: [
+            '.local'
+        ],
     },
     performance: {
         hints: isProduction ? 'error' : false,


### PR DESCRIPTION
This allows connecting from a phone on a local network without looking up a changing IP address