### PR TITLE
Fix React error with divRef

### DIFF
--- a/react/src/mapper/settings/EditMapperPanel.tsx
+++ b/react/src/mapper/settings/EditMapperPanel.tsx
@@ -236,7 +236,7 @@ function MaybeSplitLayout({ left, right, error }: { left: ReactNode, right: Reac
         : <SplitLayout error={error} left={left} right={right} />
 }
 
-function DivThatTakesUpTheRestOfThePage(props: ComponentProps<'div'> & { divRef?: MutableRefObject<HTMLDivElement | null> }): ReactNode {
+function DivThatTakesUpTheRestOfThePage({ divRef, ...props }: ComponentProps<'div'> & { divRef?: MutableRefObject<HTMLDivElement | null> }): ReactNode {
     const [height, setHeight] = useState(0)
     const ref = useRef<HTMLDivElement | null>(null)
 
@@ -265,8 +265,8 @@ function DivThatTakesUpTheRestOfThePage(props: ComponentProps<'div'> & { divRef?
             style={{ height: `${height}px`, ...props.style }}
             ref={(thing) => {
                 ref.current = thing
-                if (props.divRef) {
-                    props.divRef.current = thing
+                if (divRef) {
+                    divRef.current = thing
                 }
             }}
         />


### PR DESCRIPTION
```
Warning: React does not recognize the `%s` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `%s` instead. If you accidentally passed it from a parent component, remove it from the DOM element.%s divRef divref
```