### PR TITLE
Fix unreliable link clicking in USS editor doc popups

### DIFF
--- a/react/src/urban-stats-script/Editor.tsx
+++ b/react/src/urban-stats-script/Editor.tsx
@@ -63,6 +63,9 @@ export function Editor(
 
     const spanTokenMapRef = useRef<Map<Element, AnnotatedToken>>(new Map())
 
+    const popoverElementRef = useRef<HTMLElement | undefined>(undefined)
+    popoverElementRef.current = popoverState?.element
+
     const renderScript = useCallback((newScript: Script) => {
         spanTokenMapRef.current.clear()
 
@@ -123,6 +126,13 @@ export function Editor(
     useEffect(() => {
         const listener = (): void => {
             // These events are often spurious
+
+            // Clicking inside the popover moves the selection into it. Reacting to that would blur the editor,
+            // which tears the popover down before the click lands.
+            const anchorNode = window.getSelection()?.anchorNode
+            if (anchorNode !== undefined && anchorNode !== null && popoverElementRef.current?.contains(anchorNode) === true) {
+                return
+            }
 
             const range = getRange(editorRef.current!)
             setSelectionRef.current(range)
@@ -288,7 +298,11 @@ export function Editor(
 
     useEffect(() => {
         const editor = editorRef.current!
-        const listener = (): void => {
+        const listener = (e: FocusEvent): void => {
+            // Some browsers focus links on mousedown; tearing down here would lose the click
+            if (e.relatedTarget instanceof Node && popoverElementRef.current?.contains(e.relatedTarget) === true) {
+                return
+            }
             setPopoverState(undefined)
         }
         editor.addEventListener('blur', listener)

--- a/react/test/editor.test.ts
+++ b/react/test/editor.test.ts
@@ -254,7 +254,7 @@ test('show documentation popover', async (t) => {
     await t.expect(Selector('div').withExactText('colorPink').exists).ok() // Autocomplete menu
 })
 
-test.only('documentation popover link is clickable', async (t) => {
+test('documentation popover link is clickable', async (t) => {
     // The editor needs a selection, since that's what used to blur the editor and dismiss the popover on mousedown
     await t.click(nthEditor(0))
     await typeTextWithKeys(t, 'pi')

--- a/react/test/editor.test.ts
+++ b/react/test/editor.test.ts
@@ -1,7 +1,7 @@
 import { ClientFunction, Selector } from 'testcafe'
 
 import { checkCode, getSelectionAnchor, getSelectionFocus, nthEditor, result, selectionIsNthEditor, typeTextWithKeys } from './editor_test_utils'
-import { safeReload, screencap, target, urbanstatsFixture } from './test_utils'
+import { getLocation, safeReload, screencap, target, urbanstatsFixture } from './test_utils'
 
 urbanstatsFixture('editor test', `${target}/editor.html`)
 
@@ -252,6 +252,19 @@ test('show documentation popover', async (t) => {
     // Continuing to type should reopen autocomplete
     await typeTextWithKeys(t, 'n')
     await t.expect(Selector('div').withExactText('colorPink').exists).ok() // Autocomplete menu
+})
+
+test.only('documentation popover link is clickable', async (t) => {
+    // The editor needs a selection, since that's what used to blur the editor and dismiss the popover on mousedown
+    await t.click(nthEditor(0))
+    await typeTextWithKeys(t, 'pi')
+    await t.hover(Selector('span').withText(/^pi/))
+    await t.wait(1000)
+
+    const docLink = Selector('h4').find('a').withExactText('pi')
+    await t.expect(docLink.exists).ok()
+    await t.click(docLink)
+    await t.expect(getLocation()).contains('/uss-documentation.html')
 })
 
 test('show values of constants and variables in popovers', async (t) => {


### PR DESCRIPTION
Fixes #2107

## Cause

The documentation popover is rendered *inside* the `contenteditable` editor as a `contenteditable="false"` island. Clicking a link in it triggered this chain:

1. mousedown moves the DOM selection into the popover
2. `selectionchange` fires → `getRange` returns `null` (the node isn't contentEditable) → `setSelection(null)`
3. Editor re-renders with `selection === null` → `setRange(editor, null)` → `editor.blur()`
4. The `blur` listener calls `setPopoverState(undefined)`, removing the popover from the DOM before `mouseup` — so no `click` event ever fires

It was *unreliable* rather than consistently broken because when the editor had no prior selection, `setRange` early-returns and the popover survives, letting the click through.

## Fix

- Ignore `selectionchange` events whose anchor is inside the popover, so clicking in it no longer blurs the editor.
- Ignore `blur` events whose `relatedTarget` is inside the popover — some browsers (Safari) focus links on mousedown, which would tear the popover down the same way.

Both guards read the popover element through a ref, since these listeners are intentionally bound once.

Text selection inside the popover still works (no blanket `preventDefault` on mousedown), which the existing `show values of constants and variables in popovers` test depends on.

## Testing

Adds an e2e regression test that types into the editor (so a selection exists — the condition that triggered the bug), hovers a token to open the popover, clicks the doc link, and asserts navigation to the docs page. Run locally by @lukebrody against the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)