### PR TITLE
Fix map layer ordering bug

### DIFF
--- a/react/src/components/map-common.tsx
+++ b/react/src/components/map-common.tsx
@@ -118,8 +118,7 @@ function polygonsId(id: string, kind: 'source' | 'fill' | 'outline'): string {
 
 export function PolygonFeatureCollection({ features, clickable }: { features: GeoJSON.Feature[], clickable: boolean }): ReactNode {
     const { current: map } = useMap()
-
-    const labelId = useOrderedResolve(useMemo(() => map !== undefined ? firstLabelId(map) : Promise.resolve(undefined), [map]), 'PolygonFeatureCollection.firstLabel').result
+    const beforeId = useContentBeforeId(map)
 
     const collection: GeoJSON.FeatureCollection = useMemo(() => ({
         type: 'FeatureCollection',
@@ -141,7 +140,7 @@ export function PolygonFeatureCollection({ features, clickable }: { features: Ge
                     'fill-color': ['get', 'fillColor'],
                     'fill-opacity': ['get', 'fillOpacity'],
                 }}
-                beforeId={labelId}
+                beforeId={beforeId}
             />
             <Layer
                 id={polygonsId(id, 'outline')}
@@ -151,7 +150,7 @@ export function PolygonFeatureCollection({ features, clickable }: { features: Ge
                     'line-color': ['get', 'color'],
                     'line-width': ['get', 'weight'],
                 }}
-                beforeId={labelId}
+                beforeId={beforeId}
             />
         </>
     )
@@ -191,6 +190,19 @@ async function firstLabelId(map: MapRef): Promise<string | undefined> {
     return undefined
 }
 
+function useContentBeforeId(map: MapRef | undefined): string | undefined {
+    const labelId = useOrderedResolve(useMemo(() => map !== undefined ? firstLabelId(map) : Promise.resolve(undefined), [map]), 'useContentBeforeId').result
+    const hasBasemapSubnationalsLayer = map?.getLayer(basemapSubnationalsId) !== undefined
+    if (hasBasemapSubnationalsLayer && labelId !== undefined) {
+        // If the basemap is in front of the label, then it hasn't moved yet, and we should actually place the content before the label
+        const layersOrder = map.getLayersOrder()
+        if (layersOrder.indexOf(basemapSubnationalsId) > layersOrder.indexOf(labelId)) {
+            return labelId
+        }
+    }
+    return hasBasemapSubnationalsLayer ? basemapSubnationalsId : labelId
+}
+
 class CustomAttributionControl extends maplibregl.AttributionControl {
     constructor(startShowingAttribution: boolean) {
         super()
@@ -220,9 +232,8 @@ function pointsId(id: string, kind: 'source' | 'fill' | 'outline'): string {
 
 export function PointFeatureCollection({ features, clickable }: { features: GeoJSON.Feature[], clickable: boolean }): ReactNode {
     const { current: map } = useMap()
+    const beforeId = useContentBeforeId(map)
     const id = useId()
-
-    const labelId = useOrderedResolve(useMemo(() => map !== undefined ? firstLabelId(map) : Promise.resolve(undefined), [map]), 'PointFeatureCollection').result
 
     const collection: GeoJSON.FeatureCollection = useMemo(() => ({
         type: 'FeatureCollection',
@@ -243,7 +254,7 @@ export function PointFeatureCollection({ features, clickable }: { features: GeoJ
                     'circle-opacity': ['get', 'fillOpacity'],
                     'circle-radius': ['get', 'radius'],
                 }}
-                beforeId={labelId}
+                beforeId={beforeId}
             />
         </>
     )
@@ -303,6 +314,8 @@ function useClickable({ id, clickable, features }: { id: string, clickable: bool
 // eslint-disable-next-line no-restricted-syntax -- This is the default maplibre background color
 const defaultBackgroundColor = '#f8f4f0'
 
+const basemapSubnationalsId = 'boundary_subn_overlayed'
+
 export function Basemap({ basemap }: { basemap: Basemap }): ReactNode {
     const map = useMap().current!
 
@@ -327,7 +340,7 @@ export function Basemap({ basemap }: { basemap: Basemap }): ReactNode {
     if (basemap.type === 'osm' && basemap.subnationalOutlines !== undefined) {
         return (
             <Layer
-                id="boundary_subn_overlayed"
+                id={basemapSubnationalsId}
                 type="line"
                 source="openmaptiles"
                 source-layer="boundary"


### PR DESCRIPTION
Exposed by work in #2001

Polygon layers being behind the subnational outline was purely a result of temporal insertion order