### PR TITLE
Use the shared PlotSpec type in comparison-panel.tsx

### DIFF
--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -32,7 +32,7 @@ import { PlotProps, pullRelevantPlotProps } from './plots'
 import { createScreenshot, ScreencapElements, useScreenshotMode } from './screenshot'
 import { computeComparisonWidthColumns, computeMaxColumns, MaybeScroll } from './scrollable'
 import { SearchBox } from './search'
-import { TableContents, CellSpec } from './supertable'
+import { TableContents, CellSpec, PlotSpec } from './supertable'
 import { ColumnIdentifier } from './table'
 
 export function ComparisonPanel(props: {
@@ -280,7 +280,7 @@ export function ComparisonPanel(props: {
 
     const rowSpecsByStatTransposed = rowSpecsByStat.length === 0 ? [] : rowSpecsByStat[0].map((_, statIndex) => rowSpecsByStat.map(rowSpecs => rowSpecs[statIndex]))
 
-    const plotSpecs: ({ statDescription: string, plotProps: PlotProps[] } | undefined)[] = Array.from({ length: dataByStatArticle.length }).map((_, statIndex) =>
+    const plotSpecs: (PlotSpec | undefined)[] = Array.from({ length: dataByStatArticle.length }).map((_, statIndex) =>
         expandedByStatIndex[statIndex]
             ? {
                     statDescription: dataByStatArticle[statIndex][0].renderedStatname,


### PR DESCRIPTION
## Summary
- `article-panel.tsx` already imports and uses `supertable.tsx`'s exported `PlotSpec` type for its `plotSpecs` array. `comparison-panel.tsx` had its own inline duplicate of the identical shape (`{ statDescription: string, plotProps: PlotProps[] }`). Converges `comparison-panel.tsx` onto the shared type instead of maintaining two copies.
- No behavior change — purely a type-level consolidation, not compiler-required (structural typing means the inline type already worked), just avoids drift between the two call sites.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint --ignore-pattern=src/data --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)