### PR TITLE
Don't report unfinished quizzes

### DIFF
--- a/react/src/components/quiz-panel.tsx
+++ b/react/src/components/quiz-panel.tsx
@@ -146,6 +146,7 @@ function QuizPanelNoResets(props: { quizDescriptor: QuizDescriptor, todayName?: 
                             history={history}
                             todayName={props.todayName}
                             quizDescriptor={props.quizDescriptor}
+                            isDone={props.todaysQuiz.isDone}
                         />
                     )
                 }

--- a/react/src/quiz/quiz-result.tsx
+++ b/react/src/quiz/quiz-result.tsx
@@ -40,6 +40,7 @@ interface QuizResultProps {
     }
     wholeHistory: QuizHistory
     quiz: QuizQuestion[]
+    isDone: (correctPattern: boolean[]) => boolean
 }
 
 export function QuizResult(props: QuizResultProps): ReactNode {
@@ -60,12 +61,12 @@ export function QuizResult(props: QuizResultProps): ReactNode {
         if (props.quizDescriptor.kind === 'custom') {
             return
         }
-        void reportToServer(props.wholeHistory, props.quizDescriptor.kind)
+        void reportToServer(props.wholeHistory, props.quizDescriptor.kind, props.isDone)
         if (props.quizDescriptor.kind === 'infinite') {
             return
         }
         void getPerQuestionStats(props.quizDescriptor).then(setStats)
-    }, [props.wholeHistory, props.quizDescriptor])
+    }, [props.wholeHistory, props.quizDescriptor, props.isDone])
 
     const correctPattern = props.history.correct_pattern
 

--- a/react/src/quiz/statistics.ts
+++ b/react/src/quiz/statistics.ts
@@ -16,7 +16,7 @@ async function registerUser(): Promise<void> {
     })
 }
 
-async function reportToServerGeneric(wholeHistory: QuizHistory, endpointLatest: '/juxtastat/latest_day' | '/retrostat/latest_week', endpointStore: '/juxtastat/store_user_stats' | '/retrostat/store_user_stats', parseDay: (day: string) => number): Promise<void> {
+async function reportToServerGeneric(wholeHistory: QuizHistory, endpointLatest: '/juxtastat/latest_day' | '/retrostat/latest_week', endpointStore: '/juxtastat/store_user_stats' | '/retrostat/store_user_stats', parseDay: (day: string) => number, isDone: (correctPattern: boolean[]) => boolean): Promise<void> {
     await registerUser()
 
     // fetch from latest_day endpoint
@@ -30,13 +30,15 @@ async function reportToServerGeneric(wholeHistory: QuizHistory, endpointLatest: 
         return
     }
     const latestDay = data.latest_day
-    const filteredDays = Object.keys(wholeHistory).filter(day => parseDay(day) > latestDay)
-    const update = filteredDays.map<[number, boolean[]]>((day) => {
-        return [
+    const update = Object.keys(wholeHistory)
+        .filter(day => parseDay(day) > latestDay)
+        .map<[number, boolean[]]>(day => [
             parseDay(day),
             wholeHistory[day].correct_pattern.map(b => b === 1 || b === true),
-        ]
-    })
+        ])
+        // Don't report in-progress quizzes; an incomplete pattern would be stored
+        // as a truncated final score (see issue #1900).
+        .filter(([, correctPattern]) => isDone(correctPattern))
 
     await persistentClient.POST(endpointStore, {
         params: {
@@ -145,12 +147,12 @@ function parseInfiniteSeedVersion(day: string): [string, number] | undefined {
     return [match[1], parseInt(match[2])]
 }
 
-export async function reportToServer(wholeHistory: QuizHistory, kind: QuizKindWithStats): Promise<void> {
+export async function reportToServer(wholeHistory: QuizHistory, kind: QuizKindWithStats, isDone: (correctPattern: boolean[]) => boolean): Promise<void> {
     switch (kind) {
         case 'juxtastat':
-        { await reportToServerGeneric(wholeHistory, '/juxtastat/latest_day', '/juxtastat/store_user_stats', parseJuxtastatDay); return }
+        { await reportToServerGeneric(wholeHistory, '/juxtastat/latest_day', '/juxtastat/store_user_stats', parseJuxtastatDay, isDone); return }
         case 'retrostat':
-        { await reportToServerGeneric(wholeHistory, '/retrostat/latest_week', '/retrostat/store_user_stats', parseRetrostatWeek); return }
+        { await reportToServerGeneric(wholeHistory, '/retrostat/latest_week', '/retrostat/store_user_stats', parseRetrostatWeek, isDone); return }
         case 'infinite':
         { await reportToServerInfinite(wholeHistory); return }
     }

--- a/react/test/quiz_test_template.ts
+++ b/react/test/quiz_test_template.ts
@@ -205,6 +205,31 @@ export function quizTest({ platform }: { platform: 'desktop' | 'mobile' }): void
     })
 
     quizFixture(
+        'do not report incomplete quiz results',
+        `${target}/quiz.html#date=99`,
+        {
+            persistent_id: '000000000000007',
+            // Day 95 was only partially answered (1 of 5 questions), e.g. the user
+            // answered the first question correctly then closed the tab.
+            quiz_history: JSON.stringify({ 95: { choices: ['A'], correct_pattern: [true] } }),
+        },
+        `
+    CREATE TABLE IF NOT EXISTS JuxtaStatIndividualStats
+        (user integer, day integer, corrects integer, time integer, PRIMARY KEY (user, day));
+    `,
+        platform,
+    )
+
+    test('quiz-do-not-report-incomplete-results', async (t) => {
+        await safeReload(t)
+        await clickButtons(t, ['a', 'a', 'a', 'a', 'a'])
+        // Completing day 99 must not sweep the in-progress day 95 to the server.
+        // Reporting it persists [true], which the server pads to 5 bits and decodes
+        // to green/red/red/red/red even though the user never finished day 95 (#1900).
+        await t.expect(await juxtastatTable(t)).eql('7|99|15\n')
+    })
+
+    quizFixture(
         'percentage correct test',
         `${target}/quiz.html#date=99`,
         { persistent_id: '000000000000007' },


### PR DESCRIPTION
Fixes #1900.

## Problem

A completed daily quiz could be reported to the persistent server as a truncated score — e.g. a real score of 🟩🟩🟥🟥🟩 showing up as 🟩🟥🟥🟥🟥 — while Google Drive stayed correct.

## Root cause

`reportToServerGeneric` reported **every** history day with `parseDay(day) > latestDay`, without checking whether that day's quiz was actually finished. If you start a day, answer the first question, and abandon it, local history holds a partial `correct_pattern` (e.g. `[true]`). When a **later** day's quiz completes and triggers `reportToServer`, it sweeps up that in-progress day and stores the partial pattern. The server encodes corrects as a bitvector and pads back to 5 bits on decode, so `[true]` becomes 🟩🟥🟥🟥🟥.

## Fix

Only report days whose quiz is complete, using an `isDone` predicate derived from the quiz model (`todaysQuiz.isDone`) threaded `QuizPanel → QuizResult → reportToServer`. Infinite quizzes are unchanged — they already filter via `infiniteQuizIsDone`.

## Test

New e2e test `quiz-do-not-report-incomplete-results`: seeds an incomplete day 95 (`correct_pattern: [true]`), completes day 99, and asserts the server holds only `7|99|15`. Fails before the fix (`7|95|1\n7|99|15`), passes after.

## Not covered (intentionally)

This prevents **new** bad reports only. It does not retroactively repair rows already stored wrong, and does not change the server-side "worst score" (`min`) aggregation that surfaces such rows — so already-affected days won't self-heal from this change alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
