### PR TITLE
Fix category checkbox becoming unclickable across pages

### DIFF
--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -79,28 +79,33 @@ function saveIndeterminateState(settings: Settings, category: Category): void {
 
 export function useChangeCategorySetting(category: Category): () => void {
     const categoryStatus = useCategoryStatus(category)
+    const availableGroups = useAvailableGroups(category)
     const settings = useContext(Settings.Context)
     return () => {
+        const setAllGroups = (value: (group: Group) => boolean): void => {
+            category.contents.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, value(group)) })
+        }
         /**
-     * State machine:
-     *
-     * indeterminate -> checked -> unchecked -(if nonempty saved indeterminate)-> indeterminate
-     *                                       -(if empty saved indeterminate)-> checked
-     */
+         * State machine:
+         *
+         * indeterminate -> checked -> unchecked -(if nonempty saved indeterminate)-> indeterminate
+         *                                       -(if empty saved indeterminate)-> checked
+         */
         switch (categoryStatus) {
             case 'indeterminate':
-                category.contents.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, true) })
+                setAllGroups(() => true)
                 break
             case true:
-                category.contents.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, false) })
+                setAllGroups(() => false)
                 break
             case false:
                 const savedDeterminate = new Set(settings.get(`stat_category_saved_indeterminate_${category.id}`))
-                if (savedDeterminate.size === 0) {
-                    category.contents.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, true) })
+                // The saved state can refer to groups that don't exist on this page, which would restore nothing
+                if (availableGroups.every(group => !savedDeterminate.has(group.id))) {
+                    setAllGroups(() => true)
                 }
                 else {
-                    category.contents.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, savedDeterminate.has(group.id)) })
+                    setAllGroups(group => savedDeterminate.has(group.id))
                 }
                 break
         }

--- a/react/test/checkbox_bug.test.ts
+++ b/react/test/checkbox_bug.test.ts
@@ -1,0 +1,77 @@
+import { Selector } from 'testcafe'
+
+import { target, urbanstatsFixture, withHamburgerMenu } from './test_utils'
+
+/**
+ * Regression test for https://github.com/kavigupta/urbanstats/issues/1978
+ *
+ * The Election category contains disjoint groups for US articles
+ * (us_presidential_election) and Canadian articles (canada_general_election_*).
+ * If the saved indeterminate state for a category only refers to groups that
+ * aren't available on the current page, clicking the category checkbox becomes a
+ * no-op, and the checkbox can never be checked again.
+ */
+
+const electionCheck = 'input[data-test-id=category_election]'
+const electionExpand = '.expandButton[data-category-id=election]'
+const usPresidentialCheck = 'input[data-test-id=group_us_presidential_election]:not([inert] *)'
+
+urbanstatsFixture('cross-page category checkbox', `${target}/article.html?longname=California%2C+USA`, async (t) => {
+    await t.resizeWindow(1400, 800)
+})
+
+test('election-checkbox-clickable-after-switching-countries', async (t) => {
+    // On a US article, select only the US-specific group in the Election category.
+    // This saves an indeterminate state of [us_presidential_election].
+    await withHamburgerMenu(t, async () => {
+        await t.click(electionExpand)
+        await t.click(usPresidentialCheck)
+        await t.expect(Selector(usPresidentialCheck).checked).eql(true)
+    })
+
+    // Switch to a Canadian article, where the Election category contains an
+    // entirely different set of groups, none of which are selected.
+    await t.navigateTo(`${target}/article.html?longname=Toronto+CDR%2C+Ontario%2C+Canada`)
+
+    await withHamburgerMenu(t, async () => {
+        await t.expect(Selector(electionCheck).checked).eql(false)
+
+        // Clicking the category checkbox should check it, since the saved
+        // indeterminate state has nothing to restore on this page.
+        await t.click(electionCheck)
+        await t.expect(Selector(electionCheck).checked).eql(true)
+    })
+})
+
+test('category-checkbox-affects-groups-from-other-pages', async (t) => {
+    /**
+     * Stat group settings are global, not per-page, so toggling a category writes to every group
+     * in it, including the ones the current page can't show. A category checkbox therefore
+     * displays only the groups available on the current page, but acts on all of them.
+     *
+     * This test pins that down, since scoping the writes to the available groups would look like a
+     * reasonable change to make while fixing an unrelated bug.
+     */
+    await withHamburgerMenu(t, async () => {
+        await t.click(electionExpand)
+        await t.click(usPresidentialCheck)
+        await t.expect(Selector(electionCheck).checked).eql(true)
+    })
+
+    await t.navigateTo(`${target}/article.html?longname=Toronto+CDR%2C+Ontario%2C+Canada`)
+
+    // Cycle the category through checked and back to unchecked, using only Canadian groups.
+    await withHamburgerMenu(t, async () => {
+        await t.click(electionCheck)
+        await t.expect(Selector(electionCheck).checked).eql(true)
+        await t.click(electionCheck)
+        await t.expect(Selector(electionCheck).checked).eql(false)
+    })
+
+    await t.navigateTo(`${target}/article.html?longname=California%2C+USA`)
+
+    // The unchecking applied to the US group too, even though it isn't shown on the Canadian page.
+    await withHamburgerMenu(t, async () => {
+        await t.expect(Selector(electionCheck).checked).eql(false)
+    })
+})


### PR DESCRIPTION
Fixes #1978.

## The bug

The `Election` category has disjoint groups per country — `us_presidential_election` vs. `canada_general_election_*`. A category checkbox reflects only the groups available on the current page (`useCategoryStatus` → `useAvailableGroups`), but the saved indeterminate state is stored for the whole category.

So if you select `US Presidential Election` on a US article and then open a Canadian one, the saved state is `[us_presidential_election]` — nonempty, but referring to nothing on this page. Clicking `Election` took the "restore saved state" branch, which selected none of the available Canadian groups. The checkbox stayed unchecked, and every subsequent click repeated the same no-op, exactly as in the video on the issue.

## The fix

Test whether any *available* group appears in the saved state, rather than whether the saved state is empty. A saved state with nothing to restore on this page now falls through to selecting everything, so the checkbox always responds.

The writes still go to every group in the category, since stat group settings are global rather than per-page.

## Tests

Two tests in `react/test/checkbox_bug.test.ts`:

- `election-checkbox-clickable-after-switching-countries` — the regression test. Reproduces the issue in three steps and fails without the fix.
- `category-checkbox-affects-groups-from-other-pages` — pins the global-settings behavior, since scoping the writes to available groups looks like a reasonable thing to do while fixing the above. Verified non-vacuous: it fails if the writes are scoped.

Also passing locally: `stats_tree_desktop` (17), `stats_tree_mobile` (17), `statistics` (54), `article_link_settings` (25), `comparison_link_settings` (24), `settings` (6), `statistic-column-delete` (6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)