### PR TITLE
createScreenshot: take a () => ScreencapElements thunk

### DIFF
--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -72,7 +72,7 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
         >
             <QuerySettingsConnection />
             <PageTemplate
-                screencap={(...args) => createScreenshot(screencapElements(), ...args)}
+                screencap={(...args) => createScreenshot(screencapElements, ...args)}
                 csvExportCallback={csvExportCallback}
             >
                 <div>

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -316,7 +316,7 @@ export function ComparisonPanel(props: {
             <TransposeContext.Provider value={transpose}>
                 <QuerySettingsConnection />
                 <PageTemplate
-                    screencap={(...args) => createScreenshot(screencapElements(), ...args)}
+                    screencap={(...args) => createScreenshot(screencapElements, ...args)}
                     csvExportCallback={csvExportCallback}
                 >
                     <DndContext

--- a/react/src/components/plots-general.tsx
+++ b/react/src/components/plots-general.tsx
@@ -241,11 +241,11 @@ function PlotDownloadButton(props: { makePlot: () => HTMLElement, shortnames: st
                 document.body.appendChild(plot)
                 const uniqueShortnames = Array.from(new Set(props.shortnames))
                 await createScreenshot(
-                    {
+                    () => ({
                         path: `${uniqueShortnames.join('_')}_${props.filenameSuffix}`,
                         overallWidth: plot.offsetWidth * 2,
                         elementsToRender: [plot],
-                    },
+                    }),
                     universe,
                     colors,
                     { render: new Set(), wait: new Set() },

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -218,12 +218,15 @@ export async function withScreenshotMode<T>(context: ScreenshotContextType, fn: 
     }
 }
 
-export async function createScreenshot(config: ScreencapElements, universe: string | undefined, colors: Colors, screenshotContext: ScreenshotContextType, forceNonTesting: boolean = false): Promise<void> {
+export async function createScreenshot(config: () => ScreencapElements, universe: string | undefined, colors: Colors, screenshotContext: ScreenshotContextType, forceNonTesting: boolean = false): Promise<void> {
     await withScreenshotMode(screenshotContext, async () => {
-        const overallWidth = config.overallWidth
+        // Resolved inside screenshot mode, so callers can lay out elements differently for
+        // the screenshot and have that reflected here.
+        const resolved = config()
+        const overallWidth = resolved.overallWidth
 
         const canvases = []
-        for (const ref of config.elementsToRender) {
+        for (const ref of resolved.elementsToRender) {
             try {
                 canvases.push(await screencapElement(ref, overallWidth, { testing: !forceNonTesting && TestUtils.shared.isTesting }))
             }
@@ -274,7 +277,7 @@ export async function createScreenshot(config: ScreencapElements, universe: stri
         }
 
         canvas.toBlob(function (blob) {
-            saveAs(blob!, config.path)
+            saveAs(blob!, resolved.path)
         })
     })
 }

--- a/react/src/stat/StatisticPanelPage.tsx
+++ b/react/src/stat/StatisticPanelPage.tsx
@@ -46,11 +46,11 @@ export function StatisticPanelPage({ view, stat, data, set, loading, counts, err
 
     return (
         <PageTemplate
-            screencap={data && ((...args) => createScreenshot({
+            screencap={data && ((...args) => createScreenshot(() => ({
                 path: `${sanitize(reifyString(data.renderedStatname))}.png`,
                 overallWidth: tableRef.current!.offsetWidth * 2,
                 elementsToRender: [headersRef.current!, tableRef.current!],
-            }, ...args))}
+            }), ...args))}
             csvExportCallback={data && (() => ({
                 csvData: generateStatisticsPanelCSVData(data.articleNames, data.table, data.hideOrdinalsPercentiles),
                 csvFilename: `${sanitize(reifyString(data.renderedStatname))}.csv`,

--- a/react/src/syau/syau-panel.tsx
+++ b/react/src/syau/syau-panel.tsx
@@ -43,11 +43,11 @@ export function SYAUPanel(props: { typ?: string, universe?: Universe, counts: Co
                         if (el === null) {
                             return Promise.resolve()
                         }
-                        return createScreenshot({
+                        return createScreenshot(() => ({
                             path: `syau-${sanitize(`${props.typ!}-${props.universe!}`)}.png`,
                             overallWidth: el.offsetWidth * 4,
                             elementsToRender: [el],
-                        }, ...args, true)
+                        }), ...args, true)
                     }
                 : undefined}
         >


### PR DESCRIPTION
Refactors `createScreenshot` to accept a `() => ScreencapElements` thunk instead of a `ScreencapElements` object. The config is resolved *inside* `withScreenshotMode`, so a caller can lay out the captured elements differently for the screenshot (measured/enumerated while screenshot mode is active) rather than snapshotting them before the mode flips.

Pure refactor — no behavior change for existing callers:
- `screenshot.tsx`: signature + resolve `config()` inside `withScreenshotMode`.
- `syau-panel`, `plots-general`, `StatisticPanelPage`: wrap the object literal in `() => (...)`.
- `article-panel`, `comparison-panel`: pass their existing `screencapElements` helper directly instead of calling it.

Split out of the cross-source-border disclaimer work (#2106) to be merged first; that PR needs the thunk form so it can move the disclaimer into a screenshot-only footnote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)