### PR TITLE
Extract historyKeyForTimeIdentifier

### DIFF
--- a/react/src/quiz/quiz-statistics.tsx
+++ b/react/src/quiz/quiz-statistics.tsx
@@ -5,7 +5,7 @@ import { useColors, useJuxtastatColors } from '../page_template/colors'
 
 import { QuizDescriptor, QuizDescriptorWithTime, QuizHistory } from './quiz'
 import { ResultToDisplayForFriends } from './quiz-friends'
-import { getInfiniteQuizzes, parseTimeIdentifier } from './statistics'
+import { getInfiniteQuizzes, historyKeyForTimeIdentifier, parseTimeIdentifier } from './statistics'
 
 export function QuizStatistics(
     props: {
@@ -36,14 +36,7 @@ export function computeUserStatisticsData(
         totalFrequency: number
         frequencies: number[]
     } {
-    const history = (i: number): QuizHistory[string] | undefined => {
-        switch (quiz.kind) {
-            case 'juxtastat':
-                return wholeHistory[i]
-            case 'retrostat':
-                return wholeHistory[`W${i}`]
-        }
-    }
+    const history = (i: number): QuizHistory[string] | undefined => wholeHistory[historyKeyForTimeIdentifier(quiz.kind, i)]
 
     const today = parseTimeIdentifier(quiz.kind, quiz.name.toString())
     const historicalCorrect = new Array(today + 1).fill(-1)

--- a/react/src/quiz/statistics.ts
+++ b/react/src/quiz/statistics.ts
@@ -122,6 +122,16 @@ export function parseTimeIdentifier(quizKind: QuizKindWithTime, today: string): 
     }
 }
 
+/** Inverse of `parseTimeIdentifier`: the key a quiz at this time is stored under in the quiz history. */
+export function historyKeyForTimeIdentifier(quizKind: QuizKindWithTime, timeIdentifier: number): string {
+    switch (quizKind) {
+        case 'juxtastat':
+            return timeIdentifier.toString()
+        case 'retrostat':
+            return `W${timeIdentifier}`
+    }
+}
+
 function parseJuxtastatDay(day: string): number {
     // return -10000 if day doesn't match -?[0-9]+
     if (!/^-?[0-9]+$/.test(day)) {


### PR DESCRIPTION
Another piece split out of #2128.

The mapping from a juxtastat day number / retrostat week number to the key it's stored under in the quiz history was inline in `computeUserStatisticsData`. This names it next to `parseTimeIdentifier`, whose inverse it is, so callers that need to look up a specific quiz in the history don't have to re-derive the key format.

Behavior-preserving: for juxtastat the old code indexed `wholeHistory[i]` with a number, which coerces to the same string key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)