### PR TITLE
Attempt to map export flakiness

### DIFF
--- a/react/eslint.config.mjs
+++ b/react/eslint.config.mjs
@@ -95,6 +95,13 @@ export default tseslint.config(
             'eqeqeq': 'error',
             'guard-for-in': 'error',
             'object-shorthand': 'error',
+            'no-restricted-imports': ['error', {
+                paths: [{
+                    name: 'react-map-gl/maplibre',
+                    importNames: ['Layer'],
+                    message: 'Use ScreenshotAwareLayer from components/ScreenshotAwareLayer instead, so screenshots wait for the layer to actually be installed.',
+                }],
+            }],
             'no-restricted-syntax': [
                 'error',
                 // Good tool for writing these https://typescript-eslint.io/play/
@@ -139,6 +146,13 @@ export default tseslint.config(
                 'CallExpression[callee.name=useRef][typeArguments.params.0.typeName.name=MapRef]', // Use state instead to avoid races
                 // Should use the zIndex manifest for zIndexes
                 'Property[key.name=zIndex]:not([value.object.name=zIndex])',
+                {
+                    // Remounting the wrapper loses its screenshot subscription: the render phase snapshots
+                    // subscribers up front, so a remounted one stalls it or is never waited on. Change the
+                    // `id` instead -- the <Layer> underneath is already keyed on it.
+                    selector: 'JSXOpeningElement[name.name=ScreenshotAwareLayer] > JSXAttribute[name.name=key]',
+                    message: 'Do not pass `key` to ScreenshotAwareLayer, it must not remount. Change its `id` instead.',
+                },
             ],
             'react/prop-types': 'off',
             'no-shadow': 'error',

--- a/react/src/components/ScreenshotAwareLayer.tsx
+++ b/react/src/components/ScreenshotAwareLayer.tsx
@@ -1,0 +1,48 @@
+import React, { ReactNode, useEffect } from 'react'
+// eslint-disable-next-line no-restricted-imports -- ScreenshotAwareLayer is the wrapper everyone else must use
+import { Layer, LayerProps, useMap } from 'react-map-gl/maplibre'
+
+import { assert } from '../utils/defensive'
+
+import { useScreenshotCallback } from './screenshot'
+
+/*
+ * Use instead of react-map-gl's <Layer> so screenshots wait for the layer.
+ * This solves the problem of the layer not being present even after the `render` screenshot phase.
+ * If this happens, then map.loaded() doesn't wait for the layer.
+ *
+ * This component should not be used under a screenshot-mode dependent `key`,
+ * as this causes it to not be part of the screenshot render process.
+ */
+export function ScreenshotAwareLayer(props: LayerProps & { id: string }): ReactNode {
+    const { current: map } = useMap()
+    assert(map !== undefined, 'Must be used in Map context')
+
+    const screenshotCallback = useScreenshotCallback('render')
+
+    useEffect(() => {
+        if (screenshotCallback === undefined) {
+            return undefined
+        }
+        let cancelled: boolean = false
+        void (async () => {
+            while (map.getLayer(props.id) === undefined) {
+                await new Promise(resolve => requestAnimationFrame(resolve))
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Linter is too dumb
+                if (cancelled) {
+                    return // Try again in the next effect
+                }
+                if (map._removed) {
+                    break // Nothing will add the layer now, don't stall the screenshot
+                }
+            }
+            screenshotCallback()
+        })()
+        return () => {
+            cancelled = true
+        }
+    }, [screenshotCallback, map, props.id])
+
+    // react-map-gl memoizes the layer id at mount, so a changed id only takes effect on remount.
+    return <Layer key={props.id} {...props} />
+}

--- a/react/src/components/map-common.tsx
+++ b/react/src/components/map-common.tsx
@@ -1,7 +1,7 @@
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import React, { ReactNode, useContext, useEffect, useId, useMemo } from 'react'
-import { Layer, Map, MapProps, MapRef, Source, useControl, useMap } from 'react-map-gl/maplibre'
+import { Map, MapProps, MapRef, Source, useControl, useMap } from 'react-map-gl/maplibre'
 
 import { boundingBox, extendBoxes, geometry } from '../map-partition'
 import { Basemap } from '../mapper/settings/utils'
@@ -17,6 +17,7 @@ import { loadFeatureFromPossibleSymlink } from '../utils/symlinks'
 import { NormalizeProto } from '../utils/types'
 import { useOrderedResolve } from '../utils/useOrderedResolve'
 
+import { ScreenshotAwareLayer } from './ScreenshotAwareLayer'
 import { keptByNoBasemap } from './map-common-utils'
 import { defaultMapBorderRadius, mapBorderWidth, useScreenshotCallback, useScreenshotMode } from './screenshot'
 
@@ -78,30 +79,26 @@ function ExposeMapForTesting({ id }: { id: string }): ReactNode {
 function SynchronizeMapWithScreenshots(): ReactNode {
     const { current: map } = useMap()
 
+    assert(map !== undefined, 'Map context is required')
+
     const screenshotCallback = useScreenshotCallback('wait')
 
     useEffect(() => {
-        if (screenshotCallback !== undefined && map) {
+        if (screenshotCallback !== undefined) {
             debugLog('SynchronizeMapWithScreenshots: screenshot mode entered, map.loaded()=', map.loaded())
             void (async () => {
-                await new Promise(resolve => requestAnimationFrame(resolve))
-                let idleCount = 0
-                while (!map.loaded()) {
-                    idleCount++
-                    debugLog('SynchronizeMapWithScreenshots: map not loaded, waiting for idle (attempt', idleCount, ')')
-                    await Promise.any([
-                        map.once('idle'),
-                        map.once('remove'),
-                    ])
+                // Give the map a frame first: right after a commit,
+                // `loaded()` can still be true from before the map noticed the new work.
+                let frames = 0
+                do {
+                    await new Promise(resolve => requestAnimationFrame(resolve))
+                    frames++
                     if (map._removed) {
                         debugLog('SynchronizeMapWithScreenshots: map was removed, aborting')
                         return
                     }
-                    debugLog('SynchronizeMapWithScreenshots: idle event received, map.loaded()=', map.loaded())
-                    // Map will sometimes return to idle but needs to load more
-                    await new Promise(resolve => requestAnimationFrame(resolve))
-                }
-                debugLog('SynchronizeMapWithScreenshots: map is loaded after', idleCount, 'idle wait(s), signaling ready')
+                } while (!map.loaded())
+                debugLog('SynchronizeMapWithScreenshots: map is loaded after', frames, 'frame(s), signaling ready')
                 const layersOrder = map.getLayersOrder()
                 debugLog('SynchronizeMapWithScreenshots: layers count=', layersOrder.length)
                 for (const layerId of layersOrder) {
@@ -179,35 +176,45 @@ export function PolygonFeatureCollection({ features, clickable }: { features: Ge
 
     const id = useId()
 
-    useClickable({ id: polygonsId(id, 'fill'), features, clickable })
-
     const isScreenshotMode = useScreenshotMode()
+
+    /*
+     * A geojson source's `tolerance` is fixed at creation, so toggling screenshot mode rebuilds the
+     * source under a new id.
+     *
+     * As layers are strictly dependent on a source (they are only added to the map when their source is present),
+     * expected layers should be tied to a specific source to minimize complexity in the React <-> Maplibre binding.
+     * (e.g. the case where a layer is temporarily removed from the map because its source has changed.)
+     */
+    const instanceId = `${id}-${isScreenshotMode ? 'screenshot' : 'interactive'}`
+
+    useClickable({ id: polygonsId(instanceId, 'fill'), features, clickable })
 
     return (
         <>
             <Source
                 // Must remount to apply tolerance changes
-                key={`source-${String(isScreenshotMode)}`}
-                id={polygonsId(id, 'source')}
+                key={polygonsId(instanceId, 'source')}
+                id={polygonsId(instanceId, 'source')}
                 type="geojson"
                 data={collection}
                 // Only use tolerance=0 in screenshot mode, as it takes a lot of memory
                 {...(isScreenshotMode ? { tolerance: 0 } : { })}
             />
-            <Layer
-                id={polygonsId(id, 'fill')}
+            <ScreenshotAwareLayer
+                id={polygonsId(instanceId, 'fill')}
                 type="fill"
-                source={polygonsId(id, 'source')}
+                source={polygonsId(instanceId, 'source')}
                 paint={{
                     'fill-color': ['get', 'fillColor'],
                     'fill-opacity': ['get', 'fillOpacity'],
                 }}
                 beforeId={beforeId}
             />
-            <Layer
-                id={polygonsId(id, 'outline')}
+            <ScreenshotAwareLayer
+                id={polygonsId(instanceId, 'outline')}
                 type="line"
-                source={polygonsId(id, 'source')}
+                source={polygonsId(instanceId, 'source')}
                 paint={{
                     'line-color': ['get', 'color'],
                     'line-width': ['get', 'weight'],
@@ -307,7 +314,7 @@ export function PointFeatureCollection({ features, clickable }: { features: GeoJ
     return (
         <>
             <Source id={pointsId(id, 'source')} type="geojson" data={collection} />
-            <Layer
+            <ScreenshotAwareLayer
                 id={pointsId(id, 'fill')}
                 type="circle"
                 source={pointsId(id, 'source')}
@@ -401,7 +408,7 @@ export function Basemap({ basemap }: { basemap: Basemap }): ReactNode {
 
     if (basemap.type === 'osm' && basemap.subnationalOutlines !== undefined) {
         return (
-            <Layer
+            <ScreenshotAwareLayer
                 id={basemapSubnationalsId}
                 type="line"
                 source="openmaptiles"

--- a/react/src/syau/syau-cluster-map.tsx
+++ b/react/src/syau/syau-cluster-map.tsx
@@ -1,8 +1,9 @@
 import maplibregl from 'maplibre-gl'
 import React, { ReactNode, memo, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { FullscreenControl, Layer, MapProps, MapRef, Source, useMap } from 'react-map-gl/maplibre'
+import { FullscreenControl, MapProps, MapRef, Source, useMap } from 'react-map-gl/maplibre'
 
+import { ScreenshotAwareLayer } from '../components/ScreenshotAwareLayer'
 import { Basemap, CommonMaplibreMap, urbanStatsLayerPrefix } from '../components/map-common'
 import { Basemap as BasemapSpec } from '../mapper/settings/utils'
 import { TestUtils } from '../utils/TestUtils'
@@ -229,7 +230,7 @@ export function ClusterMap(props: ClusterMapProps): ReactNode {
               * for querySourceFeatures to return features; this circle layer is invisible
               * (radius 0) but keeps that pipeline active
               */}
-            <Layer
+            <ScreenshotAwareLayer
                 id={`${urbanStatsLayerPrefix}-centroid-placeholders`}
                 type="circle"
                 source="centroids"


### PR DESCRIPTION
There was a race condition when managing sources/layers using react-map-gl where we could be querying for map loaded when the layers were not added due to the source not being mounted yet

Related to #2024 