### PR TITLE
Turn off map export debug logging

### DIFF
--- a/react/src/utils/debug-logging.ts
+++ b/react/src/utils/debug-logging.ts
@@ -3,7 +3,7 @@ const enableDebugLogging = {
     searchPerformance: false,
     waitForLoading: false,
     undoRedo: false,
-    mapExport: true,
+    mapExport: false,
 }
 
 type Key = keyof typeof enableDebugLogging


### PR DESCRIPTION
The screenshot/polygon flakiness tracked in #2024 was fixed by the race-condition fix in #2098 and hasn't recurred, so the `mapExport` debug logging is no longer needed.

Flips the flag off rather than removing the log sites, matching how the other categories in `debug-logging.ts` are parked.

Closes #2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)