### PR TITLE
Share temperature/precipitation unit conversion with the cell renderer

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react'
 
 import { formatToSignificantFigures, separateNumber } from '../utils/text'
-import { UnitType } from '../utils/unit'
+import { convertPrecipitation, convertTemperature, UnitType } from '../utils/unit'
 
 import { ElectionResult, GenericPartyChange, GenericPartyPercentage, LeftMargin } from './display-stats'
 
@@ -295,15 +295,10 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'temperature':
             return {
                 renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-                    let unit = <span>&deg;F</span>
-                    let adjustedValue = value
-                    if (temperatureUnit === 'celsius') {
-                        unit = <span>&deg;C</span>
-                        adjustedValue = (value - 32) * (5 / 9)
-                    }
+                    const { value: adjustedValue, unit } = convertTemperature(value, temperatureUnit ?? 'fahrenheit')
                     return {
                         value: <span>{adjustedValue.toFixed(1)}</span>,
-                        unit,
+                        unit: <span>{unit}</span>,
                     }
                 },
                 renderInequality,
@@ -329,12 +324,7 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'distancePerYear':
             return {
                 renderValue: (value: number, useImperial?: boolean) => {
-                    let adjustedValue = value * 100
-                    let unit = 'cm'
-                    if (useImperial) {
-                        unit = 'in'
-                        adjustedValue /= 2.54
-                    }
+                    const { value: adjustedValue, unit } = convertPrecipitation(value, useImperial ?? false)
                     return {
                         value: <span>{adjustedValue.toFixed(1)}</span>,
                         unit: (

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -44,6 +44,28 @@ function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
 }
 
+function fahrenheitToCelsius(value: number): number {
+    return (value - 32) * (5 / 9)
+}
+
+function metersToCentimetersOrInches(value: number, useImperial: boolean): number {
+    const centimeters = value * 100
+    return useImperial ? centimeters / 2.54 : centimeters
+}
+
+export function convertTemperature(value: number, temperatureUnit: string): { value: number, unit: string } {
+    return temperatureUnit === 'celsius'
+        ? { value: fahrenheitToCelsius(value), unit: '°C' }
+        : { value, unit: '°F' }
+}
+
+export function convertPrecipitation(value: number, useImperial: boolean): { value: number, unit: string } {
+    return {
+        value: metersToCentimetersOrInches(value, useImperial),
+        unit: useImperial ? 'in' : 'cm',
+    }
+}
+
 export function getUnitName(unitType: UnitType): string {
     switch (unitType) {
         case 'percentage':


### PR DESCRIPTION
## Summary
- Extracts `convertTemperature`/`convertPrecipitation` helpers into `utils/unit.ts` (built on private `fahrenheitToCelsius`/`metersToCentimetersOrInches`)
- Updates the main table's cell renderer (`unit-display.tsx`, `getUnitDisplay`'s `'temperature'`/`'distancePerYear'` cases) to use them instead of duplicating the conversion formulas inline

Behavior-preserving refactor: the only visible diff is that the temperature unit is now rendered as the unicode `°F`/`°C` strings instead of the `&deg;F`/`&deg;C` HTML entities — same glyph on screen.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint --ignore-pattern=src/data --max-warnings=0` clean
- [x] Diffed output against known-good version to confirm byte-for-byte match with intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)