### PR TITLE
Add HumanReadableName/HumanReadableTemplate and adopt in tables

### DIFF
--- a/react/globals.d.ts
+++ b/react/globals.d.ts
@@ -9,6 +9,10 @@ interface ObjectConstructor {
     entries<const T extends Record<PropertyKey, unknown>>(o: T): (keyof { [K in keyof T as [K, T[K]]]: never })[]
     keys<const T extends Record<PropertyKey, unknown>>(o: T): (keyof T)[]
 }
+
+interface ReadonlyArray<T> {
+    includes(searchElement: unknown): searchElement is T
+}
 /* eslint-enable @typescript-eslint/method-signature-style */
 
 // Prevent extraneous errors in the ide

--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -10,6 +10,7 @@ import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-set
 import { statParents } from '../page_template/statistic-tree'
 import { PageTemplate } from '../page_template/template'
 import { Universe, universeContext, useUniverse } from '../universe'
+import { HumanReadableName } from '../urban-stats-script/types-values'
 import { assert } from '../utils/defensive'
 import { sanitize } from '../utils/paths'
 import { Article, IRelatedButtons } from '../utils/protos'
@@ -124,7 +125,7 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
 
 type NameSpec = Extract<CellSpec, { type: 'statistic-name' }>
 
-function getGroupAndDisplayNames(nameSpec: NameSpec, nameSpecs: NameSpec[]): [string | undefined, string] {
+function getGroupAndDisplayNames(nameSpec: NameSpec, nameSpecs: NameSpec[]): [string | undefined, HumanReadableName] {
     if (nameSpec.row === undefined) {
         return [undefined, nameSpec.renderedStatname]
     }

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -4,7 +4,8 @@ import { stringify } from 'csv-stringify/sync'
 import { saveAs } from 'file-saver'
 import React, { ReactNode } from 'react'
 
-import { USSOpaqueValue, USSValue } from '../urban-stats-script/types-values'
+import { reifyString } from '../urban-stats-script/derive-human-readable-name'
+import { HumanReadableName, USSOpaqueValue, USSValue } from '../urban-stats-script/types-values'
 import { Article } from '../utils/protos'
 
 import { ArticleRow } from './load-article'
@@ -161,16 +162,16 @@ export function generateMapperCSVData(
 
 export function generateStatisticsPanelCSVData(
     articleNames: string[],
-    data: { name: string, value: number[], ordinal: number[], populationPercentile: number[] }[],
+    data: { name: HumanReadableName, value: number[], ordinal: number[], populationPercentile: number[] }[],
     hideOrdinalsPercentiles: boolean,
 ): string[][] {
     // Build header row: Name, then for each column: column name, optionally "column name Ord", "column name percentile"
     const headerRow: string[] = ['Name']
 
     for (const col of data) {
-        headerRow.push(col.name)
+        headerRow.push(reifyString(col.name))
         if (!hideOrdinalsPercentiles) {
-            headerRow.push(`${col.name} Ord`, `${col.name} percentile`)
+            headerRow.push(`${reifyString(col.name)} Ord`, `${reifyString(col.name)} percentile`)
         }
     }
 

--- a/react/src/components/load-article.ts
+++ b/react/src/components/load-article.ts
@@ -7,6 +7,7 @@ import paths from '../data/statistic_path_list'
 import { loadProtobuf } from '../load_json'
 import { StatGroupSettings, statIsEnabled } from '../page_template/statistic-settings'
 import { findAmbiguousSourcesAll, statParents, StatName, StatPath, statPathToOrder } from '../page_template/statistic-tree'
+import { HumanReadableName } from '../urban-stats-script/types-values'
 import { assert } from '../utils/defensive'
 import { Article, CongressionalRepresentativeTable, ICongressionalRepresentative, ICongressionalRepresentativePointer, IFirstOrLast, IMetadata } from '../utils/protos'
 import { UnitType } from '../utils/unit'
@@ -95,7 +96,7 @@ const dataCreditExplanationPageByMetadataIndex = new Map<number, string>(
 
 interface StatisticCellRenderingInfoCommon {
     articleType: string
-    statname: string
+    statname: HumanReadableName
     unit?: UnitType
     statpath?: StatPath
 }

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -3,6 +3,7 @@ import React, { CSSProperties, Fragment, ReactNode, useMemo } from 'react'
 import { RelativeLoader } from '../navigation/loading'
 import { useColors } from '../page_template/colors'
 import { Universe, useUniverse } from '../universe'
+import { HumanReadableName } from '../urban-stats-script/types-values'
 import { assert } from '../utils/defensive'
 import { Article } from '../utils/protos'
 
@@ -304,14 +305,14 @@ export interface StatisticPanelLongnameCellProps {
 
 export interface StatisticNameCellProps {
     row?: ArticleRow
-    renderedStatname: string
+    renderedStatname: HumanReadableName
     longname: string
     currentUniverse: Universe
     center?: boolean
     highlightIndex?: number
     transpose?: boolean
     isIndented?: boolean
-    displayName?: string
+    displayName?: HumanReadableName
     footnoteSymbol?: string
     sortInfo?: {
         sortDirection: 'up' | 'down' | 'both'

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -10,6 +10,8 @@ import { Colors } from '../page_template/color-themes'
 import { colorFromCycle, useColors } from '../page_template/colors'
 import { MobileArticlePointers, rowExpandedKey, useSetting, useSettings } from '../page_template/settings'
 import { Universe, useUniverse } from '../universe'
+import { reifyReact, reifyString } from '../urban-stats-script/derive-human-readable-name'
+import { HumanReadableName } from '../urban-stats-script/types-values'
 import { withButtonRole } from '../utils/a11y'
 import { assert } from '../utils/defensive'
 import { sanitize } from '../utils/paths'
@@ -537,7 +539,7 @@ export function StatisticRowCells(props: {
                 content: () => (
                     <span className="serif value testing-statistic-value">
                         <Statistic
-                            statname={statisticRow.statname}
+                            statname={reifyString(statisticRow.statname)}
                             value={statisticRow.statval}
                             isUnit={false}
                             style={props.statisticStyle ?? {}}
@@ -554,7 +556,7 @@ export function StatisticRowCells(props: {
                     <div className="value_unit">
                         <span className="serif value">
                             <Statistic
-                                statname={statisticRow.statname}
+                                statname={reifyString(statisticRow.statname)}
                                 value={statisticRow.statval}
                                 isUnit={true}
                                 unit={statisticRow.unit}
@@ -911,7 +913,7 @@ export function StatisticNameCell(props: StatisticNameCellProps & { width: numbe
     )
 }
 
-function displayName(props: StatisticNameCellProps): string {
+function displayName(props: StatisticNameCellProps): HumanReadableName {
     return props.displayName ?? props.renderedStatname
 }
 
@@ -956,7 +958,7 @@ function StatisticName(props: {
     longname: string
     currentUniverse: Universe
     center?: boolean
-    displayName: string
+    displayName: HumanReadableName
     footnoteSymbol?: string
 }): ReactNode {
     const colors = useColors()
@@ -972,7 +974,7 @@ function StatisticName(props: {
                     )}
                     data-test-id="statistic-link"
                 >
-                    {props.displayName}
+                    {reifyReact(props.displayName)}
                 </a>
             )
         : props.row?.kind === 'statistic'
@@ -992,12 +994,12 @@ function StatisticName(props: {
                         }, { scroll: { kind: 'position', top: 0 } })}
                         data-test-id="statistic-link"
                     >
-                        {props.displayName}
+                        {reifyReact(props.displayName)}
                     </a>
                 )
             : (
                     <span style={{ color: colors.textMain }} data-test-id="statistic-link">
-                        {props.displayName}
+                        {reifyReact(props.displayName)}
                     </span>
                 )
     const screenshotMode = useScreenshotMode()

--- a/react/src/mapper/components/Colorbar.tsx
+++ b/react/src/mapper/components/Colorbar.tsx
@@ -5,6 +5,8 @@ import { getUnitDisplay } from '../../components/unit-display'
 import { Colors } from '../../page_template/color-themes'
 import { useColors } from '../../page_template/colors'
 import { ScaleInstance } from '../../urban-stats-script/constants/scale'
+import { reifyReact, reifyString } from '../../urban-stats-script/derive-human-readable-name'
+import { HumanReadableName } from '../../urban-stats-script/types-values'
 import { furthestColor, interpolateColor } from '../../utils/color'
 import { classifyStatistic, UnitType } from '../../utils/unit'
 import { Keypoints } from '../ramps'
@@ -14,13 +16,13 @@ interface EmpiricalRamp {
     ramp: Keypoints
     scale: ScaleInstance
     interpolations: number[]
-    label: string
+    label: HumanReadableName
     unit?: UnitType
     hasValuesClampedToStart: boolean
     hasValuesClampedToEnd: boolean
 }
 
-export type RampToDisplay = { type: 'ramp', value: EmpiricalRamp } | { type: 'label', value: string }
+export type RampToDisplay = { type: 'ramp', value: EmpiricalRamp } | { type: 'label', value: HumanReadableName }
 
 export function styleFromBasemap(basemap: Basemap, colors: Colors): { backgroundColor: string, color?: string } {
     return basemap.type === 'none'
@@ -40,7 +42,7 @@ export function Colorbar(props: { ramp: RampToDisplay | undefined, basemap: Base
         >
             {props.ramp && props.ramp.type === 'label' && (
                 <div className="centered_text user_input">
-                    {props.ramp.value}
+                    {reifyReact(props.ramp.value)}
                 </div>
             )}
             {props.ramp && props.ramp.type === 'ramp' && (
@@ -86,13 +88,13 @@ function RampColorbar({ ramp }: { ramp: EmpiricalRamp }): ReactNode {
             <div className="centered_text">
                 <MaybeInequality ramp={ramp} index={index} />
                 <Statistic
-                    statname={ramp.label}
+                    statname={reifyString(ramp.label)}
                     value={stat}
                     isUnit={false}
                     unit={ramp.unit}
                 />
                 <Statistic
-                    statname={ramp.label}
+                    statname={reifyString(ramp.label)}
                     value={stat}
                     isUnit={true}
                     unit={ramp.unit}
@@ -152,7 +154,7 @@ function RampColorbar({ ramp }: { ramp: EmpiricalRamp }): ReactNode {
             <div ref={valuesRef} style={{ position: 'absolute', top: 0, left: 0, display: 'flex', width: '100%', visibility: 'hidden' }}>{valuesDivs(false)}</div>
             <div style={{ display: 'flex', width: '100%' }}>{valuesDivs(shouldRotate)}</div>
             <div className="centered_text user_input">
-                {ramp.label}
+                {reifyReact(ramp.label)}
             </div>
         </div>
     )
@@ -162,7 +164,7 @@ function RampColorbar({ ramp }: { ramp: EmpiricalRamp }): ReactNode {
 function MaybeInequality({ ramp, index }: { ramp: EmpiricalRamp, index: number }): ReactNode {
     const scaleAscending = ramp.scale.inverse(0) < ramp.scale.inverse(1)
     // Similarly to how we do it with <Statistic/> above
-    const unitDisplay = getUnitDisplay(ramp.unit ?? classifyStatistic(ramp.label))
+    const unitDisplay = getUnitDisplay(ramp.unit ?? classifyStatistic(reifyString(ramp.label)))
     const isFirst = index === 0
     const isLast = index === ramp.interpolations.length - 1
     let prefix: string | undefined

--- a/react/src/mapper/settings/Selector.tsx
+++ b/react/src/mapper/settings/Selector.tsx
@@ -9,10 +9,11 @@ import { UrbanStatsASTExpression } from '../../urban-stats-script/ast'
 import { hsvToColor, rgbToColor } from '../../urban-stats-script/constants/color'
 import { Color, doRender, hexToColor, hsvColorExpression, rgbColorExpression } from '../../urban-stats-script/constants/color-utils'
 import { RampT } from '../../urban-stats-script/constants/ramp'
+import { reifyReact, reifyString } from '../../urban-stats-script/derive-human-readable-name'
 import { EditorError } from '../../urban-stats-script/editor-utils'
 import { emptyLocation } from '../../urban-stats-script/lexer'
 import { parseNoErrorAsCustomNode, parseNoErrorAsExpression } from '../../urban-stats-script/parser'
-import { Documentation, TypeEnvironment, USSType } from '../../urban-stats-script/types-values'
+import { Documentation, HumanReadableName, TypeEnvironment, USSType } from '../../urban-stats-script/types-values'
 import { TestUtils } from '../../utils/TestUtils'
 import { useTextAreaSizeSync } from '../../utils/text-area-size-sync'
 
@@ -200,19 +201,19 @@ function renderSelection(typeEnvironment: TypeEnvironment, selection: Selection)
     const doc = typeEnvironment.get(selection.name)?.documentation
     if (doc?.selectorRendering?.kind === 'subtitleLongDescription') {
         return {
-            text: doc.humanReadableName,
+            text: reifyString(doc.humanReadableName),
             node: highlighted => <LongDescriptionSubtitle doc={doc} highlighted={highlighted} />,
         }
     }
     if (doc?.selectorRendering?.kind === 'gradientBackground') {
         const ramp = doc.selectorRendering.ramp
         return {
-            text: doc.humanReadableName,
+            text: reifyString(doc.humanReadableName),
             node: highlighted => <RampSelectorOption name={doc.humanReadableName} ramp={ramp} highlighted={highlighted} />,
         }
     }
     else {
-        return { text: doc?.humanReadableName ?? selection.name }
+        return { text: reifyString(doc?.humanReadableName ?? selection.name) }
     }
 }
 
@@ -263,7 +264,7 @@ function LongDescriptionSubtitle(props: { doc: Documentation, highlighted: boole
             background: props.highlighted ? colors.slightlyDifferentBackgroundFocused : colors.slightlyDifferentBackground,
         }}
         >
-            <div>{props.doc.humanReadableName}</div>
+            <div>{reifyReact(props.doc.humanReadableName)}</div>
             <div style={{ fontSize: 'smaller', color: colors.ordinalTextColor }}>
                 {props.doc.longDescription}
             </div>
@@ -271,7 +272,7 @@ function LongDescriptionSubtitle(props: { doc: Documentation, highlighted: boole
     )
 }
 
-function RampSelectorOption(props: { name: string, ramp: RampT, highlighted: boolean }): ReactNode {
+function RampSelectorOption(props: { name: HumanReadableName, ramp: RampT, highlighted: boolean }): ReactNode {
     const colors = useColors()
     const firstRampColor = ColorLib(props.ramp[0][1])
     const highlightedColor = `rgb(from ${colors.slightlyDifferentBackgroundFocused} r g b / 1)`
@@ -282,7 +283,7 @@ function RampSelectorOption(props: { name: string, ramp: RampT, highlighted: boo
             background: props.highlighted ? `${selectionGradient(highlightedColor, 'bottom')}, ${selectionGradient(highlightedColor, 'right')}, ${toCssGradient(props.ramp)}` : toCssGradient(props.ramp),
         }}
         >
-            {props.name}
+            {reifyReact(props.name)}
         </div>
     )
 }

--- a/react/src/stat/AddColumnSearchBox.tsx
+++ b/react/src/stat/AddColumnSearchBox.tsx
@@ -4,12 +4,13 @@ import { GenericSearchBox } from '../components/search-generic'
 import { possibilities } from '../mapper/settings/parseExpr'
 import { Selection } from '../mapper/settings/selector-classifier'
 import { addColumn } from '../urban-stats-script/add-column'
-import { TypeEnvironment } from '../urban-stats-script/types-values'
+import { reifyReact, reifyString } from '../urban-stats-script/derive-human-readable-name'
+import { HumanReadableName, TypeEnvironment } from '../urban-stats-script/types-values'
 
 import { Statistic, StatSetter } from './types'
 import { mapUSSFromStat } from './utils'
 
-interface VariableSearchResult { name: string, displayName: string }
+interface VariableSearchResult { name: string, displayName: HumanReadableName }
 
 export function AddColumnSearchBox({ stat, set, typeEnvironment }: {
     stat: Statistic
@@ -22,7 +23,7 @@ export function AddColumnSearchBox({ stat, set, typeEnvironment }: {
         return (query: string): Promise<VariableSearchResult[]> => {
             const lowerQuery = query.toLowerCase()
             const filtered = allVariables.filter(v =>
-                v.displayName.toLowerCase().includes(lowerQuery)
+                reifyString(v.displayName).toLowerCase().includes(lowerQuery)
                 || v.name.toLowerCase().includes(lowerQuery),
             )
             return Promise.resolve(filtered)
@@ -61,7 +62,7 @@ export function AddColumnSearchBox({ stat, set, typeEnvironment }: {
             onMouseOver={onMouseOver}
             data-test-id={dataTestId}
         >
-            {currentMatch().displayName}
+            {reifyReact(currentMatch().displayName)}
         </div>
     )
 

--- a/react/src/stat/StatisticPanelTable.tsx
+++ b/react/src/stat/StatisticPanelTable.tsx
@@ -9,6 +9,7 @@ import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
 import { useUniverse } from '../universe'
 import { orderNonNan } from '../urban-stats-script/constants/table'
+import { reifyString } from '../urban-stats-script/derive-human-readable-name'
 import { TypeEnvironment } from '../urban-stats-script/types-values'
 import { assert } from '../utils/defensive'
 import { sanitize } from '../utils/paths'
@@ -126,7 +127,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, 
     const headerSpecs: CellSpec[] = data.table.map((col, colIndex) => ({
         type: 'statistic-name',
         renderedStatname: col.name,
-        longname: col.name,
+        longname: reifyString(col.name),
         currentUniverse,
         sortInfo: {
             onSort: () => {

--- a/react/src/stat/types.ts
+++ b/react/src/stat/types.ts
@@ -2,6 +2,7 @@ import { StatCol } from '../components/load-article'
 import statnames from '../data/statistic_name_list'
 import { MapUSS } from '../mapper/settings/map-uss'
 import { Universe } from '../universe'
+import { HumanReadableName } from '../urban-stats-script/types-values'
 import { UnitType } from '../utils/unit'
 
 export type Statistic = {
@@ -28,7 +29,7 @@ export interface StatSettings {
 
 export interface StatData {
     // One entry per column
-    table: { value: number[], populationPercentile: number[], ordinal: number[], name: string, unit?: UnitType }[]
+    table: { value: number[], populationPercentile: number[], ordinal: number[], name: HumanReadableName, unit?: UnitType }[]
     articleNames: string[]
     renderedStatname: string
     statcol?: StatCol

--- a/react/src/urban-stats-script/ast.ts
+++ b/react/src/urban-stats-script/ast.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 
 import { AutoUXNodeMetadata } from './autoux-node-metadata'
 import { LocInfo } from './location'
+import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 import { Decorated, ParseError } from './parser'
 import { USSType } from './types-values'
 
@@ -17,8 +18,8 @@ export type UrbanStatsASTExpression = (
     UrbanStatsASTLHS |
     { type: 'constant', value: Decorated<{ type: 'number', value: number } | { type: 'string', value: string }> } |
     { type: 'call', fn: UrbanStatsASTExpression, args: UrbanStatsASTArg[], entireLoc: LocInfo } |
-    { type: 'binaryOperator', operator: Decorated<string>, left: UrbanStatsASTExpression, right: UrbanStatsASTExpression } |
-    { type: 'unaryOperator', operator: Decorated<string>, expr: UrbanStatsASTExpression } |
+    { type: 'binaryOperator', operator: Decorated<BinaryOperatorSymbol>, left: UrbanStatsASTExpression, right: UrbanStatsASTExpression } |
+    { type: 'unaryOperator', operator: Decorated<UnaryOperatorSymbol>, expr: UrbanStatsASTExpression } |
     { type: 'objectLiteral', entireLoc: LocInfo, properties: [string, UrbanStatsASTExpression][] } |
     { type: 'vectorLiteral', entireLoc: LocInfo, elements: UrbanStatsASTExpression[] } |
     { type: 'if', entireLoc: LocInfo, condition: UrbanStatsASTExpression, then: UrbanStatsASTStatement, else?: UrbanStatsASTStatement } |

--- a/react/src/urban-stats-script/constants/table.ts
+++ b/react/src/urban-stats-script/constants/table.ts
@@ -2,10 +2,10 @@ import { assert } from '../../utils/defensive'
 import { UnitType } from '../../utils/unit'
 import { Context } from '../context'
 import { noLocation } from '../location'
-import { USSType, USSValue, USSRawValue, OriginalFunctionArgs, NamedFunctionArgumentWithDocumentation, createConstantExpression } from '../types-values'
+import { USSType, USSValue, USSRawValue, OriginalFunctionArgs, NamedFunctionArgumentWithDocumentation, createConstantExpression, HumanReadableName } from '../types-values'
 
 export interface TableColumn {
-    name: string
+    name: HumanReadableName
     values: number[]
     unit?: UnitType
 }

--- a/react/src/urban-stats-script/derive-human-readable-name.tsx
+++ b/react/src/urban-stats-script/derive-human-readable-name.tsx
@@ -4,28 +4,28 @@ export type HumanReadableElement = { type: 'atom', value: string } | { type: 'wh
 
 export function reifyReact(elements: HumanReadableElement[] | string): ReactNode {
     if (typeof elements === 'string') return elements
-    return elements.map((element) => {
+    return elements.map((element, index) => {
         switch (element.type) {
             case 'atom':
                 return element.value
             case 'subscript':
-                return <sub>{reifyReact(element.value)}</sub>
+                return <sub key={index}>{reifyReact(element.value)}</sub>
             case 'superscript':
-                return <sup>{reifyReact(element.value)}</sup>
+                return <sup key={index}>{reifyReact(element.value)}</sup>
             case 'where':
                 return (
-                    <>
+                    <React.Fragment key={index}>
                         {' where '}
                         {reifyReact(element.value)}
-                    </>
+                    </React.Fragment>
                 )
             case 'parens':
                 return (
-                    <>
+                    <React.Fragment key={index}>
                         (
                         {reifyReact(element.value)}
                         )
-                    </>
+                    </React.Fragment>
                 )
         }
     })

--- a/react/src/urban-stats-script/derive-human-readable-name.tsx
+++ b/react/src/urban-stats-script/derive-human-readable-name.tsx
@@ -1,0 +1,50 @@
+import React, { ReactNode } from 'react'
+
+export type HumanReadableElement = { type: 'atom', value: string } | { type: 'where' | 'superscript' | 'subscript' | 'parens', value: HumanReadableElement[] }
+
+export function reifyReact(elements: HumanReadableElement[] | string): ReactNode {
+    if (typeof elements === 'string') return elements
+    return elements.map((element) => {
+        switch (element.type) {
+            case 'atom':
+                return element.value
+            case 'subscript':
+                return <sub>{reifyReact(element.value)}</sub>
+            case 'superscript':
+                return <sup>{reifyReact(element.value)}</sup>
+            case 'where':
+                return (
+                    <>
+                        {' where '}
+                        {reifyReact(element.value)}
+                    </>
+                )
+            case 'parens':
+                return (
+                    <>
+                        (
+                        {reifyReact(element.value)}
+                        )
+                    </>
+                )
+        }
+    })
+}
+
+export function reifyString(elements: HumanReadableElement[] | string): string {
+    if (typeof elements === 'string') return elements
+    return elements.map((element) => {
+        switch (element.type) {
+            case 'atom':
+                return element.value
+            case 'subscript':
+                return `_{${reifyString(element.value)}}`
+            case 'superscript':
+                return `^{${reifyString(element.value)}}`
+            case 'where':
+                return ` where ${reifyString(element.value)}`
+            case 'parens':
+                return `(${reifyString(element.value)})`
+        }
+    }).join('')
+}

--- a/react/src/urban-stats-script/interpreter.ts
+++ b/react/src/urban-stats-script/interpreter.ts
@@ -4,7 +4,7 @@ import { UrbanStatsASTStatement, UrbanStatsASTExpression, UrbanStatsASTLHS, Urba
 import { Context } from './context'
 import { addAdditionalDims, broadcastApply, broadcastCall } from './forward-broadcasting'
 import { LocInfo } from './location'
-import { expressionOperatorMap } from './operators'
+import { BinaryOperatorSymbol, expressionOperatorMap, UnaryOperatorSymbol } from './operators'
 import { splitMask } from './split-broadcasting'
 import { renderType, unifyType, USSRawValue, USSType, USSValue, USSVectorType, ValueArg, undocValue, canUnifyTo } from './types-values'
 
@@ -297,7 +297,7 @@ function attrLookupOrSet(
     return { type: 'error', message: `Cannot access attribute of type ${renderType(type)}. Only objects and vectors support attributes.` }
 }
 
-function evaluateUnaryOperator(operand: USSValue, operator: string, env: Context, errLoc: LocInfo): USSValue {
+function evaluateUnaryOperator(operand: USSValue, operator: UnaryOperatorSymbol, env: Context, errLoc: LocInfo): USSValue {
     const operatorObj = expressionOperatorMap.get(operator)
     assert(operatorObj?.unary !== undefined, `Unknown operator: ${operator}`)
     const res = broadcastApply(
@@ -313,7 +313,7 @@ function evaluateUnaryOperator(operand: USSValue, operator: string, env: Context
     return res.result
 }
 
-function evaluateBinaryOperator(left: USSValue, right: USSValue, operator: string, env: Context, errLoc: LocInfo): USSValue {
+function evaluateBinaryOperator(left: USSValue, right: USSValue, operator: BinaryOperatorSymbol, env: Context, errLoc: LocInfo): USSValue {
     const operatorObj = expressionOperatorMap.get(operator)
     assert(operatorObj?.binary !== undefined, `Unknown operator: ${operator}`)
     const res = broadcastApply(

--- a/react/src/urban-stats-script/operators.ts
+++ b/react/src/urban-stats-script/operators.ts
@@ -111,7 +111,7 @@ function booleanOperation(fn: (a: boolean, b: boolean) => boolean): BinaryOperat
     }
 }
 
-export const expressionOperatorMap = new Map<string, Operator>([
+export const expressionOperatorMap = new Map<UnaryOperatorSymbol | BinaryOperatorSymbol, Operator>([
     // E
     [
         '**',
@@ -252,5 +252,8 @@ export const expressionOperatorMap = new Map<string, Operator>([
     ],
 ])
 
-export const unaryOperators = [...expressionOperatorMap.entries()].filter(([, op]) => op.unary !== undefined).map(([op]) => op)
-export const infixOperators = [...expressionOperatorMap.entries()].filter(([, op]) => op.binary !== undefined).map(([op]) => op)
+export const unaryOperators = ['+', '-', '!'] as const
+export type UnaryOperatorSymbol = typeof unaryOperators[number]
+
+export const infixOperators = ['**', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&', '|'] as const
+export type BinaryOperatorSymbol = typeof infixOperators[number]

--- a/react/src/urban-stats-script/parser.ts
+++ b/react/src/urban-stats-script/parser.ts
@@ -6,7 +6,7 @@ import { getAutoUXNodeMetadata } from './autoux-node-metadata'
 import { Context } from './context'
 import { AnnotatedToken, AnnotatedTokenWithValue, lex, Keyword, emptyLocation } from './lexer'
 import { noLocation, LocInfo, Block } from './location'
-import { expressionOperatorMap, infixOperators, unaryOperators } from './operators'
+import { BinaryOperatorSymbol, expressionOperatorMap, infixOperators, unaryOperators, UnaryOperatorSymbol } from './operators'
 import type { USSType } from './types-values'
 
 export interface Decorated<T> {
@@ -24,7 +24,7 @@ export interface UnparseOptions {
     wrap?: boolean
 }
 
-type USSInfixSequenceElement = { type: 'operator', operatorType: 'unary' | 'binary', value: Decorated<string> } | UrbanStatsASTExpression
+type USSInfixSequenceElement = { type: 'operator', operatorType: 'unary', value: Decorated<UnaryOperatorSymbol> } | { type: 'operator', operatorType: 'binary', value: Decorated<BinaryOperatorSymbol> } | UrbanStatsASTExpression
 
 export function toSExp(node: UrbanStatsAST): string {
     /**
@@ -330,6 +330,7 @@ class ParseState {
                     if (this.consumeOperator(...unaryOperators)) {
                         const operator = this.tokens[this.index - 1]
                         assert(operator.token.type === 'operator', 'Expected operator token')
+                        assert(unaryOperators.includes(operator.token.value), 'Expected operator token to be a unary operator')
                         operatorExpSequence.push({
                             type: 'operator',
                             operatorType: 'unary',
@@ -351,6 +352,7 @@ class ParseState {
                     if (this.consumeOperator(...infixOperators)) {
                         const operator = this.tokens[this.index - 1]
                         assert(operator.token.type === 'operator', 'Expected operator token')
+                        assert(infixOperators.includes(operator.token.value), 'Expected operator token to be a binary operator')
                         operatorExpSequence.push({
                             type: 'operator',
                             operatorType: 'binary',

--- a/react/src/urban-stats-script/types-values.ts
+++ b/react/src/urban-stats-script/types-values.ts
@@ -12,6 +12,7 @@ import { Scale } from './constants/scale'
 import { Table, TableColumn } from './constants/table'
 import { TextBox } from './constants/text-box'
 import { Context } from './context'
+import { HumanReadableElement } from './derive-human-readable-name'
 import { ConstantCategory } from './documentation-category'
 import { noLocation } from './location'
 import { unparse } from './parser'
@@ -140,8 +141,11 @@ export type USSRawValue = (
 export type DocumentationTable = 'mapper-data-variables' | 'predefined-colors' | 'unit-types' | 'predefined-ramps' | 'predefined-insets' | 'logarithm-functions' | 'trigonometric-functions'
 
 export type SelectorRendering = { kind: 'subtitleLongDescription' } | { kind: 'gradientBackground', ramp: RampT }
+
+export type HumanReadableName = string | HumanReadableElement[]
+
 export interface Documentation {
-    humanReadableName: string
+    humanReadableName: HumanReadableName
     priority?: number
     /**
      * True if this is the canonical default value for its type (e.g., the default ramp or scale).

--- a/react/src/urban-stats-script/types-values.ts
+++ b/react/src/urban-stats-script/types-values.ts
@@ -145,7 +145,7 @@ export type SelectorRendering = { kind: 'subtitleLongDescription' } | { kind: 'g
 export type HumanReadableName = string | HumanReadableElement[]
 
 export interface Documentation {
-    humanReadableName: HumanReadableName
+    humanReadableName: string
     priority?: number
     /**
      * True if this is the canonical default value for its type (e.g., the default ramp or scale).


### PR DESCRIPTION
## Summary

- Adds `HumanReadableElement` type and `HumanReadableName = string | HumanReadableElement[]` union to represent rich (subscript/superscript/where-clause) labels
- Adds `reifyReact` and `reifyString` helpers in `derive-human-readable-name.tsx` to render `HumanReadableName` to React nodes or plain strings
- Adopts `HumanReadableName` in place of `string` across tables, stat panel, article panel, CSV export, Colorbar, and Selector components
- Updates `TableColumn.name` and `StatData.table[].name` to `HumanReadableName`

Stacks on #2058.

## Test plan

- [ ] TypeScript compilation passes
- [ ] Table column headers render correctly (string names unchanged)
- [ ] CSV export still produces correct plain-text column headers via `reifyString`

🤖 Generated with [Claude Code](https://claude.com/claude-code)