### PR TITLE
Use PORT env var for persistent-data CORS origin

### DIFF
--- a/react/port.js
+++ b/react/port.js
@@ -2,6 +2,7 @@
 /**
  * Returns the port number to use for the dev server.
  * Reads from the PORT environment variable, defaulting to 8000.
+ * Kept in sync with port() in urbanstats-persistent-data/urbanstats_persistent_data/utils.py
  * @returns {number} The port number
  */
 export function port() {

--- a/urbanstats-persistent-data/urbanstats_persistent_data/main.py
+++ b/urbanstats-persistent-data/urbanstats_persistent_data/main.py
@@ -1,11 +1,11 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .utils import HTTPExceptionModel
+from .utils import HTTPExceptionModel, port
 
 app = FastAPI(responses={500: {"model": HTTPExceptionModel}})
 
-origins = ["http://localhost:8000", "https://urbanstats.org"]
+origins = [f"http://localhost:{port()}", "https://urbanstats.org"]
 
 app.add_middleware(
     CORSMiddleware,

--- a/urbanstats-persistent-data/urbanstats_persistent_data/utils.py
+++ b/urbanstats-persistent-data/urbanstats_persistent_data/utils.py
@@ -1,6 +1,18 @@
+import os
 import typing as t
 
 from pydantic import BaseModel, BeforeValidator
+
+
+# Kept in sync with port() in react/port.js
+def port() -> int:
+    value = os.environ.get("PORT")
+    if not value:
+        return 8000
+    try:
+        return int(value)
+    except ValueError as e:
+        raise ValueError(f"Invalid Port Number {value}") from e
 
 
 def corrects_to_bytes(corrects: t.List[bool]) -> bytes:


### PR DESCRIPTION
## Summary

- Add a `port()` helper in the persistent-data `utils.py` that reads the `PORT` environment variable (defaulting to `8000`), mirroring `port()` in `react/port.js`.
- Use it to build the localhost CORS origin in `main.py` so the backend allows the frontend dev server regardless of the configured port.

## Test plan

- Start the persistent-data app with a custom `PORT` and confirm `http://localhost:<PORT>` is included in the CORS allowed origins.
- Default behavior (no `PORT` set) still allows `http://localhost:8000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)