### PR TITLE
Fix toPrecision scientific-notation overflow in unit-display number formatting

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -119,13 +119,19 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'population':
             return {
                 renderValue: (value: number) => {
-                    if (value > 1e9) {
+                    /*
+                     * Boundaries are at 999.5 * scale rather than 1000 * scale so that a value that
+                     * rounds up to 4 significant digits (e.g. 999999 → 1000k) is promoted to the next
+                     * tier instead. This keeps (value / divisor).toPrecision(3) below 1000, which
+                     * avoids toPrecision returning scientific notation (e.g. "1.00e+3").
+                     */
+                    if (value > 999.5e6) {
                         return {
                             value: <span>{(value / 1e9).toPrecision(3)}</span>,
                             unit: <span>B</span>,
                         }
                     }
-                    if (value > 1e6) {
+                    if (value > 999.5e3) {
                         return {
                             value: <span>{(value / 1e6).toPrecision(3)}</span>,
                             unit: <span>m</span>,
@@ -365,7 +371,13 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'usd':
             return {
                 renderValue: (value: number) => {
-                    if (value > 1e9) {
+                    /*
+                     * Boundaries are at 999.5 * scale rather than 1000 * scale so that a value that
+                     * rounds up to 4 significant digits (e.g. 999999 → 1000k) is promoted to the next
+                     * tier instead. This keeps (value / divisor).toPrecision(3) below 1000, which
+                     * avoids toPrecision returning scientific notation (e.g. "1.00e+3").
+                     */
+                    if (value > 999.5e6) {
                         return {
                             value: (
                                 <span>
@@ -376,7 +388,7 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                             unit: <span>B</span>,
                         }
                     }
-                    if (value > 1e6) {
+                    if (value > 999.5e3) {
                         return {
                             value: (
                                 <span>

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -125,13 +125,13 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                      * tier instead. This keeps (value / divisor).toPrecision(3) below 1000, which
                      * avoids toPrecision returning scientific notation (e.g. "1.00e+3").
                      */
-                    if (value > 999.5e6) {
+                    if (value >= 999.5e6) {
                         return {
                             value: <span>{(value / 1e9).toPrecision(3)}</span>,
                             unit: <span>B</span>,
                         }
                     }
-                    if (value > 999.5e3) {
+                    if (value >= 999.5e3) {
                         return {
                             value: <span>{(value / 1e6).toPrecision(3)}</span>,
                             unit: <span>m</span>,
@@ -377,7 +377,7 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                      * tier instead. This keeps (value / divisor).toPrecision(3) below 1000, which
                      * avoids toPrecision returning scientific notation (e.g. "1.00e+3").
                      */
-                    if (value > 999.5e6) {
+                    if (value >= 999.5e6) {
                         return {
                             value: (
                                 <span>
@@ -388,7 +388,7 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                             unit: <span>B</span>,
                         }
                     }
-                    if (value > 999.5e3) {
+                    if (value >= 999.5e3) {
                         return {
                             value: (
                                 <span>

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -1,0 +1,48 @@
+import './util/localStorage'
+
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { getUnitDisplay } from '../src/components/unit-display'
+import { UnitType } from '../src/utils/unit'
+
+// Flatten a React element tree into its text content.
+function textOf(node: unknown): string {
+    if (node === null || node === undefined || typeof node === 'boolean') return ''
+    if (typeof node === 'string' || typeof node === 'number') return String(node)
+    if (Array.isArray(node)) return node.map(textOf).join('')
+    // React element
+    return textOf((node as { props?: { children?: unknown } }).props?.children)
+}
+
+function renderValue(unitType: UnitType, value: number): string {
+    const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value)
+    return `${textOf(valueEl)}${textOf(unitEl)}`.trim()
+}
+
+// Regression tests for toPrecision(3) emitting scientific notation at tier boundaries.
+// Before the fix, values in [999.5eN, 1e(N+3)) rounded to 4 significant digits and
+// rendered as e.g. "1.00e+3k" instead of being promoted to the next tier.
+for (const [value, expected] of [
+    [12345, '12.3k'],
+    [999499, '999k'],
+    [999999, '1.00m'],
+    [999499999, '999m'],
+    [999999999, '1.00B'],
+] as const) {
+    void test(`population renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue('population', value), expected)
+    })
+}
+
+for (const [value, expected] of [
+    [12345, '$12.3k'],
+    [999499, '$999k'],
+    [999999, '$1.00m'],
+    [999499999, '$999m'],
+    [999999999, '$1.00B'],
+] as const) {
+    void test(`usd renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue('usd', value), expected)
+    })
+}

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -26,8 +26,10 @@ function renderValue(unitType: UnitType, value: number): string {
 for (const [value, expected] of [
     [12345, '12.3k'],
     [999499, '999k'],
+    [999500, '1.00m'],
     [999999, '1.00m'],
     [999499999, '999m'],
+    [999500000, '1.00B'],
     [999999999, '1.00B'],
 ] as const) {
     void test(`population renders ${value} as ${expected}`, () => {
@@ -38,8 +40,10 @@ for (const [value, expected] of [
 for (const [value, expected] of [
     [12345, '$12.3k'],
     [999499, '$999k'],
+    [999500, '$1.00m'],
     [999999, '$1.00m'],
     [999499999, '$999m'],
+    [999500000, '$1.00B'],
     [999999999, '$1.00B'],
 ] as const) {
     void test(`usd renders ${value} as ${expected}`, () => {


### PR DESCRIPTION
## Problem

The `population` and `usd` value renderers in `unit-display.tsx` divide by a fixed `1eN` and format with `toPrecision(3)`. A value just below a tier threshold rounds up to 4 significant digits, so `toPrecision` switches to scientific notation:

- `formatNumber(999999)` → `(999999 / 1e3).toPrecision(3)` → `"1.00e+3"` → renders **`1.00e+3k`** instead of `1m`.

This affects publicly displayed stat values in the ranges `[999500, 999999]` (→ `k`), `[999.5e6, 1e9)` (→ `m`), etc., for both population and USD (e.g. GDP) stats.

This is the same class of bug fixed for map labels in #2057 (review [discussion](https://github.com/kavigupta/urbanstats/pull/2057#discussion_r3565857857)); this PR applies the equivalent fix to the article-page renderers.

## Fix

Move the tier boundaries from `1eN` to `999.5 * scale`, so a value that would round to 4 significant digits is promoted to the next tier, keeping `(value / divisor).toPrecision(3)` below 1000.

## Tests

Adds `unit/unit-display.test.ts` covering the boundary cases for both the `population` and `usd` renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)