### PR TITLE
Refactor operator types to use typed const arrays

### DIFF
--- a/react/globals.d.ts
+++ b/react/globals.d.ts
@@ -9,6 +9,10 @@ interface ObjectConstructor {
     entries<const T extends Record<PropertyKey, unknown>>(o: T): (keyof { [K in keyof T as [K, T[K]]]: never })[]
     keys<const T extends Record<PropertyKey, unknown>>(o: T): (keyof T)[]
 }
+
+interface ReadonlyArray<T> {
+    includes(searchElement: unknown): searchElement is T
+}
 /* eslint-enable @typescript-eslint/method-signature-style */
 
 // Prevent extraneous errors in the ide

--- a/react/src/urban-stats-script/ast.ts
+++ b/react/src/urban-stats-script/ast.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 
 import { AutoUXNodeMetadata } from './autoux-node-metadata'
 import { LocInfo } from './location'
+import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 import { Decorated, ParseError } from './parser'
 import { USSType } from './types-values'
 
@@ -17,8 +18,8 @@ export type UrbanStatsASTExpression = (
     UrbanStatsASTLHS |
     { type: 'constant', value: Decorated<{ type: 'number', value: number } | { type: 'string', value: string }> } |
     { type: 'call', fn: UrbanStatsASTExpression, args: UrbanStatsASTArg[], entireLoc: LocInfo } |
-    { type: 'binaryOperator', operator: Decorated<string>, left: UrbanStatsASTExpression, right: UrbanStatsASTExpression } |
-    { type: 'unaryOperator', operator: Decorated<string>, expr: UrbanStatsASTExpression } |
+    { type: 'binaryOperator', operator: Decorated<BinaryOperatorSymbol>, left: UrbanStatsASTExpression, right: UrbanStatsASTExpression } |
+    { type: 'unaryOperator', operator: Decorated<UnaryOperatorSymbol>, expr: UrbanStatsASTExpression } |
     { type: 'objectLiteral', entireLoc: LocInfo, properties: [string, UrbanStatsASTExpression][] } |
     { type: 'vectorLiteral', entireLoc: LocInfo, elements: UrbanStatsASTExpression[] } |
     { type: 'if', entireLoc: LocInfo, condition: UrbanStatsASTExpression, then: UrbanStatsASTStatement, else?: UrbanStatsASTStatement } |

--- a/react/src/urban-stats-script/interpreter.ts
+++ b/react/src/urban-stats-script/interpreter.ts
@@ -4,7 +4,7 @@ import { UrbanStatsASTStatement, UrbanStatsASTExpression, UrbanStatsASTLHS, Urba
 import { Context } from './context'
 import { addAdditionalDims, broadcastApply, broadcastCall } from './forward-broadcasting'
 import { LocInfo } from './location'
-import { expressionOperatorMap } from './operators'
+import { BinaryOperatorSymbol, expressionOperatorMap, UnaryOperatorSymbol } from './operators'
 import { splitMask } from './split-broadcasting'
 import { renderType, unifyType, USSRawValue, USSType, USSValue, USSVectorType, ValueArg, undocValue, canUnifyTo } from './types-values'
 
@@ -297,7 +297,7 @@ function attrLookupOrSet(
     return { type: 'error', message: `Cannot access attribute of type ${renderType(type)}. Only objects and vectors support attributes.` }
 }
 
-function evaluateUnaryOperator(operand: USSValue, operator: string, env: Context, errLoc: LocInfo): USSValue {
+function evaluateUnaryOperator(operand: USSValue, operator: UnaryOperatorSymbol, env: Context, errLoc: LocInfo): USSValue {
     const operatorObj = expressionOperatorMap.get(operator)
     assert(operatorObj?.unary !== undefined, `Unknown operator: ${operator}`)
     const res = broadcastApply(
@@ -313,7 +313,7 @@ function evaluateUnaryOperator(operand: USSValue, operator: string, env: Context
     return res.result
 }
 
-function evaluateBinaryOperator(left: USSValue, right: USSValue, operator: string, env: Context, errLoc: LocInfo): USSValue {
+function evaluateBinaryOperator(left: USSValue, right: USSValue, operator: BinaryOperatorSymbol, env: Context, errLoc: LocInfo): USSValue {
     const operatorObj = expressionOperatorMap.get(operator)
     assert(operatorObj?.binary !== undefined, `Unknown operator: ${operator}`)
     const res = broadcastApply(

--- a/react/src/urban-stats-script/operators.ts
+++ b/react/src/urban-stats-script/operators.ts
@@ -111,7 +111,7 @@ function booleanOperation(fn: (a: boolean, b: boolean) => boolean): BinaryOperat
     }
 }
 
-export const expressionOperatorMap = new Map<string, Operator>([
+export const expressionOperatorMap = new Map<UnaryOperatorSymbol | BinaryOperatorSymbol, Operator>([
     // E
     [
         '**',
@@ -252,5 +252,8 @@ export const expressionOperatorMap = new Map<string, Operator>([
     ],
 ])
 
-export const unaryOperators = [...expressionOperatorMap.entries()].filter(([, op]) => op.unary !== undefined).map(([op]) => op)
-export const infixOperators = [...expressionOperatorMap.entries()].filter(([, op]) => op.binary !== undefined).map(([op]) => op)
+export const unaryOperators = ['+', '-', '!'] as const
+export type UnaryOperatorSymbol = typeof unaryOperators[number]
+
+export const infixOperators = ['**', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&', '|'] as const
+export type BinaryOperatorSymbol = typeof infixOperators[number]

--- a/react/src/urban-stats-script/parser.ts
+++ b/react/src/urban-stats-script/parser.ts
@@ -6,7 +6,7 @@ import { getAutoUXNodeMetadata } from './autoux-node-metadata'
 import { Context } from './context'
 import { AnnotatedToken, AnnotatedTokenWithValue, lex, Keyword, emptyLocation } from './lexer'
 import { noLocation, LocInfo, Block } from './location'
-import { expressionOperatorMap, infixOperators, unaryOperators } from './operators'
+import { BinaryOperatorSymbol, expressionOperatorMap, infixOperators, unaryOperators, UnaryOperatorSymbol } from './operators'
 import type { USSType } from './types-values'
 
 export interface Decorated<T> {
@@ -24,7 +24,7 @@ export interface UnparseOptions {
     wrap?: boolean
 }
 
-type USSInfixSequenceElement = { type: 'operator', operatorType: 'unary' | 'binary', value: Decorated<string> } | UrbanStatsASTExpression
+type USSInfixSequenceElement = { type: 'operator', operatorType: 'unary', value: Decorated<UnaryOperatorSymbol> } | { type: 'operator', operatorType: 'binary', value: Decorated<BinaryOperatorSymbol> } | UrbanStatsASTExpression
 
 export function toSExp(node: UrbanStatsAST): string {
     /**
@@ -330,6 +330,7 @@ class ParseState {
                     if (this.consumeOperator(...unaryOperators)) {
                         const operator = this.tokens[this.index - 1]
                         assert(operator.token.type === 'operator', 'Expected operator token')
+                        assert(unaryOperators.includes(operator.token.value), 'Expected operator token to be a unary operator')
                         operatorExpSequence.push({
                             type: 'operator',
                             operatorType: 'unary',
@@ -351,6 +352,7 @@ class ParseState {
                     if (this.consumeOperator(...infixOperators)) {
                         const operator = this.tokens[this.index - 1]
                         assert(operator.token.type === 'operator', 'Expected operator token')
+                        assert(infixOperators.includes(operator.token.value), 'Expected operator token to be a binary operator')
                         operatorExpSequence.push({
                             type: 'operator',
                             operatorType: 'binary',


### PR DESCRIPTION
## Summary

- Defines `UnaryOperatorSymbol` and `BinaryOperatorSymbol` as typed `const` arrays instead of plain `string`
- Narrows `operator` fields in `UrbanStatsASTExpression` (`binaryOperator`, `unaryOperator`) to use these types
- Types `evaluateUnaryOperator` / `evaluateBinaryOperator` params in the interpreter
- Adds `ReadonlyArray<T>.includes` override in `globals.d.ts` to make exhaustiveness checks work with `const` arrays

## Test plan

- [ ] TypeScript compilation passes
- [ ] Existing USS interpreter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)