### PR TITLE
Extract Histogram's settings bar into a shared PlotSettingsBar component

### DIFF
--- a/react/src/components/plots-general.tsx
+++ b/react/src/components/plots-general.tsx
@@ -1,6 +1,7 @@
 import * as Plot from '@observablehq/plot'
-import React, { ReactElement, ReactNode, useCallback, useEffect, useRef } from 'react'
+import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react'
 
+import { Navigator } from '../navigation/Navigator'
 import { Colors } from '../page_template/color-themes'
 import { useColors } from '../page_template/colors'
 import { useUniverse } from '../universe'
@@ -9,6 +10,7 @@ import { useTranspose } from '../utils/transpose'
 import { zIndex } from '../utils/zIndex'
 
 import { createScreenshot, useScreenshotMode } from './screenshot'
+import { SearchBox } from './search'
 
 import './plots.css'
 
@@ -56,7 +58,7 @@ export function transposeAwareTip<T>(
 }
 
 // the screenshot-download icon shared by every plot type's settings bar
-export function PlotDownloadButton(props: { makePlot: () => HTMLElement, shortnames: string[], filenameSuffix: string }): ReactNode {
+function PlotDownloadButton(props: { makePlot: () => HTMLElement, shortnames: string[], filenameSuffix: string }): ReactNode {
     const universe = useUniverse()
     const colors = useColors()
     return (
@@ -83,6 +85,90 @@ export function PlotDownloadButton(props: { makePlot: () => HTMLElement, shortna
             height="20"
             style={{ cursor: 'pointer' }}
         />
+    )
+}
+
+function deduplicate(arr: string[]): string[] {
+    return Array.from(new Set(arr))
+}
+
+export const transposeSettingsHeight = 30.5
+
+// the settings bar shared by every plot type: download button, "add region" search popup, and
+// (when relevant) plot-type-specific controls (e.g. histogram's line/bar select)
+export function PlotSettingsBar(props: {
+    makePlot: () => HTMLElement
+    shortnames: string[]
+    longnames: string[]
+    sharedTypeOfAllArticles?: string
+    filenameSuffix: string
+    children?: ReactNode
+}): ReactNode {
+    const colors = useColors()
+    const universe = useUniverse()
+    const transpose = useTranspose()
+    const navContext = useContext(Navigator.Context)
+    const [showSearchBox, setShowSearchBox] = useState(false)
+
+    return (
+        <div
+            className="serif"
+            style={{
+                backgroundColor: transpose ? undefined : colors.background,
+                padding: transpose ? undefined : '0.5em',
+                border: transpose ? undefined : `1px solid ${colors.textMain}`,
+                display: 'flex',
+                gap: '0.5em',
+                height: transpose ? `${transposeSettingsHeight}px` : undefined,
+                alignItems: transpose ? 'center' : undefined,
+                justifyContent: transpose ? 'center' : undefined,
+                position: 'relative',
+            }}
+        >
+            <PlotDownloadButton makePlot={props.makePlot} shortnames={props.shortnames} filenameSuffix={props.filenameSuffix} />
+            <div style={{ position: 'relative' }}>
+                <img
+                    src="/add.png"
+                    onClick={() => { setShowSearchBox(!showSearchBox) }}
+                    width="20"
+                    height="20"
+                    style={{ cursor: 'pointer' }}
+                />
+                {showSearchBox && (
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: '25px',
+                            left: '0px',
+                            backgroundColor: colors.background,
+                            border: `1px solid ${colors.textMain}`,
+                            borderRadius: '4px',
+                            padding: '0.5em',
+                            zIndex: zIndex.plotSettings,
+                            minWidth: '200px',
+                        }}
+                    >
+                        <SearchBox
+                            style={{ width: '100%' }}
+                            placeholder="Add region..."
+                            autoFocus={true}
+                            prioritizeArticleType={props.sharedTypeOfAllArticles}
+                            onChange={() => {
+                                setShowSearchBox(false)
+                            }}
+                            articleLink={(regionName) => {
+                                return navContext.link({
+                                    kind: 'comparison',
+                                    universe,
+                                    longnames: [...deduplicate(props.longnames), regionName],
+                                }, { scroll: { kind: 'none' } })
+                            }}
+                        />
+                    </div>
+                )}
+            </div>
+            {props.children}
+        </div>
     )
 }
 

--- a/react/src/components/plots-histogram.tsx
+++ b/react/src/components/plots-histogram.tsx
@@ -1,18 +1,14 @@
 import * as Plot from '@observablehq/plot'
-import React, { ReactElement, ReactNode, useCallback, useContext, useState } from 'react'
+import React, { ReactElement, ReactNode, useCallback } from 'react'
 
 // imort Observable plot
-import { Navigator } from '../navigation/Navigator'
 import { Colors } from '../page_template/color-themes'
 import { useColors } from '../page_template/colors'
 import { HistogramType, useSetting } from '../page_template/settings'
-import { useUniverse } from '../universe'
 import { IHistogram } from '../utils/protos'
 import { useTranspose } from '../utils/transpose'
-import { zIndex } from '../utils/zIndex'
 
-import { axisAndGrid, computeDashPatterns, manualLegend, multiSeriesTipTitle, PlotComponent, PlotDownloadButton, transposeAwareTip } from './plots-general'
-import { SearchBox } from './search'
+import { axisAndGrid, computeDashPatterns, manualLegend, multiSeriesTipTitle, PlotComponent, PlotSettingsBar, transposeAwareTip } from './plots-general'
 import { CheckboxSetting } from './sidebar'
 
 const yPad = 0.025
@@ -38,7 +34,7 @@ function processHistogramType(histogramType: HistogramType, histograms: Histogra
 }
 
 export function Histogram(props: { histograms: HistogramProps[], statDescription: string, sharedTypeOfAllArticles?: string, dashOrder?: string[] }): ReactNode {
-    const [histogramTypeRaw] = useSetting('histogram_type')
+    const [histogramTypeRaw, setHistogramType] = useSetting('histogram_type')
     const histogramType = processHistogramType(histogramTypeRaw, props.histograms)
     const [useImperial] = useSetting('use_imperial')
     const [relative] = useSetting('histogram_relative')
@@ -49,11 +45,30 @@ export function Histogram(props: { histograms: HistogramProps[], statDescription
             throw new Error('histograms have different binMin or binSize')
         }
     }
-    const settingsElement = (makePlot: () => HTMLElement): ReactElement => (
-        <HistogramSettings makePlot={makePlot} shortnames={props.histograms.map(h => h.shortname)} longnames={props.histograms.map(h => h.longname)} sharedTypeOfAllArticles={props.sharedTypeOfAllArticles} />
-    )
-
     const systemColors = useColors()
+    const isTransposed = useTranspose()
+    const settingsElement = (makePlot: () => HTMLElement): ReactElement => (
+        <PlotSettingsBar
+            makePlot={makePlot}
+            shortnames={props.histograms.map(h => h.shortname)}
+            longnames={props.histograms.map(h => h.longname)}
+            sharedTypeOfAllArticles={props.sharedTypeOfAllArticles}
+            filenameSuffix="histogram"
+        >
+            <select
+                value={histogramTypeRaw}
+                style={{ backgroundColor: systemColors.background, color: systemColors.textMain }}
+                onChange={(e) => { setHistogramType(e.target.value as HistogramType) }}
+                className="serif"
+                data-test-id="histogram_type"
+            >
+                <option value="Line">Line</option>
+                <option value="Line (cumulative)">Line (cumulative)</option>
+                <option value="Bar">Bar</option>
+            </select>
+            <CheckboxSetting name={isTransposed ? 'Relative' : 'Relative Histograms'} settingKey="histogram_relative" testId="histogram_relative" />
+        </PlotSettingsBar>
+    )
 
     const plotSpec = useCallback(
         (transpose: boolean) => {
@@ -84,99 +99,6 @@ export function Histogram(props: { histograms: HistogramProps[], statDescription
             settingsElement={settingsElement}
         />
     )
-}
-
-export const transposeSettingsHeight = 30.5
-
-function HistogramSettings(props: {
-    shortnames: string[]
-    longnames: string[]
-    makePlot: () => HTMLElement
-    sharedTypeOfAllArticles?: string
-}): ReactNode {
-    const universe = useUniverse()
-    const [histogramType, setHistogramType] = useSetting('histogram_type')
-    const colors = useColors()
-    const transpose = useTranspose()
-    const navContext = useContext(Navigator.Context)
-    const [showSearchBox, setShowSearchBox] = useState(false)
-
-    // dropdown for histogram type
-    return (
-        <div
-            className="serif"
-            style={{
-                backgroundColor: transpose ? undefined : colors.background,
-                padding: transpose ? undefined : '0.5em',
-                border: transpose ? undefined : `1px solid ${colors.textMain}`,
-                display: 'flex',
-                gap: '0.5em',
-                height: transpose ? `${transposeSettingsHeight}px` : undefined,
-                alignItems: transpose ? 'center' : undefined,
-                justifyContent: transpose ? 'center' : undefined,
-                position: 'relative',
-            }}
-        >
-            <PlotDownloadButton makePlot={props.makePlot} shortnames={props.shortnames} filenameSuffix="histogram" />
-            <div style={{ position: 'relative' }}>
-                <img
-                    src="/add.png"
-                    onClick={() => { setShowSearchBox(!showSearchBox) }}
-                    width="20"
-                    height="20"
-                    style={{ cursor: 'pointer' }}
-                />
-                {showSearchBox && (
-                    <div
-                        style={{
-                            position: 'absolute',
-                            top: '25px',
-                            left: '0px',
-                            backgroundColor: colors.background,
-                            border: `1px solid ${colors.textMain}`,
-                            borderRadius: '4px',
-                            padding: '0.5em',
-                            zIndex: zIndex.plotSettings,
-                            minWidth: '200px',
-                        }}
-                    >
-                        <SearchBox
-                            style={{ width: '100%' }}
-                            placeholder="Add region..."
-                            autoFocus={true}
-                            prioritizeArticleType={props.sharedTypeOfAllArticles}
-                            onChange={() => {
-                                setShowSearchBox(false)
-                            }}
-                            articleLink={(regionName) => {
-                                return navContext.link({
-                                    kind: 'comparison',
-                                    universe,
-                                    longnames: [...deduplicate(props.longnames), regionName],
-                                }, { scroll: { kind: 'none' } })
-                            }}
-                        />
-                    </div>
-                )}
-            </div>
-            <select
-                value={histogramType}
-                style={{ backgroundColor: colors.background, color: colors.textMain }}
-                onChange={(e) => { setHistogramType(e.target.value as HistogramType) }}
-                className="serif"
-                data-test-id="histogram_type"
-            >
-                <option value="Line">Line</option>
-                <option value="Line (cumulative)">Line (cumulative)</option>
-                <option value="Bar">Bar</option>
-            </select>
-            <CheckboxSetting name={transpose ? 'Relative' : 'Relative Histograms'} settingKey="histogram_relative" testId="histogram_relative" />
-        </div>
-    )
-}
-
-function deduplicate(arr: string[]): string[] {
-    return Array.from(new Set(arr))
 }
 
 function histogramBounds(histograms: HistogramProps[]): [number, number] {

--- a/react/src/components/plots.tsx
+++ b/react/src/components/plots.tsx
@@ -4,7 +4,8 @@ import { statParents, Year } from '../page_template/statistic-tree'
 import { assert } from '../utils/defensive'
 
 import { ArticleRow, ExtraStat } from './load-article'
-import { Histogram, transposeSettingsHeight } from './plots-histogram'
+import { transposeSettingsHeight } from './plots-general'
+import { Histogram } from './plots-histogram'
 import { TimeSeriesPlot } from './plots-timeseries'
 
 export interface PlotProps {


### PR DESCRIPTION
## Summary
- Moves `Histogram`'s settings bar (download button, "add region" search popup, transpose-aware container styling) out of the histogram-specific `HistogramSettings` into a new `PlotSettingsBar` component in `plots-general.tsx`, alongside the other shared plot infrastructure (`axisAndGrid`, `manualLegend`, etc).
- Histogram-specific controls (the Line/Bar type dropdown, the "Relative" checkbox) are now passed in as `children`.
- Behavior-preserving: same DOM structure, same element order, same styling logic. Only reachable consumer today is `Histogram`; this sets up `PlotSettingsBar` to be reused by upcoming plot types without duplicating the settings-bar UI.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint --ignore-pattern=src/data --max-warnings=0` clean
- [x] `knip` reports no new unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)