### PR TITLE
useObserver change: intern hash to avoid warning

### DIFF
--- a/react/src/utils/useObserverSets.ts
+++ b/react/src/utils/useObserverSets.ts
@@ -15,6 +15,26 @@ export function useObserverSets(observerSets: Set<() => void>[]): void {
         return () => {
             observerSets.forEach(set => set.delete(observer))
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- That's fine
-    }, observerSets)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Signature reflects the set identities this hook subscribes to.
+    }, [hashObserverSets(observerSets)])
+}
+
+// we do this because we're not allowed to change the number of dependencies in a useEffect hook.
+// it was producing a warning otherwise.
+function hashObserverSets(observerSets: Set<() => void>[]): string {
+    return observerSets.map(getObserverSetId).join(',')
+}
+
+// identity hashing, using interning.
+const observerSetIds = new WeakMap<Set<() => void>, number>()
+let nextObserverSetId = 1
+
+function getObserverSetId(observerSet: Set<() => void>): number {
+    let id = observerSetIds.get(observerSet)
+    if (id === undefined) {
+        id = nextObserverSetId
+        nextObserverSetId += 1
+        observerSetIds.set(observerSet, id)
+    }
+    return id
 }


### PR DESCRIPTION
fixes warning:

```
Warning: The final argument passed to useEffect changed size between renders. The order and size of this array must remain constant.

Previous: [[object Set], [object Set], [object Set], [object Set], [object Set], [object Set], [object Set], [object Set], [object Set]]
Incoming: [[object Set], [object Set], [object Set], [object Set], [object Set], [object Set], [object Set], [object Set]]
    at CategoryComponent (http://localhost:8000/scripts/index.js:50733:26)
    at div
    at StatsTree (http://localhost:8000/scripts/index.js:50668:85)
    at ul
    at div
    at SidebarForStatisticChoice (http://localhost:8000/scripts/index.js:55179:33)
    at div
    at Sidebar (http://localhost:8000/scripts/index.js:54945:28)
    at div
    at LeftPanel (http://localhost:8000/scripts/index.js:81808:34)
    at div
    at BodyPanel (http://localhost:8000/scripts/index.js:81775:31)
    at div
    at PageTemplate (http://localhost:8000/scripts/index.js:81622:34)
    at ArticlePanel (http://localhost:8000/scripts/src_components_article-panel_tsx-src_components_comparison-panel_tsx-src_utils_Property_ts-sr-8e0491.js:553:25)
    at PageRouter (http://localhost:8000/scripts/index.js:77737:26)
    at Router (http://localhost:8000/scripts/index.js:77679:70)
```