### PR TITLE
Give the editable ordinal a data-test-id; use it in tests

### DIFF
--- a/react/src/components/editable-field.tsx
+++ b/react/src/components/editable-field.tsx
@@ -5,7 +5,7 @@ import { useColors } from '../page_template/colors'
 
 import { useScreenshotMode } from './screenshot'
 
-export function EditableString(props: { content: string, onNewContent: (content: string) => void, style: CSSProperties, inputMode: 'text' | 'decimal' }): ReactNode {
+export function EditableString(props: { content: string, onNewContent: (content: string) => void, style: CSSProperties, inputMode: 'text' | 'decimal', testId?: string }): ReactNode {
     /*
      * This code is weird because the `ContentEditable` needs to use refs.
      * See https://www.npmjs.com/package/react-contenteditable
@@ -48,6 +48,7 @@ export function EditableString(props: { content: string, onNewContent: (content:
     return (
         <ContentEditable
             className="editable_content"
+            data-test-id={props.testId}
             style={props.style}
             innerRef={contentEditable}
             html={html.current}
@@ -67,7 +68,7 @@ export function EditableString(props: { content: string, onNewContent: (content:
     )
 }
 
-export function EditableNumber(props: { number: number, onNewNumber: (number: number) => void }): ReactNode {
+export function EditableNumber(props: { number: number, onNewNumber: (number: number) => void, testId?: string }): ReactNode {
     const colors = useColors()
     if (useScreenshotMode()) {
         return props.number.toString()
@@ -84,6 +85,7 @@ export function EditableNumber(props: { number: number, onNewNumber: (number: nu
             onNewContent={onNewContent}
             style={{ minWidth: '2em', display: 'inline-block', border: `1px solid ${colors.borderNonShadow}`, borderRadius: 3, padding: '0 2px' }}
             inputMode="decimal"
+            testId={props.testId}
         />
     )
 }

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -1268,6 +1268,7 @@ function Ordinal(props: {
                 <EditableNumber
                     number={ordinal}
                     onNewNumber={onNewNumber}
+                    testId="editable-ordinal"
                 />
             )
         : (

--- a/react/test/article-universe.test.ts
+++ b/react/test/article-universe.test.ts
@@ -52,7 +52,7 @@ test('article-universe-right-arrow', async (t) => {
 
 test('article-universe-ordinal', async (t) => {
     // click the ordinal for the universe
-    const editableNumber = Selector('span').withAttribute('class', 'editable_content').nth(0)
+    const editableNumber = Selector('span').withAttribute('data-test-id', 'editable-ordinal').nth(0)
     await t
         .click(editableNumber)
     // select all and delete

--- a/react/test/article.test.ts
+++ b/react/test/article.test.ts
@@ -56,8 +56,8 @@ test('san-marino-article-test', async (t) => {
 })
 
 test('editable-number', async (t) => {
-    // span with class editable_content
-    const editableNumber = Selector('span').withAttribute('class', 'editable_content').nth(0)
+    // the editable ordinal for the first statistic (population)
+    const editableNumber = Selector('span').withAttribute('data-test-id', 'editable-ordinal').nth(0)
     await t
         .click(editableNumber)
         // select all and delete

--- a/react/test/comparison_x0.test.ts
+++ b/react/test/comparison_x0.test.ts
@@ -99,7 +99,7 @@ test('comparison-3-replace-second', async (t) => {
 })
 
 test('comparison-3-editable-number-third', async (t) => {
-    const editableNumber = Selector('span').withAttribute('class', 'editable_content').nth(2)
+    const editableNumber = Selector('span').withAttribute('data-test-id', 'editable-ordinal').nth(2)
     await t
         .click(editableNumber)
         // select all and delete

--- a/react/test/data_sanity_check.test.ts
+++ b/react/test/data_sanity_check.test.ts
@@ -9,7 +9,7 @@ async function goToExtremeArticle(t: TestController): Promise<void> {
     const rows = Selector('.for-testing-table-row')
     await t.expect(await rows.count).eql(1)
     while (true) {
-        const editableContent = Selector('.editable_content')
+        const editableContent = Selector('span').withAttribute('data-test-id', 'editable-ordinal')
         await t.click(editableContent)
         await t.pressKey('ctrl+a delete')
         await t.typeText(editableContent, '-1')


### PR DESCRIPTION
The editable ordinal field was only reachable via the global `.editable_content` class + `nth()` index. That's fragile: any *other* editable field on the page (e.g. an editable percentile) shifts the indices and silently retargets these tests to the wrong field.

This threads an optional `testId` through `EditableNumber`/`EditableString` onto the underlying `ContentEditable` element, tags the ordinal as `editable-ordinal`, and selects by that id in the article, article-universe, comparison, and data-sanity-check tests.

Behavior-preserving refactor — no user-facing change. Splitting it out ahead of the editable-percentiles feature (#2119), which is what would otherwise shift those `nth()` indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)