### PR TITLE
Refactor operator map to a typed object with unary/binary discriminant

### DIFF
--- a/react/src/urban-stats-script/interpreter.ts
+++ b/react/src/urban-stats-script/interpreter.ts
@@ -298,8 +298,7 @@ function attrLookupOrSet(
 }
 
 function evaluateUnaryOperator(operand: USSValue, operator: UnaryOperatorSymbol, env: Context, errLoc: LocInfo): USSValue {
-    const operatorObj = expressionOperatorMap.get(operator)
-    assert(operatorObj?.unary !== undefined, `Unknown operator: ${operator}`)
+    const operatorObj = expressionOperatorMap[operator]
     const res = broadcastApply(
         operatorObj.unary(operator, errLoc),
         [operand],
@@ -314,8 +313,7 @@ function evaluateUnaryOperator(operand: USSValue, operator: UnaryOperatorSymbol,
 }
 
 function evaluateBinaryOperator(left: USSValue, right: USSValue, operator: BinaryOperatorSymbol, env: Context, errLoc: LocInfo): USSValue {
-    const operatorObj = expressionOperatorMap.get(operator)
-    assert(operatorObj?.binary !== undefined, `Unknown operator: ${operator}`)
+    const operatorObj = expressionOperatorMap[operator]
     const res = broadcastApply(
         operatorObj.binary(operator, errLoc),
         [left, right],

--- a/react/src/urban-stats-script/lexer.ts
+++ b/react/src/urban-stats-script/lexer.ts
@@ -80,7 +80,7 @@ const identifierLexer: GenericLexer = {
 
 export function allOperators(): string[] {
     const ops = new Set<string>(nonExpressionOperators)
-    for (const op of expressionOperatorMap.keys()) {
+    for (const op of Object.keys(expressionOperatorMap)) {
         ops.add(op)
     }
     // sort operators in descending length order to ensure longest match first

--- a/react/src/urban-stats-script/operators.ts
+++ b/react/src/urban-stats-script/operators.ts
@@ -2,13 +2,18 @@ import { Context } from './context'
 import { LocInfo } from './location'
 import { getPrimitiveType, USSPrimitiveRawValue, USSRawValue, USSValue } from './types-values'
 
-interface Operator {
+interface UnaryOperator { type: 'unary', unary: (op: string, locInfo: LocInfo) => USSValue }
+interface BinaryOperator {
+    type: 'binary'
+    binary: (op: string, locInfo: LocInfo) => USSValue
+    isAssociative: boolean
+}
+
+type Operator = {
     precedence: number
-    unary?: (op: string, locInfo: LocInfo) => USSValue
-    binary?: (op: string, locInfo: LocInfo) => USSValue
     description: string
     examples: string[]
-}
+} & (UnaryOperator | BinaryOperator | (Omit<UnaryOperator, 'type'> & Omit<BinaryOperator, 'type'> & { type: 'unary+binary' }))
 
 interface UnaryOperation {
     type: string
@@ -111,40 +116,40 @@ function booleanOperation(fn: (a: boolean, b: boolean) => boolean): BinaryOperat
     }
 }
 
-export const expressionOperatorMap = new Map<UnaryOperatorSymbol | BinaryOperatorSymbol, Operator>([
+export const expressionOperatorMap = {
     // E
-    [
-        '**',
+    '**':
         {
+            type: 'binary',
             precedence: 1000,
             binary: binaryOperator([numericBinaryOperation((a, b) => Math.pow(a, b))]),
             description: 'Exponentiation (power)',
             examples: ['2 ** 3 → 8', '3 ** 2 → 9'],
+            isAssociative: false,
         },
-    ],
     // MD
-    [
-        '*',
+    '*':
         {
+            type: 'binary',
             precedence: 900,
             binary: binaryOperator([numericBinaryOperation((a, b) => a * b)]),
             description: 'Multiplication',
             examples: ['3 * 4 → 12', '5 * 2 → 10'],
+            isAssociative: true,
         },
-    ],
-    [
-        '/',
+    '/':
         {
+            type: 'binary',
             precedence: 900,
             binary: binaryOperator([numericBinaryOperation((a, b) => a / b)]),
             description: 'Division',
             examples: ['10 / 2 → 5', '15 / 3 → 5'],
+            isAssociative: false,
         },
-    ],
     // AS
-    [
-        '+',
+    '+':
         {
+            type: 'unary+binary',
             precedence: 800,
             unary: unaryOperator([{ type: 'number', fn: x => x }]),
             binary: binaryOperator([
@@ -153,104 +158,103 @@ export const expressionOperatorMap = new Map<UnaryOperatorSymbol | BinaryOperato
             ]),
             description: 'Unary plus, Addition, String concatenation',
             examples: ['+5', '2 + 3 → 5', '"hello" + "world" → "helloworld"'],
+            isAssociative: true,
         },
-    ],
-    [
-        '-',
+    '-':
         {
+            type: 'unary+binary',
             precedence: 800,
             unary: unaryOperator([{ type: 'number', fn: x => -(x as number) }]),
             binary: binaryOperator([numericBinaryOperation((a, b) => a - b)]),
             description: 'Unary minus, Subtraction',
             examples: ['-5', '7 - 3 → 4'],
+            isAssociative: false,
         },
-    ],
     // Comparators
-    [
-        '==',
+    '==':
         {
+            type: 'binary',
             precedence: 700,
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- for consistency
             binary: binaryOperator(comparisonOperation((a, b) => a === b, (a, b) => a === b, (a, b) => a === b, (a, b) => a === b)),
             description: 'Equality (works with numbers, strings, booleans, null)',
             examples: ['5 == 5 → true', '"hello" == "hello" → true', 'true == true → true'],
+            isAssociative: false,
         },
-    ],
-    [
-        '!=',
+    '!=':
         {
+            type: 'binary',
             precedence: 700,
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- for consistency
             binary: binaryOperator(comparisonOperation((a, b) => a !== b, (a, b) => a !== b, (a, b) => a !== b, (a, b) => a !== b)),
             description: 'Inequality (works with numbers, strings, booleans, null)',
             examples: ['5 != 3 → true', '"hello" != "world" → true'],
+            isAssociative: false,
         },
-    ],
-    [
-        '<',
+    '<':
         {
+            type: 'binary',
             precedence: 700,
             binary: binaryOperator(comparisonOperation((a, b) => a < b, (a, b) => a < b)),
             description: 'Less than (numbers and strings)',
             examples: ['3 < 5 → true', '"abc" < "def" → true'],
+            isAssociative: false,
         },
-    ],
-    [
-        '>',
+    '>':
         {
+            type: 'binary',
             precedence: 700,
             binary: binaryOperator(comparisonOperation((a, b) => a > b, (a, b) => a > b)),
             description: 'Greater than (numbers and strings)',
             examples: ['7 > 3 → true', '"xyz" > "abc" → true'],
+            isAssociative: false,
         },
-    ],
-    [
-        '<=',
+    '<=':
         {
+            type: 'binary',
             precedence: 700,
             binary: binaryOperator(comparisonOperation((a, b) => a <= b, (a, b) => a <= b)),
             description: 'Less than or equal (numbers and strings)',
             examples: ['5 <= 5 → true', '3 <= 5 → true'],
+            isAssociative: false,
         },
-    ],
-    [
-        '>=',
+    '>=':
         {
+            type: 'binary',
             precedence: 700,
             binary: binaryOperator(comparisonOperation((a, b) => a >= b, (a, b) => a >= b)),
             description: 'Greater than or equal (numbers and strings)',
             examples: ['5 >= 3 → true', '5 >= 5 → true'],
+            isAssociative: false,
         },
-    ],
     // Logic
-    [
-        '!',
+    '!':
         {
+            type: 'unary',
             precedence: 650,
             unary: unaryOperator([{ type: 'boolean', fn: x => !(x as boolean) }]),
             description: 'Logical NOT',
             examples: ['!true → false', '!false → true'],
         },
-    ],
-    [
-        '&',
+    '&':
         {
+            type: 'binary',
             precedence: 600,
             binary: binaryOperator([booleanOperation((a, b) => a && b)]),
             description: 'Logical AND',
             examples: ['true & false → false', 'true & true → true'],
+            isAssociative: true,
         },
-    ],
-    [
-        '|',
+    '|':
         {
+            type: 'binary',
             precedence: 500,
             binary: binaryOperator([booleanOperation((a, b) => a || b)]),
             description: 'Logical OR',
             examples: ['true | false → true', 'false | false → false'],
+            isAssociative: true,
         },
-    ],
-])
+} satisfies Record<UnaryOperatorSymbol | BinaryOperatorSymbol, Operator>
 
 export const unaryOperators = ['+', '-', '!'] as const
 export type UnaryOperatorSymbol = typeof unaryOperators[number]

--- a/react/src/urban-stats-script/parser.ts
+++ b/react/src/urban-stats-script/parser.ts
@@ -376,7 +376,7 @@ class ParseState {
             return operatorExpSequence[0]
         }
         // Get the highest precedence operator
-        const precedences = operatorExpSequence.map(x => x.type === 'operator' ? expressionOperatorMap.get(x.value.node)?.precedence ?? 0 : 0)
+        const precedences = operatorExpSequence.map(x => x.type === 'operator' ? expressionOperatorMap[x.value.node].precedence : 0)
         const maxPrecedence = Math.max(...precedences)
         assert(maxPrecedence > 0, 'No valid operator found in infix sequence')
         const index = precedences.findIndex(p => p === maxPrecedence)
@@ -913,10 +913,10 @@ export function unparse(node: UrbanStatsASTStatement | UrbanStatsASTExpression, 
         case 'binaryOperator':
             const leftStr = unparse(node.left, { ...opts, inline: true, expressionalContext: true })
             const rightStr = unparse(node.right, { ...opts, inline: true, expressionalContext: true })
-            const opPrecedence = expressionOperatorMap.get(node.operator.node)?.precedence ?? 0
+            const opPrecedence = expressionOperatorMap[node.operator.node].precedence
             let leftWithParens = leftStr
             if (node.left.type === 'binaryOperator') {
-                const leftOpPrecedence = expressionOperatorMap.get(node.left.operator.node)?.precedence ?? 0
+                const leftOpPrecedence = expressionOperatorMap[node.left.operator.node].precedence
                 if (leftOpPrecedence < opPrecedence) {
                     leftWithParens = `(${leftStr})`
                 }
@@ -926,7 +926,7 @@ export function unparse(node: UrbanStatsASTStatement | UrbanStatsASTExpression, 
             }
             let rightWithParens = rightStr
             if (node.right.type === 'binaryOperator') {
-                const rightOpPrecedence = expressionOperatorMap.get(node.right.operator.node)?.precedence ?? 0
+                const rightOpPrecedence = expressionOperatorMap[node.right.operator.node].precedence
                 if (rightOpPrecedence <= opPrecedence) {
                     rightWithParens = `(${rightStr})`
                 }

--- a/react/src/uss-documentation.tsx
+++ b/react/src/uss-documentation.tsx
@@ -517,18 +517,16 @@ function OperatorTable(): ReactNode {
     const colors = useColors()
 
     const headers = ['Operator', 'Type', 'Precedence', 'Description', 'Example']
-    const cells = Array.from(expressionOperatorMap.entries()).map(([operator, info]) => ({
+    const cells = Object.entries(expressionOperatorMap).map(([operator, info]) => ({
         row: [
             <code key="operator" style={{ backgroundColor: colors.slightlyDifferentBackground, padding: '2px 4px', borderRadius: '3px', fontFamily: '\'Courier New\', monospace', fontSize: '13px' }}>
                 {operator}
             </code>,
-            info.unary && info.binary
+            info.type === 'unary+binary'
                 ? 'Unary/Binary'
-                : info.unary
+                : info.type === 'unary'
                     ? 'Unary'
-                    : info.binary
-                        ? 'Binary'
-                        : 'Unknown',
+                    : 'Binary',
             info.precedence,
             info.description,
             info.examples.map((example, exampleIndex) => (


### PR DESCRIPTION
## Summary
- Replace `expressionOperatorMap`'s `Map<Symbol, Operator>` with a plain object (`Record<UnaryOperatorSymbol | BinaryOperatorSymbol, Operator>`), letting `satisfies` verify every operator symbol is covered at compile time instead of relying on runtime `assert`s at lookup sites.
- Give `Operator` a `type` discriminant (`'unary' | 'binary' | 'unary+binary'`) plus a new `isAssociative` flag on binary operators, replacing the old optional `unary`/`binary` fields.
- Update all lookup sites (`interpreter.ts`, `lexer.ts`, `parser.ts`, `uss-documentation.tsx`) to use object indexing/`Object.keys`/`Object.entries` instead of `Map` methods, and to branch on `type` instead of checking field presence.

## Test plan
- [ ] `npm run typecheck` / `npm test` in `react/`