### PR TITLE
Extract seriesOfType from RenderedPlot's per-type dispatch

### DIFF
--- a/react/src/components/plots.tsx
+++ b/react/src/components/plots.tsx
@@ -17,6 +17,14 @@ export interface PlotProps {
     subseriesName: string
 }
 
+// for each plot prop carrying an extra stat of `type`, the series' shared fields plus that stat
+function seriesOfType<T extends ExtraStat['type']>(props: PlotProps[], type: T): { shortname: string, longname: string, color: string, subseriesName: string, stat: Extract<ExtraStat, { type: T }> }[] {
+    return props.flatMap((p) => {
+        const stat = p.extraStats.find(es => es.type === type)
+        return stat === undefined ? [] : [{ shortname: p.shortname, longname: p.longname, color: p.color, subseriesName: p.subseriesName, stat: stat as Extract<ExtraStat, { type: T }> }]
+    })
+}
+
 export function RenderedPlot({ statDescription, plotProps }: { statDescription: string, plotProps: PlotProps[] }): ReactNode {
     const type = plotProps.flatMap(p => p.extraStats.map(es => es.type)).reduce<undefined | 'histogram' | 'time_series'>((result, t) => {
         if (result === undefined) {
@@ -32,43 +40,14 @@ export function RenderedPlot({ statDescription, plotProps }: { statDescription: 
             return (
                 <Histogram
                     statDescription={statDescription}
-                    histograms={plotProps.flatMap(
-                        (props) => {
-                            const extraStat = props.extraStats.find(es => es.type === 'histogram')
-                            if (extraStat === undefined) {
-                                return []
-                            }
-                            return [
-                                {
-                                    shortname: props.shortname,
-                                    longname: props.longname,
-                                    histogram: extraStat,
-                                    color: props.color,
-                                    universeTotal: extraStat.universeTotal,
-                                    subseriesName: props.subseriesName,
-                                },
-                            ]
-                        },
-                    )}
+                    histograms={seriesOfType(plotProps, 'histogram').map(({ stat, ...series }) => ({ ...series, histogram: stat, universeTotal: stat.universeTotal }))}
                     sharedTypeOfAllArticles={plotProps[0]?.sharedTypeOfAllArticles}
                 />
             )
         case 'time_series':
             return (
                 <TimeSeriesPlot
-                    stats={plotProps.map(
-                        (props) => {
-                            const extraStat = props.extraStats.find(es => es.type === 'time_series')
-                            if (extraStat === undefined) {
-                                throw new Error('expected time_series')
-                            }
-                            return {
-                                shortname: props.shortname,
-                                stat: extraStat,
-                                color: props.color,
-                            }
-                        },
-                    )}
+                    stats={seriesOfType(plotProps, 'time_series').map(({ shortname, color, stat }) => ({ shortname, color, stat }))}
                 />
             )
         case undefined:


### PR DESCRIPTION
## Summary
Collapses `RenderedPlot`'s repeated `flatMap`/`find`/guard/shape pattern into one `seriesOfType(props, type)` helper that returns each series' shared fields plus its typed stat.

- **histogram** case: straight extraction, behavior-identical.
- **time_series** case: switches from throw-if-missing to `seriesOfType`'s drop-if-missing. This path is unreachable -- no `time_series` extra stat is constructed anywhere in `src` (the type is defined and consumed, never produced) -- so the change is unobservable.

Groundwork for the weather-plots work, which uses `seriesOfType` across its four plot types; landing the helper here keeps that PR focused.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint . --max-warnings=0` clean
- [x] `knip --include exports` clean
- [x] Unit suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)