### PR TITLE
Extract resolveStatYears from pullRelevantPlotProps

### DIFF
--- a/react/src/components/plots.tsx
+++ b/react/src/components/plots.tsx
@@ -83,50 +83,40 @@ export function extraHeaderSpaceForVertical(spec: PlotProps): number {
     return 0
 }
 
+// which rows to plot for the stat at statIndex: one per year, choosing the best source per year
+function resolveStatYears(rows: ArticleRow[], statIndex: number): { idx: number, year: Year }[] {
+    const sPs = rows.map(row => statParents.get(row.statpath)!).map((sP, i) => ({ sP, i }))
+    const byYear = new Map<Year, number[]>()
+    sPs.filter(({ sP, i }) => sP.group.id === sPs[statIndex].sP.group.id && rows[i].kind === 'statistic' && rows[i].extraStats.length > 0)
+        .forEach(({ sP: { year }, i }) => {
+            assert(year !== null, 'Year should not be null for plot data')
+            byYear.set(year, [...(byYear.get(year) ?? []), i])
+        })
+    const chosen = Array.from(byYear.entries()).map(([year, indices]) => {
+        if (indices.length === 1) {
+            return { idx: indices[0], year }
+        }
+        const sources = indices.map(i => sPs[i].sP.source)
+        const exactMatch = sources.findIndex(source => JSON.stringify(source) === JSON.stringify(sPs[statIndex].sP.source))
+        const nullMatch = sources.findIndex(source => source === null)
+        return { idx: indices[exactMatch !== -1 ? exactMatch : nullMatch !== -1 ? nullMatch : 0], year }
+    })
+    if (chosen.length > 1) {
+        assert(chosen.length === new Set(chosen.map(c => c.year)).size, 'All statpaths for plot data should have unique years')
+    }
+    return chosen
+}
+
 export function pullRelevantPlotProps(rows: ArticleRow[], statIndex: number, color: string, shortname: string, longname: string, sharedTypeOfAllArticles: string | undefined): PlotProps[] {
     if (rows[statIndex].kind !== 'statistic' || rows[statIndex].extraStats.length === 0) {
         return []
     }
-    const sPs = rows.map(row => statParents.get(row.statpath)!).map((sP, i) => ({ sP, i }))
-    const byYear = new Map<Year, number[]>()
-    sPs.filter((
-        { sP, i }) => sP.group.id === sPs[statIndex].sP.group.id && rows[i].kind === 'statistic' && rows[i].extraStats.length > 0,
-    ).forEach(({ sP: { year }, i }) => {
-        assert(year !== null, 'Year should not be null for plot data')
-        byYear.set(year, [...(byYear.get(year) ?? []), i])
-    })
-    const bestSourceEach = Array.from(byYear.entries()).map(([, indices]) => {
-        if (indices.length === 1) {
-            return indices[0]
-        }
-        const sources = indices.map(i => sPs[i].sP.source)
-        const exactMatch = sources.findIndex(source => JSON.stringify(source) === JSON.stringify(sPs[statIndex].sP.source))
-        if (exactMatch !== -1) {
-            return indices[exactMatch]
-        }
-        const nullMatch = sources.findIndex(source => source === null)
-        if (nullMatch !== -1) {
-            return indices[nullMatch]
-        }
-        return indices[0]
-    })
-    const statpaths = bestSourceEach.map(i => sPs[i])
-    const overOne = statpaths.length > 1
-    if (overOne) {
-        statpaths.forEach(({ sP: { year } }) => {
-            assert(year !== null, 'Year should not be null for plot data')
-        })
-        assert(statpaths.length === new Set(statpaths.map(({ sP: { year } }) => year)).size, 'All statpaths for plot data should have unique years')
-    }
-    return statpaths.map(({ i: idx, sP: { year } }) => {
-        assert(year !== null, 'unreachable, we checked this already')
-        return {
-            ...rows[idx],
-            color,
-            shortname,
-            longname,
-            sharedTypeOfAllArticles,
-            subseriesName: year.toString(),
-        } satisfies PlotProps
-    })
+    return resolveStatYears(rows, statIndex).map(({ idx, year }) => ({
+        ...rows[idx],
+        color,
+        shortname,
+        longname,
+        sharedTypeOfAllArticles,
+        subseriesName: year.toString(),
+    } satisfies PlotProps))
 }


### PR DESCRIPTION
## Summary
Pure structural refactor of `pullRelevantPlotProps`: the per-year / best-source resolution (the `byYear` grouping + source-picking + uniqueness assert) moves into a named `resolveStatYears` helper, leaving `pullRelevantPlotProps` a two-line map. Behavior-preserving.

Groundwork for the weather-plots work, which needs the same year resolution independent of the (separate) pairing logic -- landing it on its own keeps that later PR focused.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint . --max-warnings=0` clean
- [x] `knip --include exports` clean
- [x] Unit suite passing
- [x] Live: multi-year density histogram (Pasadena 2020/2010/2000) renders the same three year-series

🤖 Generated with [Claude Code](https://claude.com/claude-code)