### PR TITLE
Check the site repo's branch in update_scripts

### DIFF
--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -35,7 +35,7 @@ def update_scripts(branch):
     """
     synchronize()
     # if the branch isn't the same as the current branch, checkout to the branch
-    current_branch = get_current_branch(".")
+    current_branch = get_current_branch(PATH)
     if current_branch != branch:
         # create a new branch if it doesn't exist
         subprocess.run(["git", "checkout", "-b", branch], cwd=PATH, check=True)


### PR DESCRIPTION
`update_scripts` does all of its git work in `PATH` (the site checkout), but read the current branch from `"."` — the urbanstats repo the script itself is running out of. So the `current_branch != branch` guard compared the wrong repo's branch, and the `git checkout -b` was skipped whenever the urbanstats repo happened to be on a branch of the same name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)