### PR TITLE
Drag to reorder table columns

### DIFF
--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -20,6 +20,7 @@ export interface SuperHeaderSpec {
     headerSpecs: CellSpec[]
     showBottomBar: boolean
     groupNames?: (string | undefined)[]
+    handleReorder?: (from: number, to: number) => void
 }
 
 export interface LeftHeaderSpec {

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -1,4 +1,5 @@
-import { useSortable } from '@dnd-kit/sortable'
+import { closestCenter, DndContext, DragEndEvent, PointerSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { horizontalListSortingStrategy, SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import React, { CSSProperties, ReactNode, useContext, useEffect, useRef, useState } from 'react'
 
@@ -120,6 +121,7 @@ export interface SuperHeaderHorizontalProps {
     showBottomBar: boolean
     leftSpacerWidth: number
     groupNames?: (string | undefined)[]
+    handleReorder?: (from: number, to: number) => void
 }
 
 export function SuperHeaderHorizontal(props: SuperHeaderHorizontalProps): ReactNode {
@@ -145,20 +147,78 @@ export function SuperHeaderHorizontal(props: SuperHeaderHorizontalProps): ReactN
         )
     }
 
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 1 } }),
+        useSensor(TouchSensor, { activationConstraint: { delay: 50, tolerance: 0 } }),
+    )
+
+    const handleDragEnd = (event: DragEndEvent): void => {
+        const { active, over } = event
+        if (over && active.id !== over.id) {
+            props.handleReorder?.(parseInt(active.id as string), parseInt(over.id as string))
+        }
+    }
+
     const getBarColor = (idx: number): string | undefined => {
         const spec = props.headerSpecs[idx]
         return spec.highlightIndex !== undefined ? colorFromCycle(colors.hueColors, spec.highlightIndex) : undefined
     }
+
+    const cellsRow = (
+        <div style={{ display: 'flex' }}>
+            <div style={{ width: `${props.leftSpacerWidth}%` }} />
+            {props.handleReorder
+                ? (
+                        <SortableContext items={props.headerSpecs.map((_, idx) => idx.toString())} strategy={horizontalListSortingStrategy}>
+                            {props.headerSpecs.map((cellSpec, idx) => {
+                                const nonDraggableSpec: CellSpec = cellSpec.type === 'comparison-longname' ? { ...cellSpec, draggable: false } : cellSpec
+                                return (
+                                    <SortableHeaderCell key={idx} id={idx.toString()} width={props.widthsEach[idx]}>
+                                        <Cell {...nonDraggableSpec} width={100} />
+                                    </SortableHeaderCell>
+                                )
+                            })}
+                        </SortableContext>
+                    )
+                : props.headerSpecs.map((cellSpec, idx) => <Cell key={idx} {...cellSpec} width={props.widthsEach[idx]} />)}
+        </div>
+    )
+
     return (
         <>
             {props.groupNames && <SuperHeaderGroupNames leftSpacerWidth={props.leftSpacerWidth} groupNames={props.groupNames} widthsEach={props.widthsEach} />}
             {bars(getBarColor)}
-            <div style={{ display: 'flex' }}>
-                <div style={{ width: `${props.leftSpacerWidth}%` }} />
-                {props.headerSpecs.map((cellSpec, idx) => <Cell key={idx} {...cellSpec} width={props.widthsEach[idx]} />)}
-            </div>
+            {props.handleReorder
+                ? (
+                        <DndContext sensors={sensors} onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+                            {cellsRow}
+                        </DndContext>
+                    )
+                : cellsRow}
             {props.showBottomBar && bars(getBarColor)}
         </>
+    )
+}
+
+function SortableHeaderCell({ id, width, children }: { id: string, width: number, children: ReactNode }): ReactNode {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
+    return (
+        <div
+            ref={setNodeRef}
+            style={{
+                width: `${width}%`,
+                display: 'flex',
+                transform: CSS.Transform.toString(transform),
+                transition: isDragging ? transition : 'none',
+                opacity: isDragging ? 0.5 : 1,
+                touchAction: 'none',
+                cursor: 'grab',
+            }}
+            {...attributes}
+            {...listeners}
+        >
+            {children}
+        </div>
     )
 }
 

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -205,6 +205,7 @@ function SortableHeaderCell({ id, width, children }: { id: string, width: number
     return (
         <div
             ref={setNodeRef}
+            data-test-id="sortable-column-header"
             style={{
                 width: `${width}%`,
                 display: 'flex',

--- a/react/src/stat/StatisticPanelPage.tsx
+++ b/react/src/stat/StatisticPanelPage.tsx
@@ -66,7 +66,7 @@ export function StatisticPanelPage({ view, stat, data, set, loading, counts, err
             {view.edit && <EditPreamble stat={stat} view={view} set={set} typeEnvironment={typeEnvironment} counts={counts} errors={errors} assignments={assignments} />}
             {!view.edit && <DisplayResults results={errors.filter(error => error.kind === 'error')} editor={false} />}
             {data
-                ? <StatisticPanelTable view={view} stat={stat} data={data} set={set} tableRef={tableRef} loading={loading} />
+                ? <StatisticPanelTable view={view} stat={stat} data={data} set={set} tableRef={tableRef} loading={loading} typeEnvironment={typeEnvironment} />
                 : (
                         <div style={{ position: 'relative', width: '100%', height: '200px' }}>
                             <RelativeLoader loading={loading} />

--- a/react/src/stat/StatisticPanelTable.tsx
+++ b/react/src/stat/StatisticPanelTable.tsx
@@ -9,18 +9,21 @@ import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
 import { useUniverse } from '../universe'
 import { orderNonNan } from '../urban-stats-script/constants/table'
+import { TypeEnvironment } from '../urban-stats-script/types-values'
 import { assert } from '../utils/defensive'
 import { sanitize } from '../utils/paths'
 
+import { makeColumnReorderHandler } from './makeColumnReorderHandler'
 import { Statistic, StatData, StatSetter, View } from './types'
 
-export function StatisticPanelTable({ view, stat, data, set, tableRef, loading }: {
+export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, typeEnvironment }: {
     view: View
     stat: Statistic
     data: StatData
     set: StatSetter
     tableRef: React.RefObject<HTMLDivElement>
     loading: boolean
+    typeEnvironment: TypeEnvironment
 }): ReactNode {
     const colors = useColors()
 
@@ -135,6 +138,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading }
     const superHeaderSpec: SuperHeaderSpec = {
         headerSpecs,
         showBottomBar: false,
+        handleReorder: makeColumnReorderHandler(stat, set, typeEnvironment),
     }
 
     const highlightOriginalIdx = data.articleNames.indexOf(view.highlight ?? '')

--- a/react/src/stat/StatisticPanelTable.tsx
+++ b/react/src/stat/StatisticPanelTable.tsx
@@ -138,7 +138,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, 
     const superHeaderSpec: SuperHeaderSpec = {
         headerSpecs,
         showBottomBar: false,
-        handleReorder: makeColumnReorderHandler(stat, set, typeEnvironment),
+        handleReorder: makeColumnReorderHandler(stat, set, typeEnvironment, view),
     }
 
     const highlightOriginalIdx = data.articleNames.indexOf(view.highlight ?? '')

--- a/react/src/stat/makeColumnReorderHandler.ts
+++ b/react/src/stat/makeColumnReorderHandler.ts
@@ -5,7 +5,7 @@ import { tableType } from '../urban-stats-script/constants/table'
 import * as l from '../urban-stats-script/literal-parser'
 import { TypeEnvironment } from '../urban-stats-script/types-values'
 
-import { Statistic, StatSetter } from './types'
+import { Statistic, StatSetter, View } from './types'
 import { mapUSSFromStat } from './utils'
 
 const tableColumnsParser = mapUssParser(
@@ -23,6 +23,7 @@ export function makeColumnReorderHandler(
     stat: Statistic,
     set: StatSetter,
     typeEnvironment: TypeEnvironment,
+    view: View,
 ): ((from: number, to: number) => void) | undefined {
     let parseResult
     if (stat.type !== 'uss') {
@@ -44,6 +45,13 @@ export function makeColumnReorderHandler(
         const newUss = parseResult.namedArgs.columns.edit(
             elements => arrayMove(elements, from, to),
         )
-        set({ stat: { ...stat, uss: newUss as MapUSS } }, { undoable: true })
+        const columns = parseResult.namedArgs.columns.currentValue
+        const indices = Array.from({ length: columns.length }, (_, i) => i)
+        const reordered = arrayMove(indices, from, to)
+        const newSortColumn = reordered.indexOf(view.sortColumn)
+        set({
+            stat: { ...stat, uss: newUss as MapUSS },
+            view: { ...view, sortColumn: newSortColumn },
+        }, { undoable: true })
     }
 }

--- a/react/src/stat/makeColumnReorderHandler.ts
+++ b/react/src/stat/makeColumnReorderHandler.ts
@@ -1,0 +1,44 @@
+import { arrayMove } from '@dnd-kit/sortable'
+
+import { MapUSS, mapUssParser } from '../mapper/settings/map-uss'
+import { tableType } from '../urban-stats-script/constants/table'
+import * as l from '../urban-stats-script/literal-parser'
+import { TypeEnvironment } from '../urban-stats-script/types-values'
+
+import { Statistic, StatSetter } from './types'
+
+const tableColumnsParser = mapUssParser(
+    l.call({
+        fn: l.identifier('table'),
+        unnamedArgs: [],
+        namedArgs: {
+            columns: l.editableVector(l.passthrough()),
+        },
+    }),
+    [tableType],
+)
+
+export function makeColumnReorderHandler(
+    stat: Statistic,
+    set: StatSetter,
+    typeEnvironment: TypeEnvironment,
+): ((from: number, to: number) => void) | undefined {
+    if (stat.type !== 'uss') {
+        return undefined
+    }
+    try {
+        tableColumnsParser(stat.uss, typeEnvironment)
+    }
+    catch (err) {
+        if (err instanceof l.LiteralParseError) {
+            return undefined
+        }
+        throw err
+    }
+    return (from: number, to: number): void => {
+        const newUss = tableColumnsParser(stat.uss, typeEnvironment).namedArgs.columns.edit(
+            elements => arrayMove(elements, from, to),
+        )
+        set({ stat: { ...stat, uss: newUss as MapUSS } }, { undoable: true })
+    }
+}

--- a/react/src/stat/makeColumnReorderHandler.ts
+++ b/react/src/stat/makeColumnReorderHandler.ts
@@ -6,6 +6,7 @@ import * as l from '../urban-stats-script/literal-parser'
 import { TypeEnvironment } from '../urban-stats-script/types-values'
 
 import { Statistic, StatSetter } from './types'
+import { mapUSSFromStat } from './utils'
 
 const tableColumnsParser = mapUssParser(
     l.call({
@@ -23,11 +24,12 @@ export function makeColumnReorderHandler(
     set: StatSetter,
     typeEnvironment: TypeEnvironment,
 ): ((from: number, to: number) => void) | undefined {
+    let parseResult
     if (stat.type !== 'uss') {
         return undefined
     }
     try {
-        tableColumnsParser(stat.uss, typeEnvironment)
+        parseResult = tableColumnsParser(mapUSSFromStat(stat), typeEnvironment)
     }
     catch (err) {
         if (err instanceof l.LiteralParseError) {
@@ -35,8 +37,11 @@ export function makeColumnReorderHandler(
         }
         throw err
     }
+    if (parseResult.namedArgs.columns.currentValue.length < 2) {
+        return undefined
+    }
     return (from: number, to: number): void => {
-        const newUss = tableColumnsParser(stat.uss, typeEnvironment).namedArgs.columns.edit(
+        const newUss = parseResult.namedArgs.columns.edit(
             elements => arrayMove(elements, from, to),
         )
         set({ stat: { ...stat, uss: newUss as MapUSS } }, { undoable: true })

--- a/react/test/statistic-column-reorder.test.ts
+++ b/react/test/statistic-column-reorder.test.ts
@@ -8,6 +8,7 @@ function createUSSStatisticsPage(uss: string, start = 1, amount = 5, universe = 
 
 const columnHeader = (n: number): Selector => Selector('[data-test-id="sortable-column-header"]').nth(n)
 const columnHeaderLink = (n: number): Selector => columnHeader(n).find('[data-test-id="statistic-link"]')
+const sortIndicator = (n: number): Selector => columnHeader(n).find('.testing-order-swap')
 
 const twoColumnUSS = `table(
     columns=[
@@ -40,6 +41,21 @@ test('column reorder persists in URL', async (t) => {
     await waitForLoading()
     await t.expect(columnHeaderLink(0).innerText).eql('Col B')
     await t.expect(columnHeaderLink(1).innerText).eql('Col A')
+})
+
+test('sort indicator follows logical column after reorder', async (t) => {
+    await waitForLoading()
+    // Click column 0 header to sort by it; sort indicator should appear on col 0
+    await t.click(columnHeader(0))
+    await waitForLoading()
+    await t.expect(sortIndicator(0).getAttribute('alt')).notEql('both')
+    await t.expect(sortIndicator(1).getAttribute('alt')).eql('both')
+
+    // Drag col 0 to col 1 — sort indicator must follow the logical column to position 1
+    await t.dragToElement(columnHeader(0), columnHeader(1))
+    await waitForLoading()
+    await t.expect(sortIndicator(0).getAttribute('alt')).eql('both')
+    await t.expect(sortIndicator(1).getAttribute('alt')).notEql('both')
 })
 
 test('column reorder updates data values', async (t) => {

--- a/react/test/statistic-column-reorder.test.ts
+++ b/react/test/statistic-column-reorder.test.ts
@@ -1,0 +1,118 @@
+import { Selector } from 'testcafe'
+
+import { target, urbanstatsFixture, waitForLoading, dataValues, safeReload } from './test_utils'
+
+function createUSSStatisticsPage(uss: string, start = 1, amount = 5, universe = 'California, USA', articleType = 'County'): string {
+    return `${target}/statistic.html?uss=${encodeURIComponent(uss)}&article_type=${encodeURIComponent(articleType)}&start=${start}&amount=${amount}&universe=${encodeURIComponent(universe)}`
+}
+
+const columnHeader = (n: number): Selector => Selector('[data-test-id="sortable-column-header"]').nth(n)
+const columnHeaderLink = (n: number): Selector => columnHeader(n).find('[data-test-id="statistic-link"]')
+
+const twoColumnUSS = `table(
+    columns=[
+        column(values=density_pw_1km, name="Col A", unit=unitDensity),
+        column(values=commute_transit, name="Col B", unit=unitPercentage)
+    ]
+)`
+
+urbanstatsFixture('column reorder basic', createUSSStatisticsPage(twoColumnUSS))
+
+test('drag column header swaps columns', async (t) => {
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('Col A')
+    await t.expect(columnHeaderLink(1).innerText).eql('Col B')
+
+    await t.dragToElement(columnHeader(0), columnHeader(1))
+
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('Col B')
+    await t.expect(columnHeaderLink(1).innerText).eql('Col A')
+})
+
+test('column reorder persists in URL', async (t) => {
+    await waitForLoading()
+
+    await t.dragToElement(columnHeader(0), columnHeader(1))
+    await waitForLoading()
+
+    await safeReload(t)
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('Col B')
+    await t.expect(columnHeaderLink(1).innerText).eql('Col A')
+})
+
+test('column reorder updates data values', async (t) => {
+    await waitForLoading()
+    const valsBefore = await dataValues()
+
+    await t.dragToElement(columnHeader(0), columnHeader(1))
+    await waitForLoading()
+
+    // After swapping, the first set of data values should be what was previously in Col B
+    const valsAfter = await dataValues()
+    // The two columns have different statistics so values should differ
+    await t.expect(valsAfter).notEql(valsBefore)
+})
+
+const threeColumnURL = createUSSStatisticsPage(`table(
+    columns=[
+        column(values=density_pw_1km, name="C1", unit=unitDensity),
+        column(values=commute_transit, name="C2", unit=unitPercentage),
+        column(
+            values=traffic_fatalities_per_capita,
+            name="C3",
+            unit=unitFatalitiesPerCapita
+        )
+    ]
+)`)
+
+urbanstatsFixture('column reorder multi-column', threeColumnURL)
+
+test('drag last column to first position', async (t) => {
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('C1')
+    await t.expect(columnHeaderLink(1).innerText).eql('C2')
+    await t.expect(columnHeaderLink(2).innerText).eql('C3')
+
+    await t.dragToElement(columnHeader(2), columnHeader(0))
+
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('C3')
+    await t.expect(columnHeaderLink(1).innerText).eql('C1')
+    await t.expect(columnHeaderLink(2).innerText).eql('C2')
+})
+
+test('multiple sequential reorders', async (t) => {
+    await waitForLoading()
+
+    // Move C1 → position 1 (C1, C2, C3 → C2, C1, C3)
+    await t.dragToElement(columnHeader(0), columnHeader(1))
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('C2')
+    await t.expect(columnHeaderLink(1).innerText).eql('C1')
+    await t.expect(columnHeaderLink(2).innerText).eql('C3')
+
+    // Move C3 → position 0 (C2, C1, C3 → C3, C2, C1)
+    await t.dragToElement(columnHeader(2), columnHeader(0))
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).innerText).eql('C3')
+    await t.expect(columnHeaderLink(1).innerText).eql('C2')
+    await t.expect(columnHeaderLink(2).innerText).eql('C1')
+})
+
+const variableURL = createUSSStatisticsPage(`
+columns = [
+    column(values=density_pw_1km, name="Col A", unit=unitDensity),
+    column(values=commute_transit, name="Col B", unit=unitPercentage)
+]
+table(
+    columns=columns
+)`)
+
+urbanstatsFixture('uss with columns variable', variableURL)
+
+test('drag column header does not swap columns', async (t) => {
+    await waitForLoading()
+    await t.expect(columnHeaderLink(0).exists).notOk()
+})


### PR DESCRIPTION
Resolves #1942

## Summary
- Adds drag-and-drop column reordering to the statistics panel table
- Implements `makeColumnReorderHandler` to manage column order state
- Updates `table.tsx` to support draggable headers with visual feedback

## Test plan
- [ ] Drag column headers to reorder in the statistics panel
- [ ] Verify column order persists within the session
- [ ] Run `statistic-column-reorder.test.ts` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)