### PR TITLE
refactor: extract isMac() utility to platform.ts

### DIFF
--- a/react/src/urban-stats-script/DebugEditorPanel.tsx
+++ b/react/src/urban-stats-script/DebugEditorPanel.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useEffect } from 'react'
 
 import { PageTemplate } from '../page_template/template'
-import { TestUtils } from '../utils/TestUtils'
+import { isMac } from '../utils/platform'
 
 import { Editor } from './Editor'
 import { useStandaloneEditorState } from './StandaloneEditor'
@@ -25,13 +25,12 @@ export function DebugEditorPanel(props: { undoChunking?: number }): ReactNode {
 
     useEffect(() => {
         const listener = (e: KeyboardEvent): void => {
-            const isMac = navigator.userAgent.includes('Mac') && !TestUtils.shared.isTesting
             // TestCafe doesn't send `e.code`, so we need to use `toLowerCase` otherwise the char is capitalized on Mac
-            if (e.key.toLowerCase() === 's' && (isMac ? e.metaKey : e.ctrlKey) && e.shiftKey) {
+            if (e.key.toLowerCase() === 's' && (isMac() ? e.metaKey : e.ctrlKey) && e.shiftKey) {
                 e.preventDefault()
                 setSelection([selection[1], selection[0]])
             }
-            if (e.key.toLowerCase() === 'd' && (isMac ? e.metaKey : e.ctrlKey) && e.shiftKey) {
+            if (e.key.toLowerCase() === 'd' && (isMac() ? e.metaKey : e.ctrlKey) && e.shiftKey) {
                 e.preventDefault()
                 setSelection([null, null])
             }

--- a/react/src/utils/platform.ts
+++ b/react/src/utils/platform.ts
@@ -1,5 +1,7 @@
 import { TestUtils } from './TestUtils'
 
+// Returns false during TestCafe tests: even on a Mac, TestCafe sends Windows-style
+// keyboard events (Ctrl not Cmd), so callers should treat it as non-Mac.
 export function isMac(): boolean {
     return navigator.userAgent.includes('Mac') && !TestUtils.shared.isTesting
 }

--- a/react/src/utils/platform.ts
+++ b/react/src/utils/platform.ts
@@ -1,0 +1,5 @@
+import { TestUtils } from './TestUtils'
+
+export function isMac(): boolean {
+    return navigator.userAgent.includes('Mac') && !TestUtils.shared.isTesting
+}

--- a/react/src/utils/useUndoRedo.tsx
+++ b/react/src/utils/useUndoRedo.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
-import { TestUtils } from './TestUtils'
 import { makeDebugLogger } from './debug-logging'
+import { isMac } from './platform'
 import { useMobileLayout } from './responsive'
 import { zIndex } from './zIndex'
 
@@ -113,12 +113,11 @@ export function useUndoRedo<T, S>(
                 return
             }
 
-            const isMac = navigator.userAgent.includes('Mac') && !TestUtils.shared.isTesting
-            if (isMac ? e.key.toLowerCase() === 'z' && e.metaKey && !e.shiftKey : e.key.toLowerCase() === 'z' && e.ctrlKey) {
+            if (isMac() ? e.key.toLowerCase() === 'z' && e.metaKey && !e.shiftKey : e.key.toLowerCase() === 'z' && e.ctrlKey) {
                 e.preventDefault()
                 doUndo()
             }
-            else if (isMac ? e.key.toLowerCase() === 'z' && e.metaKey && e.shiftKey : e.key.toLowerCase() === 'y' && e.ctrlKey) {
+            else if (isMac() ? e.key.toLowerCase() === 'z' && e.metaKey && e.shiftKey : e.key.toLowerCase() === 'y' && e.ctrlKey) {
                 e.preventDefault()
                 doRedo()
             }


### PR DESCRIPTION
## Summary
- Adds `react/src/utils/platform.ts` with an `isMac()` helper that centralises the `navigator.userAgent.includes('Mac') && !TestUtils.shared.isTesting` check
- Replaces inline `const isMac = …` locals in `useUndoRedo.tsx` and `DebugEditorPanel.tsx` with calls to the shared utility

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Existing editor e2e tests pass (undo/redo, Ctrl+Shift+S, Ctrl+Shift+D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)