### PR TITLE
Untangle the table components' plumbing

### DIFF
--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -1,32 +1,27 @@
 import '../common.css'
 import './article.css'
 
-import React, { ReactNode, useCallback, useContext, useRef } from 'react'
+import React, { ReactNode, useContext, useMemo, useRef } from 'react'
 
 import { Navigator } from '../navigation/Navigator'
-import { useColors } from '../page_template/colors'
-import { useSetting, useSettings } from '../page_template/settings'
+import { useSettings } from '../page_template/settings'
 import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
 import { PageTemplate } from '../page_template/template'
-import { Universe, universeContext, useDefinedUniverse, useUniverse } from '../universe'
+import { Universe, universeContext, useUniverse } from '../universe'
 import { sanitize } from '../utils/paths'
 import { Article, IRelatedButtons } from '../utils/protos'
-import { useComparisonHeadStyle, useHeaderTextClass, useMobileLayout, useSubHeaderTextClass } from '../utils/responsive'
+import { useComparisonHeadStyle, useHeaderTextClass, useSubHeaderTextClass } from '../utils/responsive'
 import { NormalizeProto } from '../utils/types'
 
 import { ArticleMap } from './ArticleMap'
-import { ArticleWarnings } from './ArticleWarnings'
 import { ExternalLinks } from './ExternalLiinks'
 import { QuerySettingsConnection } from './QuerySettingsConnection'
-import { generateCSVDataForArticles, CSVExportData } from './csv-export'
+import { ArticleTable } from './article-table'
+import { useCSVExport } from './csv-export'
 import { ArticleRow } from './load-article'
-import { pullRelevantPlotProps, useExpandedByStat } from './plots'
 import { Related } from './related-button'
-import { createScreenshot, ScreencapElements, useScreenshotMode } from './screenshot'
+import { createScreenshot, ScreencapElements } from './screenshot'
 import { SearchBox } from './search'
-import { computeNameSpecsWithGroups, nameSpecsForRows } from './statistic-name-specs'
-import { CellSpec, PlotSpec, TableContents } from './supertable'
-import { ColumnIdentifier } from './table'
 
 export function ArticlePanel({ article, rows, universe }: { article: Article, rows: (settings: StatGroupSettings) => ArticleRow[][], universe: Universe }): ReactNode {
     const headersRef = useRef<HTMLDivElement>(null)
@@ -46,11 +41,8 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
     const settings = useSettings(groupYearKeys())
     const filteredRows = rows(settings)[0]
 
-    const csvExportCallback = useCallback<CSVExportData>(() => {
-        const data = generateCSVDataForArticles([article], [filteredRows], true)
-        const filename = `${sanitize(article.longname)}.csv`
-        return { csvData: data, csvFilename: filename }
-    }, [article, filteredRows])
+    const articles = useMemo(() => [article], [article])
+    const csvExportCallback = useCSVExport(articles, rows, true, article.longname)
 
     const navigator = useContext(Navigator.Context)
 
@@ -121,73 +113,6 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
     )
 }
 
-function ArticleTable(props: {
-    filteredRows: ArticleRow[]
-    article: Article
-}): ReactNode {
-    const colors = useColors()
-    const expandedEach = useExpandedByStat(
-        props.filteredRows.map(row => row.statpath),
-        index => props.filteredRows[index].extraStats.length > 0,
-    )
-    const currentUniverse = useDefinedUniverse()
-    const [simpleOrdinals] = useSetting('simple_ordinals')
-    const navContext = useContext(Navigator.Context)
-
-    const { widthLeftHeader, columnWidth } = useWidths()
-
-    const { updatedNameSpecs: leftHeaderSpecs, groupNames } = computeNameSpecsWithGroups(
-        nameSpecsForRows(props.filteredRows, props.article.longname, currentUniverse),
-    )
-
-    const onlyColumns: ColumnIdentifier[] = ['statval', 'statval_unit', 'statistic_percentile', 'statistic_ordinal', 'pointer_in_class', 'pointer_overall']
-    const cellSpecs: CellSpec[][] = props.filteredRows.map(row => [({
-        type: 'statistic-row',
-        longname: props.article.longname,
-        row,
-        onNavigate: (newArticle) => {
-            void navContext.navigate({
-                kind: 'article',
-                longname: newArticle,
-                universe: currentUniverse,
-            }, { history: 'push', scroll: { kind: 'none' } })
-        },
-        simpleOrdinals,
-        onlyColumns,
-    })])
-
-    const plotSpecs: (PlotSpec | undefined)[] = expandedEach.map((expanded, index) => expanded
-        ? {
-                statDescription: props.filteredRows[index].renderedStatname,
-                plotProps: pullRelevantPlotProps(
-                    props.filteredRows,
-                    index,
-                    colors.hueColors.blue,
-                    props.article.shortname,
-                    props.article.longname,
-                    props.article.articleType,
-                ),
-            }
-        : undefined,
-    )
-
-    const topLeftSpec = { type: 'top-left-header' } satisfies CellSpec
-
-    return (
-        <div className="stats_table">
-            <TableContents
-                leftHeaderSpec={{ leftHeaderSpecs, groupNames }}
-                rowSpecs={cellSpecs}
-                horizontalPlotSpecs={plotSpecs}
-                verticalPlotSpecs={[]}
-                topLeftSpec={topLeftSpec}
-                layout={{ widthLeftHeader, columnWidth, onlyColumns, simpleOrdinals }}
-            />
-            <ArticleWarnings />
-        </div>
-    )
-}
-
 function ComparisonSearchBox({ longname, type }: { longname: string, type: string }): ReactNode {
     const currentUniverse = useUniverse()
     const navContext = useContext(Navigator.Context)
@@ -204,19 +129,4 @@ function ComparisonSearchBox({ longname, type }: { longname: string, type: strin
             prioritizeArticleType={type}
         />
     )
-}
-
-function useWidths(): { widthLeftHeader: number, columnWidth: number } {
-    const [simpleOrdinals] = useSetting('simple_ordinals')
-    const isMobile = useMobileLayout()
-    const screenshotMode = useScreenshotMode()
-
-    // TODO clean this up and reduce the amount of magic numbers
-    const nonPointerColumns = 15 + 10 + (simpleOrdinals ? 7 + 8 : 17 + 25)
-    const pointerColumns = 8 * (screenshotMode ? 0 : (!simpleOrdinals && isMobile ? 1 : 2))
-    const numerator = 31
-    const denominator = nonPointerColumns + pointerColumns + numerator
-    const widthLeftHeader = 100 * (numerator / denominator)
-    const columnWidth = 100 - widthLeftHeader
-    return { widthLeftHeader, columnWidth }
 }

--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -181,10 +181,7 @@ function ArticleTable(props: {
                 horizontalPlotSpecs={plotSpecs}
                 verticalPlotSpecs={[]}
                 topLeftSpec={topLeftSpec}
-                widthLeftHeader={widthLeftHeader}
-                columnWidth={columnWidth}
-                onlyColumns={onlyColumns}
-                simpleOrdinals={simpleOrdinals}
+                layout={{ widthLeftHeader, columnWidth, onlyColumns, simpleOrdinals }}
             />
             <ArticleWarnings />
         </div>

--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -5,12 +5,10 @@ import React, { ReactNode, useCallback, useContext, useRef } from 'react'
 
 import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
-import { rowExpandedKey, useSetting, useSettings } from '../page_template/settings'
+import { useSetting, useSettings } from '../page_template/settings'
 import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
-import { statParents } from '../page_template/statistic-tree'
 import { PageTemplate } from '../page_template/template'
 import { Universe, universeContext, useDefinedUniverse, useUniverse } from '../universe'
-import { HumanReadableName } from '../utils/human-readable-name'
 import { sanitize } from '../utils/paths'
 import { Article, IRelatedButtons } from '../utils/protos'
 import { useComparisonHeadStyle, useHeaderTextClass, useMobileLayout, useSubHeaderTextClass } from '../utils/responsive'
@@ -22,10 +20,11 @@ import { ExternalLinks } from './ExternalLiinks'
 import { QuerySettingsConnection } from './QuerySettingsConnection'
 import { generateCSVDataForArticles, CSVExportData } from './csv-export'
 import { ArticleRow } from './load-article'
-import { pullRelevantPlotProps } from './plots'
+import { pullRelevantPlotProps, useExpandedByStat } from './plots'
 import { Related } from './related-button'
 import { createScreenshot, ScreencapElements, useScreenshotMode } from './screenshot'
 import { SearchBox } from './search'
+import { computeNameSpecsWithGroups, nameSpecsForRows } from './statistic-name-specs'
 import { CellSpec, PlotSpec, TableContents } from './supertable'
 import { ColumnIdentifier } from './table'
 
@@ -122,74 +121,24 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
     )
 }
 
-type NameSpec = Extract<CellSpec, { type: 'statistic-name' }>
-
-function getGroupAndDisplayNames(nameSpec: NameSpec, nameSpecs: NameSpec[]): [string | undefined, HumanReadableName] {
-    if (nameSpec.row === undefined) {
-        return [undefined, nameSpec.renderedStatname]
-    }
-    const statParent = statParents.get(nameSpec.row.statpath)
-
-    const groupRows = nameSpecs.filter(s => s.row !== undefined && statParents.get(s.row.statpath)?.group.id === statParent?.group.id)
-    const groupSize = groupRows.length
-
-    const groupSourcesSet = new Set(
-        groupRows
-            .map(s => statParents.get(s.row!.statpath)?.source)
-            .filter(source => source !== null)
-            .map(source => source!.name),
-    )
-    const groupHasMultipleSources = groupSourcesSet.size > 1
-
-    const sourceName = statParent?.source?.name
-    let displayName = groupSize > 1 ? (statParent?.indentedName ?? nameSpec.renderedStatname) : nameSpec.renderedStatname
-    if (groupHasMultipleSources && sourceName) {
-        displayName = `${displayName} [${sourceName}]`
-    }
-    const groupName = groupSize > 1 ? statParent?.group.name : undefined
-    return [groupName, displayName]
-}
-
-export function computeNameSpecsWithGroups(nameSpecs: NameSpec[]): { updatedNameSpecs: NameSpec[], groupNames: (string | undefined)[] } {
-    const updatedNameSpecs: NameSpec[] = []
-    const groupNames: (string | undefined)[] = []
-
-    for (const spec of nameSpecs) {
-        const [groupName, displayName] = getGroupAndDisplayNames(spec, nameSpecs)
-
-        updatedNameSpecs.push({
-            ...spec,
-            isIndented: groupName !== undefined,
-            displayName,
-        })
-        groupNames.push(groupName)
-    }
-
-    return { updatedNameSpecs, groupNames }
-}
-
 function ArticleTable(props: {
     filteredRows: ArticleRow[]
     article: Article
 }): ReactNode {
     const colors = useColors()
-    const expandedSettings = useSettings(props.filteredRows.map(row => rowExpandedKey(row.statpath)))
-    const expandedEach = props.filteredRows.map(row => row.extraStats.length > 0 && (expandedSettings[rowExpandedKey(row.statpath)] ?? false))
+    const expandedEach = useExpandedByStat(
+        props.filteredRows.map(row => row.statpath),
+        index => props.filteredRows[index].extraStats.length > 0,
+    )
     const currentUniverse = useDefinedUniverse()
     const [simpleOrdinals] = useSetting('simple_ordinals')
     const navContext = useContext(Navigator.Context)
 
     const { widthLeftHeader, columnWidth } = useWidths()
 
-    const statNameSpecs: Extract<CellSpec, { type: 'statistic-name' }>[] = props.filteredRows.map(row => ({
-        type: 'statistic-name',
-        longname: props.article.longname,
-        row,
-        renderedStatname: row.renderedStatname,
-        currentUniverse,
-    }))
-
-    const { updatedNameSpecs: leftHeaderSpecs, groupNames } = computeNameSpecsWithGroups(statNameSpecs)
+    const { updatedNameSpecs: leftHeaderSpecs, groupNames } = computeNameSpecsWithGroups(
+        nameSpecsForRows(props.filteredRows, props.article.longname, currentUniverse),
+    )
 
     const onlyColumns: ColumnIdentifier[] = ['statval', 'statval_unit', 'statistic_percentile', 'statistic_ordinal', 'pointer_in_class', 'pointer_overall']
     const cellSpecs: CellSpec[][] = props.filteredRows.map(row => [({

--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -9,8 +9,7 @@ import { rowExpandedKey, useSetting, useSettings } from '../page_template/settin
 import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
 import { statParents } from '../page_template/statistic-tree'
 import { PageTemplate } from '../page_template/template'
-import { Universe, universeContext, useUniverse } from '../universe'
-import { assert } from '../utils/defensive'
+import { Universe, universeContext, useDefinedUniverse, useUniverse } from '../universe'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { sanitize } from '../utils/paths'
 import { Article, IRelatedButtons } from '../utils/protos'
@@ -176,8 +175,7 @@ function ArticleTable(props: {
     const colors = useColors()
     const expandedSettings = useSettings(props.filteredRows.map(row => rowExpandedKey(row.statpath)))
     const expandedEach = props.filteredRows.map(row => row.extraStats.length > 0 && (expandedSettings[rowExpandedKey(row.statpath)] ?? false))
-    const currentUniverse = useUniverse()
-    assert(currentUniverse !== undefined, 'no universe')
+    const currentUniverse = useDefinedUniverse()
     const [simpleOrdinals] = useSetting('simple_ordinals')
     const navContext = useContext(Navigator.Context)
 

--- a/react/src/components/article-table.tsx
+++ b/react/src/components/article-table.tsx
@@ -1,0 +1,95 @@
+import React, { ReactNode, useContext } from 'react'
+
+import { Navigator } from '../navigation/Navigator'
+import { useColors } from '../page_template/colors'
+import { useSetting } from '../page_template/settings'
+import { useDefinedUniverse } from '../universe'
+import { Article } from '../utils/protos'
+import { useMobileLayout } from '../utils/responsive'
+
+import { ArticleWarnings } from './ArticleWarnings'
+import { ArticleRow } from './load-article'
+import { pullRelevantPlotProps, useExpandedByStat } from './plots'
+import { useScreenshotMode } from './screenshot'
+import { computeNameSpecsWithGroups, nameSpecsForRows } from './statistic-name-specs'
+import { CellSpec, PlotSpec, TableContents, TableLayout } from './supertable'
+import { ColumnIdentifier } from './table'
+
+const allColumns: ColumnIdentifier[] = ['statval', 'statval_unit', 'statistic_percentile', 'statistic_ordinal', 'pointer_in_class', 'pointer_overall']
+
+/** A plot for each row whose extras are currently expanded, and undefined for the rest. */
+function useExpandedPlotSpecs(rows: ArticleRow[], article: Article): (PlotSpec | undefined)[] {
+    const colors = useColors()
+    const expanded = useExpandedByStat(rows.map(row => row.statpath), index => rows[index].extraStats.length > 0)
+    return rows.map((row, index) => expanded[index]
+        ? {
+                statDescription: row.renderedStatname,
+                plotProps: pullRelevantPlotProps(rows, index, colors.hueColors.blue, article.shortname, article.longname, article.articleType),
+            }
+        : undefined,
+    )
+}
+
+function useArticleTableLayout(): TableLayout {
+    const [simpleOrdinals] = useSetting('simple_ordinals')
+    const isMobile = useMobileLayout()
+    const screenshotMode = useScreenshotMode()
+
+    // TODO clean this up and reduce the amount of magic numbers
+    const nonPointerColumns = 15 + 10 + (simpleOrdinals ? 7 + 8 : 17 + 25)
+    const pointerColumns = 8 * (screenshotMode ? 0 : (!simpleOrdinals && isMobile ? 1 : 2))
+    const numerator = 31
+    const denominator = nonPointerColumns + pointerColumns + numerator
+    const widthLeftHeader = 100 * (numerator / denominator)
+
+    return {
+        simpleOrdinals,
+        widthLeftHeader,
+        columnWidth: 100 - widthLeftHeader,
+        onlyColumns: allColumns,
+    }
+}
+
+export function ArticleTable(props: {
+    filteredRows: ArticleRow[]
+    article: Article
+}): ReactNode {
+    const currentUniverse = useDefinedUniverse()
+    const layout = useArticleTableLayout()
+    const navContext = useContext(Navigator.Context)
+
+    const { updatedNameSpecs: leftHeaderSpecs, groupNames } = computeNameSpecsWithGroups(
+        nameSpecsForRows(props.filteredRows, props.article.longname, currentUniverse),
+    )
+
+    const plotSpecs = useExpandedPlotSpecs(props.filteredRows, props.article)
+
+    const cellSpecs: CellSpec[][] = props.filteredRows.map(row => [({
+        type: 'statistic-row',
+        longname: props.article.longname,
+        row,
+        onNavigate: (newArticle) => {
+            void navContext.navigate({
+                kind: 'article',
+                longname: newArticle,
+                universe: currentUniverse,
+            }, { history: 'push', scroll: { kind: 'none' } })
+        },
+        simpleOrdinals: layout.simpleOrdinals,
+        onlyColumns: layout.onlyColumns,
+    })])
+
+    return (
+        <div className="stats_table">
+            <TableContents
+                layout={layout}
+                leftHeaderSpec={{ leftHeaderSpecs, groupNames }}
+                rowSpecs={cellSpecs}
+                horizontalPlotSpecs={plotSpecs}
+                verticalPlotSpecs={[]}
+                topLeftSpec={{ type: 'top-left-header' }}
+            />
+            <ArticleWarnings />
+        </div>
+    )
+}

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -9,7 +9,7 @@ import { FullscreenControl, MapRef } from 'react-map-gl/maplibre'
 import { boundingBox, extendBoxes } from '../map-partition'
 import { Navigator } from '../navigation/Navigator'
 import { colorFromCycle, useColors } from '../page_template/colors'
-import { rowExpandedKey, useSettings } from '../page_template/settings'
+import { useSettings } from '../page_template/settings'
 import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
 import { PageTemplate } from '../page_template/template'
 import { compareArticleRows } from '../sorting'
@@ -24,14 +24,14 @@ import { zIndex } from '../utils/zIndex'
 
 import { ArticleWarnings } from './ArticleWarnings'
 import { QuerySettingsConnection } from './QuerySettingsConnection'
-import { computeNameSpecsWithGroups } from './article-panel'
 import { generateCSVDataForArticles, CSVExportData } from './csv-export'
 import { ArticleRow, isCongressionalRepresentativesMetadataRow, isNoValue } from './load-article'
 import { CommonMaplibreMap, PolygonFeatureCollection, polygonFeatureCollection, useZoomAllFeatures, defaultMapPadding, CustomAttributionControlComponent } from './map-common'
-import { PlotProps, pullRelevantPlotProps } from './plots'
+import { PlotProps, pullRelevantPlotProps, useExpandedByStat } from './plots'
 import { createScreenshot, ScreencapElements, useScreenshotMode } from './screenshot'
 import { computeComparisonWidthColumns, computeMaxColumns, MaybeScroll } from './scrollable'
 import { SearchBox } from './search'
+import { computeNameSpecsWithGroups } from './statistic-name-specs'
 import { TableContents, CellSpec, PlotSpec } from './supertable'
 import { ColumnIdentifier } from './table'
 
@@ -161,9 +161,10 @@ export function ComparisonPanel(props: {
 
     const onlyColumns: ColumnIdentifier[] = includeOrdinals ? ['statval', 'statval_unit', 'statistic_ordinal', 'statistic_percentile'] : ['statval', 'statval_unit']
 
-    const expandedSettings = useSettings(dataByStatArticle.filter(statData => statData.some(row => row.extraStats.length > 0)).map(([{ statpath }]) => rowExpandedKey(statpath)))
-
-    const expandedByStatIndex = dataByStatArticle.map(([{ statpath }]) => expandedSettings[rowExpandedKey(statpath)] ?? false)
+    const expandedByStatIndex = useExpandedByStat(
+        dataByStatArticle.map(([{ statpath }]) => statpath),
+        statIndex => dataByStatArticle[statIndex].some(row => row.extraStats.length > 0),
+    )
     const numExpandedExtras = expandedByStatIndex.filter(v => v).length
 
     let widthColumns = computeComparisonWidthColumns(localArticlesToUse.length, includeOrdinals)

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -32,8 +32,8 @@ import { createScreenshot, ScreencapElements, useScreenshotMode } from './screen
 import { computeComparisonWidthColumns, computeMaxColumns, MaybeScroll } from './scrollable'
 import { SearchBox } from './search'
 import { computeNameSpecsWithGroups } from './statistic-name-specs'
-import { TableContents, CellSpec, PlotSpec } from './supertable'
-import { ColumnIdentifier } from './table'
+import { TableContents, CellSpec, PlotSpec, TableLayout } from './supertable'
+import { ColumnIdentifier, valueOnlyColumns } from './table'
 
 export function ComparisonPanel(props: {
     universe: Universe
@@ -159,7 +159,7 @@ export function ComparisonPanel(props: {
         && (validOrdinalsByStat.length === 0 || validOrdinalsByStat.some(x => x))
     )
 
-    const onlyColumns: ColumnIdentifier[] = includeOrdinals ? ['statval', 'statval_unit', 'statistic_ordinal', 'statistic_percentile'] : ['statval', 'statval_unit']
+    const onlyColumns: ColumnIdentifier[] = includeOrdinals ? ['statval', 'statval_unit', 'statistic_ordinal', 'statistic_percentile'] : valueOnlyColumns
 
     const expandedByStatIndex = useExpandedByStat(
         dataByStatArticle.map(([{ statpath }]) => statpath),
@@ -292,6 +292,32 @@ export function ComparisonPanel(props: {
 
     const topLeftSpec: CellSpec = { type: 'comparison-top-left-header', statNameOverride: transpose ? 'Region' : undefined }
 
+    const layout: TableLayout = {
+        widthLeftHeader: leftMarginPercent * 100,
+        columnWidth,
+        onlyColumns,
+        simpleOrdinals: true,
+    }
+
+    // Transposing swaps which axis the statistics run along, so it swaps the headers, the
+    // row specs, and which direction the expanded plots stretch in. Everything else about
+    // the table is the same either way.
+    const orientedSpecs = transpose
+        ? {
+                superHeaderSpec: { headerSpecs: statisticNameHeaderSpecs, showBottomBar: false, groupNames: statisticNameGroupNames },
+                leftHeaderSpec: { leftHeaderSpecs: longnameHeaderSpecs },
+                rowSpecs: rowSpecsByStatTransposed,
+                horizontalPlotSpecs: plotSpecs.map(() => undefined),
+                verticalPlotSpecs: plotSpecs,
+            }
+        : {
+                superHeaderSpec: { headerSpecs: longnameHeaderSpecs, showBottomBar: true },
+                leftHeaderSpec: { leftHeaderSpecs: statisticNameHeaderSpecs, groupNames: statisticNameGroupNames },
+                rowSpecs: rowSpecsByStat,
+                horizontalPlotSpecs: plotSpecs,
+                verticalPlotSpecs: [],
+            }
+
     const csvExportCallback = useCallback<CSVExportData>(() => {
         const data = generateCSVDataForArticles(localArticlesToUse, dataByArticleStat, includeOrdinals)
         const filename = `${sanitize(joinedString)}.csv`
@@ -357,35 +383,11 @@ export function ComparisonPanel(props: {
 
                                 <MaybeScroll widthColumns={widthColumns}>
                                     <div ref={tableRef}>
-                                        {transpose
-                                            ? (
-                                                    <TableContents
-                                                        superHeaderSpec={{ headerSpecs: statisticNameHeaderSpecs, showBottomBar: false, groupNames: statisticNameGroupNames }}
-                                                        leftHeaderSpec={{ leftHeaderSpecs: longnameHeaderSpecs }}
-                                                        rowSpecs={rowSpecsByStatTransposed}
-                                                        horizontalPlotSpecs={plotSpecs.map(() => undefined)}
-                                                        verticalPlotSpecs={plotSpecs}
-                                                        topLeftSpec={topLeftSpec}
-                                                        widthLeftHeader={leftMarginPercent * 100}
-                                                        columnWidth={columnWidth}
-                                                        onlyColumns={onlyColumns}
-                                                        simpleOrdinals={true}
-                                                    />
-                                                )
-                                            : (
-                                                    <TableContents
-                                                        superHeaderSpec={{ headerSpecs: longnameHeaderSpecs, showBottomBar: true }}
-                                                        leftHeaderSpec={{ leftHeaderSpecs: statisticNameHeaderSpecs, groupNames: statisticNameGroupNames }}
-                                                        rowSpecs={rowSpecsByStat}
-                                                        horizontalPlotSpecs={plotSpecs}
-                                                        verticalPlotSpecs={[]}
-                                                        topLeftSpec={topLeftSpec}
-                                                        widthLeftHeader={leftMarginPercent * 100}
-                                                        columnWidth={columnWidth}
-                                                        onlyColumns={onlyColumns}
-                                                        simpleOrdinals={true}
-                                                    />
-                                                )}
+                                        <TableContents
+                                            layout={layout}
+                                            {...orientedSpecs}
+                                            topLeftSpec={topLeftSpec}
+                                        />
                                         <ArticleWarnings />
                                     </div>
                                 </MaybeScroll>

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -3,7 +3,7 @@ import './article.css'
 
 import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, PointerSensor, TouchSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core'
 import { SortableContext, arrayMove, horizontalListSortingStrategy, verticalListSortingStrategy } from '@dnd-kit/sortable'
-import React, { ReactNode, useCallback, useContext, useId, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, useContext, useId, useMemo, useRef, useState } from 'react'
 import { FullscreenControl, MapRef } from 'react-map-gl/maplibre'
 
 import { boundingBox, extendBoxes } from '../map-partition'
@@ -24,7 +24,7 @@ import { zIndex } from '../utils/zIndex'
 
 import { ArticleWarnings } from './ArticleWarnings'
 import { QuerySettingsConnection } from './QuerySettingsConnection'
-import { generateCSVDataForArticles, CSVExportData } from './csv-export'
+import { useCSVExport } from './csv-export'
 import { ArticleRow, isCongressionalRepresentativesMetadataRow, isNoValue } from './load-article'
 import { CommonMaplibreMap, PolygonFeatureCollection, polygonFeatureCollection, useZoomAllFeatures, defaultMapPadding, CustomAttributionControlComponent } from './map-common'
 import { PlotProps, pullRelevantPlotProps, useExpandedByStat } from './plots'
@@ -318,11 +318,7 @@ export function ComparisonPanel(props: {
                 verticalPlotSpecs: [],
             }
 
-    const csvExportCallback = useCallback<CSVExportData>(() => {
-        const data = generateCSVDataForArticles(localArticlesToUse, dataByArticleStat, includeOrdinals)
-        const filename = `${sanitize(joinedString)}.csv`
-        return { csvData: data, csvFilename: filename }
-    }, [joinedString, localArticlesToUse, dataByArticleStat, includeOrdinals])
+    const csvExportCallback = useCSVExport(localArticlesToUse, props.rows, includeOrdinals, joinedString)
 
     return (
         <universeContext.Provider value={{

--- a/react/src/components/congressional-table/model.ts
+++ b/react/src/components/congressional-table/model.ts
@@ -1,3 +1,6 @@
+import { assert } from '../../utils/defensive'
+import { MetadataStatValue } from '../load-article'
+
 export interface CongressionalRepresentativeEntry {
     representative: {
         name: string
@@ -12,6 +15,35 @@ export interface CongressionalRepresentativeEntry {
 export interface CongressionalColumnData {
     longname: string
     representatives: CongressionalRepresentativeEntry[]
+}
+
+/**
+ * Returns undefined for rows that aren't a representatives metadata row. Takes the
+ * row structurally so it works with both ArticleRow and StatisticCellRenderingInfo.
+ */
+export function congressionalDataForRow(
+    row: { kind: 'statistic' } | { kind: 'metadata', statval: MetadataStatValue },
+    longname: string,
+): CongressionalColumnData | undefined {
+    if (row.kind !== 'metadata' || typeof row.statval === 'string') {
+        return undefined
+    }
+    return {
+        longname,
+        representatives: row.statval.representatives.map((r): CongressionalRepresentativeEntry => {
+            assert(r.representative.name !== undefined && r.representative.name !== null, 'representative name missing')
+            return {
+                representative: {
+                    name: r.representative.name,
+                    wikipediaPage: r.representative.wikipediaPage ?? undefined,
+                    party: r.representative.party ?? undefined,
+                },
+                districtLongname: r.districtLongname,
+                startTerm: r.startTerm,
+                endTerm: r.endTerm,
+            }
+        }),
+    }
 }
 
 export interface CongressionalDisplayHeaderSpaceRow {

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -2,15 +2,37 @@ import assert from 'assert'
 
 import { stringify } from 'csv-stringify/sync'
 import { saveAs } from 'file-saver'
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useCallback, useContext } from 'react'
 
+import { Settings } from '../page_template/settings'
+import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
 import { USSOpaqueValue, USSValue } from '../urban-stats-script/types-values'
 import { HumanReadableName, reifyString } from '../utils/human-readable-name'
+import { sanitize } from '../utils/paths'
 import { Article } from '../utils/protos'
 
 import { ArticleRow } from './load-article'
 
 export type CSVExportData = () => { csvData: string[][], csvFilename: string }
+
+/**
+ * The CSV export for a table of articles, named after `filenameBase`.
+ *
+ * The rows are built from the settings read at the moment the export is requested, so the
+ * caller doesn't have to hold them for the export's sake.
+ */
+export function useCSVExport(
+    articles: Article[],
+    rows: (settings: StatGroupSettings) => ArticleRow[][],
+    includeOrdinals: boolean,
+    filenameBase: string,
+): CSVExportData {
+    const settings = useContext(Settings.Context)
+    return useCallback(() => ({
+        csvData: generateCSVDataForArticles(articles, rows(settings.getMultiple(groupYearKeys())), includeOrdinals),
+        csvFilename: `${sanitize(filenameBase)}.csv`,
+    }), [articles, rows, settings, includeOrdinals, filenameBase])
+}
 
 export function exportToCSV(data: string[][], filename: string): void {
     // Use csv-stringify library for proper CSV generation
@@ -45,7 +67,7 @@ export function CSVButton(props: { onClick: () => void }): ReactNode {
     )
 }
 
-export function generateCSVDataForArticles(
+function generateCSVDataForArticles(
     articles: Article[],
     dataByArticleStat: ArticleRow[][],
     includeOrdinals: boolean,

--- a/react/src/components/plots.tsx
+++ b/react/src/components/plots.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
-import { PlotMode, useSetting } from '../page_template/settings'
+import { PlotMode, rowExpandedKey, useSetting, useSettings } from '../page_template/settings'
 import { statParents, StatPath, Year } from '../page_template/statistic-tree'
 import { assert } from '../utils/defensive'
 
@@ -206,6 +206,15 @@ function resolveStatYears(rows: ArticleRow[], statIndex: number): { idx: number,
         assert(chosen.length === new Set(chosen.map(c => c.year)).size, 'All statpaths for plot data should have unique years')
     }
     return chosen
+}
+
+/**
+ * Whether each statistic's extras are currently expanded, in statistic order. Only the
+ * statistics that have extras are subscribed to, since the rest can never be expanded.
+ */
+export function useExpandedByStat(statpaths: StatPath[], hasExtras: (statIndex: number) => boolean): boolean[] {
+    const expandedSettings = useSettings(statpaths.filter((_, index) => hasExtras(index)).map(rowExpandedKey))
+    return statpaths.map(statpath => expandedSettings[rowExpandedKey(statpath)] ?? false)
 }
 
 export function pullRelevantPlotProps(rows: ArticleRow[], statIndex: number, color: string, shortname: string, longname: string, sharedTypeOfAllArticles: string | undefined): PlotProps[] {

--- a/react/src/components/related-button.tsx
+++ b/react/src/components/related-button.tsx
@@ -7,11 +7,10 @@ import { Navigator } from '../navigation/Navigator'
 import { HueColors } from '../page_template/color-themes'
 import { useColors } from '../page_template/colors'
 import { relationshipKey, useSettings } from '../page_template/settings'
-import { useUniverse } from '../universe'
+import { useDefinedUniverse, useUniverse } from '../universe'
 import { DefaultMap } from '../utils/DefaultMap'
 import { withButtonRole } from '../utils/a11y'
 import { mixWithBackground } from '../utils/color'
-import { assert } from '../utils/defensive'
 import { useMobileLayout } from '../utils/responsive'
 import { isAllowedToBeShown } from '../utils/restricted-types'
 import { displayType } from '../utils/text'
@@ -237,8 +236,7 @@ function Row(props: {
 
     const checkId = useId()
 
-    const universe = useUniverse()
-    assert(universe !== undefined, 'no universe')
+    const universe = useDefinedUniverse()
 
     return (
         <li style={{
@@ -306,8 +304,7 @@ export function Related(props: { articleType: string, related: { relationshipTyp
     const showSettings = useSettings(['show_historical_cds', 'show_person_circles'])
     const buttons = new DefaultMap<string, DefaultMap<string, Region[]>>(() => new DefaultMap(() => []))
 
-    const universe = useUniverse()
-    assert(universe !== undefined, 'no universe')
+    const universe = useDefinedUniverse()
 
     const [searchTerm, setSearchTerm] = useState('')
 

--- a/react/src/components/statistic-name-specs.ts
+++ b/react/src/components/statistic-name-specs.ts
@@ -1,0 +1,82 @@
+import { statParents } from '../page_template/statistic-tree'
+import { Universe } from '../universe'
+import { HumanReadableName } from '../utils/human-readable-name'
+
+import { ArticleRow } from './load-article'
+import { CellSpec } from './supertable'
+
+export type NameSpec = Extract<CellSpec, { type: 'statistic-name' }>
+
+interface GroupAggregate {
+    size: number
+    sourceNames: Set<string>
+}
+
+/** Tallies each group once, so naming stays linear in the number of specs. */
+function aggregateByGroup(nameSpecs: NameSpec[]): Map<string | undefined, GroupAggregate> {
+    const aggregates = new Map<string | undefined, GroupAggregate>()
+    for (const spec of nameSpecs) {
+        if (spec.row === undefined) {
+            continue
+        }
+        const statParent = statParents.get(spec.row.statpath)
+        let aggregate = aggregates.get(statParent?.group.id)
+        if (aggregate === undefined) {
+            aggregate = { size: 0, sourceNames: new Set() }
+            aggregates.set(statParent?.group.id, aggregate)
+        }
+        aggregate.size++
+        if (statParent?.source !== null && statParent?.source !== undefined) {
+            aggregate.sourceNames.add(statParent.source.name)
+        }
+    }
+    return aggregates
+}
+
+function getGroupAndDisplayNames(nameSpec: NameSpec, aggregates: Map<string | undefined, GroupAggregate>): [string | undefined, HumanReadableName] {
+    if (nameSpec.row === undefined) {
+        return [undefined, nameSpec.renderedStatname]
+    }
+    const statParent = statParents.get(nameSpec.row.statpath)
+    const aggregate = aggregates.get(statParent?.group.id)!
+    const groupSize = aggregate.size
+    const groupHasMultipleSources = aggregate.sourceNames.size > 1
+
+    const sourceName = statParent?.source?.name
+    let displayName = groupSize > 1 ? (statParent?.indentedName ?? nameSpec.renderedStatname) : nameSpec.renderedStatname
+    if (groupHasMultipleSources && sourceName) {
+        displayName = `${displayName} [${sourceName}]`
+    }
+    const groupName = groupSize > 1 ? statParent?.group.name : undefined
+    return [groupName, displayName]
+}
+
+export function computeNameSpecsWithGroups(nameSpecs: NameSpec[]): { updatedNameSpecs: NameSpec[], groupNames: (string | undefined)[] } {
+    const updatedNameSpecs: NameSpec[] = []
+    const groupNames: (string | undefined)[] = []
+    const aggregates = aggregateByGroup(nameSpecs)
+
+    for (const spec of nameSpecs) {
+        const [groupName, displayName] = getGroupAndDisplayNames(spec, aggregates)
+
+        updatedNameSpecs.push({
+            ...spec,
+            isIndented: groupName !== undefined,
+            displayName,
+        })
+        groupNames.push(groupName)
+    }
+
+    return { updatedNameSpecs, groupNames }
+}
+
+/** The name cell spec for each row, before `computeNameSpecsWithGroups` fills in display names. */
+export function nameSpecsForRows(rows: ArticleRow[], longname: string, currentUniverse: Universe): NameSpec[] {
+    return rows.map(row => ({
+        type: 'statistic-name',
+        longname,
+        row,
+        renderedStatname: row.renderedStatname,
+        currentUniverse,
+    }))
+}

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -272,7 +272,12 @@ function StatisticTableRow(props: {
     isHighlighted?: boolean
 }): ReactNode {
     const { layout, cellSpecs } = props
-    const congressionalRegions = useMemo(() => congressionalRegionsForCells(cellSpecs), [cellSpecs])
+    /*
+     * Deliberately not memoized. The representatives widget only puts the terms that were
+     * on screen into a screenshot, and it re-measures which those are off a change of
+     * identity here -- so holding this steady across renders empties the screenshot.
+     */
+    const congressionalRegions = congressionalRegionsForCells(cellSpecs)
 
     return (
         <>

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -2,12 +2,11 @@ import React, { CSSProperties, Fragment, ReactNode, useMemo } from 'react'
 
 import { RelativeLoader } from '../navigation/loading'
 import { useColors } from '../page_template/colors'
-import { Universe, useUniverse } from '../universe'
-import { assert } from '../utils/defensive'
+import { Universe, useDefinedUniverse } from '../universe'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { Article } from '../utils/protos'
 
-import { CongressionalColumnData, CongressionalRepresentativeEntry } from './congressional-table/model'
+import { CongressionalColumnData, congressionalDataForRow } from './congressional-table/model'
 import { CongressionalRepresentativesWidget } from './congressional-table/render'
 import { ArticleRow, StatisticCellRenderingInfo } from './load-article'
 import { extraHeaderSpaceForVertical, PlotProps, RenderedPlot } from './plots'
@@ -52,10 +51,9 @@ export interface TableContentsProps {
 }
 
 export function TableContents(props: TableContentsProps): ReactNode {
-    const universe = useUniverse()
+    const universe = useDefinedUniverse()
     const colors = useColors()
     const screenshotMode = useScreenshotMode()
-    assert(universe !== undefined, 'no universe')
 
     const rowsForFootnotes = useMemo(() => {
         const fromLeft = props.leftHeaderSpec.leftHeaderSpecs.filter((s): s is CellSpec & { type: 'statistic-name', row: ArticleRow } =>
@@ -198,33 +196,7 @@ function SuperTableRow(props: {
     extraSpaceRight: number[]
     isHighlighted: boolean
 }): ReactNode {
-    const congressionalRegions = useMemo(() => props.cellSpecs.flatMap((cell) => {
-        if (cell.type !== 'statistic-row') {
-            return []
-        }
-        if (cell.row.kind !== 'metadata') {
-            return []
-        }
-        if (typeof cell.row.statval === 'string') {
-            return []
-        }
-        return [{
-            longname: cell.longname,
-            representatives: cell.row.statval.representatives.map((r): CongressionalRepresentativeEntry => {
-                assert(r.representative.name !== undefined && r.representative.name !== null, 'representative name missing')
-                return {
-                    representative: {
-                        name: r.representative.name,
-                        wikipediaPage: r.representative.wikipediaPage ?? undefined,
-                        party: r.representative.party ?? undefined,
-                    },
-                    districtLongname: r.districtLongname,
-                    startTerm: r.startTerm,
-                    endTerm: r.endTerm,
-                }
-            }),
-        } satisfies CongressionalColumnData]
-    }), [props.cellSpecs])
+    const congressionalRegions = useMemo(() => congressionalRegionsForCells(props.cellSpecs), [props.cellSpecs])
 
     return (
         <div>
@@ -261,6 +233,17 @@ function SuperTableRow(props: {
             )}
         </div>
     )
+}
+
+/** The representatives tables a row's cells call for, in column order. */
+function congressionalRegionsForCells(cellSpecs: CellSpec[]): CongressionalColumnData[] {
+    return cellSpecs.flatMap((cell) => {
+        if (cell.type !== 'statistic-row') {
+            return []
+        }
+        const data = congressionalDataForRow(cell.row, cell.longname)
+        return data === undefined ? [] : [data]
+    })
 }
 
 export type CellSpec = ({ type: 'comparison-longname' } & ComparisonLongnameCellProps) |

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -11,7 +11,7 @@ import { CongressionalRepresentativesWidget } from './congressional-table/render
 import { ArticleRow, StatisticCellRenderingInfo } from './load-article'
 import { extraHeaderSpaceForVertical, PlotProps, RenderedPlot } from './plots'
 import { useScreenshotMode } from './screenshot'
-import { ColumnIdentifier, MainHeaderRow, ComparisonLongnameCell, ComparisonTopLeftHeader, SuperHeaderHorizontal, StatisticNameCell, StatisticPanelLongnameCell, StatisticRowCells, TableHeaderContainer, TableRowContainer, TopLeftHeader, computeDisclaimerFootnotes, computeSizesForRow, CommonLayoutInformation } from './table'
+import { ColumnIdentifier, MainHeaderRow, ComparisonLongnameCell, ComparisonTopLeftHeader, SuperHeaderHorizontal, StatisticNameCell, StatisticPanelLongnameCell, StatisticRowCells, TableHeaderContainer, TableRowContainer, TopLeftHeader, computeDisclaimerFootnotes, maxLayoutInformation, CommonLayoutInformation } from './table'
 
 export interface PlotSpec {
     statDescription: string
@@ -35,17 +35,52 @@ export interface DisclaimerFootnote {
     text: string
 }
 
+/** The column shape a table's rows are laid out against. */
+export interface TableLayout {
+    widthLeftHeader: number
+    columnWidth: number
+    onlyColumns: ColumnIdentifier[]
+    simpleOrdinals: boolean
+}
+
+/** A `TableLayout` with its columns measured, which is what rows are actually rendered against. */
+export interface MeasuredTableLayout extends TableLayout {
+    /** One entry per column, which is also what the column count is read from. */
+    columnWidthsInfo: (CommonLayoutInformation | undefined)[]
+    /** The space reserved to the right of each column, which a vertical plot occupies. */
+    extraSpaceRight: number[]
+}
+
+/** Measures each column against the rows it contains. */
+function measureColumns(columnRows: StatisticCellRenderingInfo[][], universe: Universe, simpleOrdinals: boolean): CommonLayoutInformation[] {
+    return columnRows.map(rows => maxLayoutInformation(rows, universe, simpleOrdinals))
+}
+
+/**
+ * The layout rows are rendered against. `extraSpaceRight` is asked for per column rather
+ * than passed as an array, so it can't disagree with the measurements about the column count.
+ */
+function measuredLayout(layout: TableLayout, columnWidthsInfo: CommonLayoutInformation[], extraSpaceRight: (columnIndex: number) => number): MeasuredTableLayout {
+    return {
+        ...layout,
+        columnWidthsInfo,
+        extraSpaceRight: columnWidthsInfo.map((_, columnIndex) => extraSpaceRight(columnIndex)),
+    }
+}
+
+/** Each column's width including the space reserved to its right. */
+function columnFullWidths(layout: MeasuredTableLayout): number[] {
+    return layout.extraSpaceRight.map(extra => layout.columnWidth + extra)
+}
+
 export interface TableContentsProps {
+    layout: TableLayout
     superHeaderSpec?: SuperHeaderSpec
     leftHeaderSpec: LeftHeaderSpec
     rowSpecs: CellSpec[][]
     horizontalPlotSpecs: (PlotSpec | undefined)[]
     verticalPlotSpecs: (PlotSpec | undefined)[]
     topLeftSpec: CellSpec
-    widthLeftHeader: number
-    columnWidth: number
-    onlyColumns: ColumnIdentifier[]
-    simpleOrdinals: boolean
     highlightRowIndex?: number
     loading?: boolean
 }
@@ -54,104 +89,68 @@ export function TableContents(props: TableContentsProps): ReactNode {
     const universe = useDefinedUniverse()
     const colors = useColors()
     const screenshotMode = useScreenshotMode()
+    const { widthLeftHeader, columnWidth, simpleOrdinals } = props.layout
 
-    const rowsForFootnotes = useMemo(() => {
-        const fromLeft = props.leftHeaderSpec.leftHeaderSpecs.filter((s): s is CellSpec & { type: 'statistic-name', row: ArticleRow } =>
-            s.type === 'statistic-name' && s.row !== undefined,
-        ).map(s => s.row)
-        const fromSuper = (props.superHeaderSpec?.headerSpecs ?? []).filter((s): s is CellSpec & { type: 'statistic-name', row: ArticleRow } =>
-            s.type === 'statistic-name' && s.row !== undefined,
-        ).map(s => s.row)
-        return [...fromLeft, ...fromSuper]
-    }, [props.leftHeaderSpec.leftHeaderSpecs, props.superHeaderSpec?.headerSpecs])
-    const disclaimerFootnotes = useMemo(() => computeDisclaimerFootnotes(rowsForFootnotes), [rowsForFootnotes])
+    const { leftHeaderSpecs } = props.leftHeaderSpec
+    const superHeaderSpecs = props.superHeaderSpec?.headerSpecs
+
+    const disclaimerFootnotes = useMemo(
+        () => computeDisclaimerFootnotes([...leftHeaderSpecs, ...(superHeaderSpecs ?? [])]),
+        [leftHeaderSpecs, superHeaderSpecs],
+    )
+
+    // In screenshot mode the disclaimers move into numbered footnotes below the table, so the
+    // cells that carry one need to show the symbol that points at theirs.
+    const withFootnote = (spec: CellSpec): CellSpec =>
+        screenshotMode && spec.type === 'statistic-name' && spec.row?.disclaimer !== undefined
+            ? { ...spec, footnoteSymbol: disclaimerFootnotes.getSymbol(spec.row.disclaimer) }
+            : spec
 
     const headerHeight = props.verticalPlotSpecs.flatMap(p => p === undefined ? [] : p.plotProps).map(p => extraHeaderSpaceForVertical(p)).reduce((a, b) => Math.max(a, b), 0)
     const contentHeight = '379.5px'
 
     const shouldSetMinHeight = props.verticalPlotSpecs.some(p => p !== undefined)
     const overallMinHeight = shouldSetMinHeight ? `calc(${headerHeight}px + ${contentHeight})` : undefined
-    const rowMinHeight = shouldSetMinHeight ? `calc(${contentHeight} / ${props.leftHeaderSpec.leftHeaderSpecs.length})` : undefined
+    const rowMinHeight = shouldSetMinHeight ? `calc(${contentHeight} / ${leftHeaderSpecs.length})` : undefined
 
     // should be 1 column, unless there are header specs. only use header specs if we can't infer from the cells.
-    const ncols = props.rowSpecs.length !== 0 ? props.rowSpecs[0].length : props.superHeaderSpec?.headerSpecs.length ?? 1
+    const ncols = props.rowSpecs.length !== 0 ? props.rowSpecs[0].length : superHeaderSpecs?.length ?? 1
 
-    const extraSpaceRight = Array.from({ length: ncols }).map((_, i) => (props.verticalPlotSpecs[i] === undefined ? 0 : props.columnWidth))
-    const columnFullWidths = extraSpaceRight.map(extra => props.columnWidth + extra)
+    const columnRows = Array.from({ length: ncols }).map((_, colIndex) => props.rowSpecs.flatMap((row) => {
+        const cell = row[colIndex]
+        return cell.type === 'statistic-row' ? [cell.row] : []
+    }))
 
-    const columnWidthsInfo = Array.from({ length: ncols }).map((_, colIndex) => {
-        const widthsEach = props.rowSpecs.map(row => row[colIndex].type === 'statistic-row' ? computeSizesForRow(row[colIndex].row, universe, props.simpleOrdinals) : undefined)
-        const maxima = widthsEach.reduce((acc, curr) => {
-            if (curr === undefined) {
-                return acc
-            }
-            else if (acc === undefined) {
-                return curr
-            }
-            return {
-                ordinalColumnWidthEm: Math.max(acc.ordinalColumnWidthEm, curr.ordinalColumnWidthEm),
-                percentileColumnWidthEm: Math.max(acc.percentileColumnWidthEm, curr.percentileColumnWidthEm),
-                ordinalColumnPadding: Math.max(acc.ordinalColumnPadding, curr.ordinalColumnPadding),
-            }
-        }, { ordinalColumnWidthEm: 0, percentileColumnWidthEm: 0, ordinalColumnPadding: 0 })
-        return maxima
-    })
+    const layout = measuredLayout(
+        props.layout,
+        measureColumns(columnRows, universe, simpleOrdinals),
+        colIndex => props.verticalPlotSpecs[colIndex] === undefined ? 0 : columnWidth,
+    )
+    const fullWidths = columnFullWidths(layout)
+
+    const superHeaderSpec = props.superHeaderSpec === undefined
+        ? undefined
+        : { ...props.superHeaderSpec, headerSpecs: props.superHeaderSpec.headerSpecs.map(withFootnote) }
 
     return (
         <>
-            {props.superHeaderSpec !== undefined && (
-                <SuperHeaderHorizontal
-                    {...props.superHeaderSpec}
-                    headerSpecs={props.superHeaderSpec.headerSpecs.map((spec) => {
-                        if (screenshotMode && spec.type === 'statistic-name' && spec.row?.disclaimer !== undefined) {
-                            return { ...spec, footnoteSymbol: disclaimerFootnotes.getSymbol(spec.row.disclaimer) }
-                        }
-                        return spec
-                    })}
-                    leftSpacerWidth={props.widthLeftHeader}
-                    widthsEach={columnFullWidths}
-                />
-            )}
-
-            <div style={{ position: 'relative', minHeight: overallMinHeight }}>
-                <TableHeaderContainer>
-                    <MainHeaderRow
-                        columnWidth={props.columnWidth}
-                        topLeftSpec={props.topLeftSpec}
-                        topLeftWidth={props.widthLeftHeader}
-                        onlyColumns={props.onlyColumns}
-                        extraSpaceRight={extraSpaceRight}
-                        simpleOrdinals={props.simpleOrdinals}
-                        columnWidthsInfo={columnWidthsInfo}
-                    />
-                </TableHeaderContainer>
+            <TableFrame
+                layout={layout}
+                topLeftSpec={props.topLeftSpec}
+                superHeaderSpec={superHeaderSpec}
+                minHeight={overallMinHeight}
+            >
                 {props.rowSpecs.map((rowSpecsForItem, rowIndex) => {
                     const plotSpec = props.horizontalPlotSpecs[rowIndex]
                     return (
                         <SuperTableRow
                             key={`TableRowContainer_${rowIndex}`}
+                            layout={layout}
                             rowIndex={rowIndex}
                             rowMinHeight={rowMinHeight}
-                            cellSpecs={rowSpecsForItem.map((cellSpec, colIndex) => {
-                                if (cellSpec.type === 'statistic-row') {
-                                    return {
-                                        ...cellSpec,
-                                        columnWidthsInfo: columnWidthsInfo[colIndex],
-                                    }
-                                }
-                                return cellSpec
-                            })}
-                            extraSpaceRight={extraSpaceRight}
+                            cellSpecs={rowSpecsForItem}
                             plotSpec={plotSpec}
-                            leftHeaderSpec={(() => {
-                                const spec = props.leftHeaderSpec.leftHeaderSpecs[rowIndex]
-                                if (screenshotMode && spec.type === 'statistic-name' && spec.row?.disclaimer !== undefined) {
-                                    return { ...spec, footnoteSymbol: disclaimerFootnotes.getSymbol(spec.row.disclaimer) }
-                                }
-                                return spec
-                            })()}
-                            widthLeftHeader={props.widthLeftHeader}
-                            columnWidth={props.columnWidth}
+                            leftHeaderSpec={withFootnote(leftHeaderSpecs[rowIndex])}
                             groupName={props.leftHeaderSpec.groupNames?.[rowIndex]}
                             prevGroupName={rowIndex > 0 ? props.leftHeaderSpec.groupNames?.[rowIndex - 1] : undefined}
                             isHighlighted={props.highlightRowIndex === rowIndex}
@@ -160,14 +159,14 @@ export function TableContents(props: TableContentsProps): ReactNode {
                 })}
                 {props.verticalPlotSpecs.map((plotSpec, statIndex) => plotSpec
                     ? (
-                            <div key={`statPlot_${statIndex}`} style={{ position: 'absolute', top: 0, left: `${props.widthLeftHeader + Array.from({ length: statIndex }).reduce((acc: number, unused, i) => acc + columnFullWidths[i], props.columnWidth)}%`, bottom: 0, width: `${props.columnWidth}%` }}>
+                            <div key={`statPlot_${statIndex}`} style={{ position: 'absolute', top: 0, left: `${widthLeftHeader + Array.from({ length: statIndex }).reduce((acc: number, unused, i) => acc + fullWidths[i], columnWidth)}%`, bottom: 0, width: `${columnWidth}%` }}>
                                 <RenderedPlot statDescription={plotSpec.statDescription} plotProps={plotSpec.plotProps} />
                             </div>
                         )
                     : null,
                 )}
                 <RelativeLoader loading={props.loading ?? false} />
-            </div>
+            </TableFrame>
             {screenshotMode && disclaimerFootnotes.footnotes.length > 0 && (
                 <div className="disclaimer-footnotes serif" style={{ fontSize: '0.85em', marginTop: '1em', color: colors.textMain }}>
                     {disclaimerFootnotes.footnotes.map(({ symbol, text }) => (
@@ -183,21 +182,57 @@ export function TableContents(props: TableContentsProps): ReactNode {
     )
 }
 
+/**
+ * Everything a table has above its rows -- the optional super header, and the main header
+ * row of column names -- plus the positioned container the rows themselves live in, which
+ * the vertical plots are absolutely positioned against.
+ */
+function TableFrame(props: {
+    layout: MeasuredTableLayout
+    superHeaderSpec?: SuperHeaderSpec
+    topLeftSpec: CellSpec
+    minHeight?: string
+    children: ReactNode
+}): ReactNode {
+    const { widthLeftHeader, columnWidth, onlyColumns, simpleOrdinals, columnWidthsInfo, extraSpaceRight } = props.layout
+    return (
+        <>
+            {props.superHeaderSpec !== undefined && (
+                <SuperHeaderHorizontal
+                    {...props.superHeaderSpec}
+                    leftSpacerWidth={widthLeftHeader}
+                    widthsEach={columnFullWidths(props.layout)}
+                />
+            )}
+            <div style={{ position: 'relative', minHeight: props.minHeight }}>
+                <TableHeaderContainer>
+                    <MainHeaderRow
+                        columnWidth={columnWidth}
+                        topLeftSpec={props.topLeftSpec}
+                        topLeftWidth={widthLeftHeader}
+                        onlyColumns={onlyColumns}
+                        extraSpaceRight={extraSpaceRight}
+                        simpleOrdinals={simpleOrdinals}
+                        columnWidthsInfo={columnWidthsInfo}
+                    />
+                </TableHeaderContainer>
+                {props.children}
+            </div>
+        </>
+    )
+}
+
 function SuperTableRow(props: {
+    layout: MeasuredTableLayout
     rowIndex: number
     leftHeaderSpec: CellSpec
     cellSpecs: CellSpec[]
     plotSpec?: PlotSpec
-    widthLeftHeader: number
-    columnWidth: number
     rowMinHeight?: string
     groupName?: string
     prevGroupName?: string
-    extraSpaceRight: number[]
     isHighlighted: boolean
 }): ReactNode {
-    const congressionalRegions = useMemo(() => congressionalRegionsForCells(props.cellSpecs), [props.cellSpecs])
-
     return (
         <div>
             {props.groupName !== undefined && (props.groupName !== props.prevGroupName) && (
@@ -209,14 +244,41 @@ function SuperTableRow(props: {
                     </div>
                 </TableRowContainer>
             )}
-            <TableRowContainer index={props.rowIndex} minHeight={props.rowMinHeight} isHighlighted={props.isHighlighted}>
-                <Cell {...props.leftHeaderSpec} width={props.widthLeftHeader} />
-                {props.cellSpecs.map((spec, colIndex) => (
-                    <Fragment key={`cells_${colIndex}_${props.rowIndex}`}>
-                        <Cell {...spec} width={props.columnWidth} />
-                        <div style={{ width: `${props.extraSpaceRight[colIndex]}%` }}></div>
-                    </Fragment>
-                ))}
+            <StatisticTableRow
+                layout={props.layout}
+                index={props.rowIndex}
+                leftHeader={<Cell {...props.leftHeaderSpec} width={props.layout.widthLeftHeader} />}
+                cellSpecs={props.cellSpecs}
+                plotSpec={props.plotSpec}
+                minHeight={props.rowMinHeight}
+                isHighlighted={props.isHighlighted}
+            />
+        </div>
+    )
+}
+
+/**
+ * The shape every statistic row has: a left header followed by a cell per column, and below
+ * it the blocks the row's extras call for -- its expanded plot and its representatives
+ * table. Callers differ only in what they put in the left header.
+ */
+function StatisticTableRow(props: {
+    layout: MeasuredTableLayout
+    index: number
+    leftHeader: ReactNode
+    cellSpecs: CellSpec[]
+    plotSpec?: PlotSpec
+    minHeight?: string
+    isHighlighted?: boolean
+}): ReactNode {
+    const { layout, cellSpecs } = props
+    const congressionalRegions = useMemo(() => congressionalRegionsForCells(cellSpecs), [cellSpecs])
+
+    return (
+        <>
+            <TableRowContainer index={props.index} minHeight={props.minHeight} isHighlighted={props.isHighlighted}>
+                {props.leftHeader}
+                <RowCells layout={layout} cellSpecs={cellSpecs} />
             </TableRowContainer>
             {props.plotSpec && (
                 <div style={{ width: '100%', position: 'relative' }}>
@@ -226,13 +288,31 @@ function SuperTableRow(props: {
             {congressionalRegions.length > 0 && (
                 <CongressionalRepresentativesWidget
                     regions={congressionalRegions}
-                    widthLeftHeader={props.widthLeftHeader}
-                    columnWidth={props.columnWidth}
-                    extraSpaceRight={props.extraSpaceRight}
+                    widthLeftHeader={layout.widthLeftHeader}
+                    columnWidth={layout.columnWidth}
+                    extraSpaceRight={layout.extraSpaceRight}
                 />
             )}
-        </div>
+        </>
     )
+}
+
+/**
+ * A row's cells, each followed by the space its column reserves to the right. Statistic
+ * cells are given their column's measured widths here, so every table that renders a row
+ * of cells lines its columns up the same way.
+ */
+function RowCells(props: { layout: MeasuredTableLayout, cellSpecs: CellSpec[] }): ReactNode {
+    const { columnWidth, extraSpaceRight, columnWidthsInfo } = props.layout
+    return props.cellSpecs.map((spec, colIndex) => (
+        <Fragment key={colIndex}>
+            <Cell
+                {...(spec.type === 'statistic-row' ? { ...spec, columnWidthsInfo: columnWidthsInfo[colIndex] } : spec)}
+                width={columnWidth}
+            />
+            <div style={{ width: `${extraSpaceRight[colIndex]}%` }}></div>
+        </Fragment>
+    ))
 }
 
 /** The representatives tables a row's cells call for, in column order. */

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -36,6 +36,9 @@ import { Cell, CellSpec, ComparisonLongnameCellProps, StatisticPanelLongnameCell
 
 export type ColumnIdentifier = 'statval' | 'statval_unit' | 'statistic_percentile' | 'statistic_ordinal' | 'pointer_in_class' | 'pointer_overall'
 
+/** Just the value, for the tables that have no room for the ordinal and percentile columns. */
+export const valueOnlyColumns: ColumnIdentifier[] = ['statval', 'statval_unit']
+
 const leftBarMargin = 0.02
 
 const tableRowStyle: React.CSSProperties = {
@@ -941,6 +944,22 @@ function SortButton(props: StatisticNameCellProps & { sortInfo: NonNullable<Stat
     )
 }
 
+/**
+ * The controls that sit next to a statistic's name: the plot expander and the disclaimer
+ * marker.
+ */
+function useStatisticNameAdornments(row: ArticleRow | undefined, footnote?: string): ReactNode[] {
+    const screenshotMode = useScreenshotMode()
+    const adornments: ReactNode[] = []
+    if (row !== undefined && row.extraStats.length !== 0 && !screenshotMode) {
+        adornments.push(<ExpansionButton key="expansion" row={row} />)
+    }
+    if (row?.disclaimer !== undefined) {
+        adornments.push(<StatisticNameDisclaimer key="disclaimer" disclaimer={row.disclaimer} footnoteSymbol={footnote} />)
+    }
+    return adornments
+}
+
 function ExpansionButton(props: { row: ArticleRow }): ReactNode {
     const [expanded, setExpanded] = useSetting(rowExpandedKey(props.row.statpath))
     const colors = useColors()
@@ -1005,16 +1024,7 @@ function StatisticName(props: {
                         {reifyReact(props.displayName)}
                     </span>
                 )
-    const screenshotMode = useScreenshotMode()
-    const elements = [link]
-    if (props.row !== undefined && props.row.extraStats.length !== 0 && !screenshotMode) {
-        elements.push(
-            <ExpansionButton key="expansion" row={props.row} />,
-        )
-    }
-    if (props.row?.disclaimer !== undefined) {
-        elements.push(<StatisticNameDisclaimer disclaimer={props.row.disclaimer} footnoteSymbol={props.footnoteSymbol} />)
-    }
+    const elements = [link, ...useStatisticNameAdornments(props.row, props.footnoteSymbol)]
     if (elements.length > 1) {
         const footnoteOnly = elements.length === 2 && props.footnoteSymbol !== undefined
         if (footnoteOnly) {
@@ -1069,11 +1079,16 @@ function ComparisonColorBar({ highlightIndex }: { highlightIndex: number | undef
     )
 }
 
-export function computeDisclaimerFootnotes(rows: { disclaimer?: Disclaimer }[]): { getSymbol: (d: Disclaimer) => string, footnotes: { symbol: string, text: string }[] } {
+/**
+ * The numbered footnotes a table's disclaimers collapse into for a screenshot, drawn from the
+ * statistics its name cells refer to -- the same cells that then show the symbols.
+ */
+export function computeDisclaimerFootnotes(specs: CellSpec[]): { getSymbol: (d: Disclaimer) => string, footnotes: { symbol: string, text: string }[] } {
     const uniqueMessages: string[] = []
-    for (const row of rows) {
-        if (row.disclaimer !== undefined) {
-            const msg = computeDisclaimerText(row.disclaimer)
+    for (const spec of specs) {
+        const disclaimer = spec.type === 'statistic-name' ? spec.row?.disclaimer : undefined
+        if (disclaimer !== undefined) {
+            const msg = computeDisclaimerText(disclaimer)
             if (!uniqueMessages.includes(msg)) {
                 uniqueMessages.push(msg)
             }
@@ -1124,7 +1139,7 @@ function StatisticNameDisclaimer(props: { disclaimer: Disclaimer, footnoteSymbol
     )
 }
 
-export function TableRowContainer({ children, index, minHeight, isHighlighted }: { children: React.ReactNode, index: number, minHeight?: string, isHighlighted: boolean }): React.ReactNode {
+export function TableRowContainer({ children, index, minHeight, isHighlighted = false }: { children: React.ReactNode, index: number, minHeight?: string, isHighlighted?: boolean }): React.ReactNode {
     const colors = useColors()
     const style: React.CSSProperties = {
         ...tableRowStyle,
@@ -1191,7 +1206,7 @@ function ordinalWidthInEm(ordinal: number, total: number, type: string, universe
     }
 }
 
-export function computeSizesForRow(row: StatisticCellRenderingInfo, universe: string, simpleOrdinals: boolean): CommonLayoutInformation {
+function computeSizesForRow(row: StatisticCellRenderingInfo, universe: string, simpleOrdinals: boolean): CommonLayoutInformation {
     // Compute the size of the ordinal and percentile text
     if (row.kind !== 'statistic') {
         return {
@@ -1212,6 +1227,18 @@ export function computeSizesForRow(row: StatisticCellRenderingInfo, universe: st
         ordinalColumnPadding,
         percentileColumnWidthEm: percentileColumnWidthEm + editableBoxPad,
     }
+}
+
+/** Column widths that fit every row, i.e. the maximum of each row's requirement. */
+export function maxLayoutInformation(rows: StatisticCellRenderingInfo[], universe: string, simpleOrdinals: boolean): CommonLayoutInformation {
+    return rows.reduce<CommonLayoutInformation>((acc, row) => {
+        const curr = computeSizesForRow(row, universe, simpleOrdinals)
+        return {
+            ordinalColumnWidthEm: Math.max(acc.ordinalColumnWidthEm, curr.ordinalColumnWidthEm),
+            percentileColumnWidthEm: Math.max(acc.percentileColumnWidthEm, curr.percentileColumnWidthEm),
+            ordinalColumnPadding: Math.max(acc.ordinalColumnPadding, curr.ordinalColumnPadding),
+        }
+    }, { ordinalColumnWidthEm: 0, percentileColumnWidthEm: 0, ordinalColumnPadding: 0 })
 }
 
 function Percentile(props: {

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -9,7 +9,7 @@ import { Navigator } from '../navigation/Navigator'
 import { Colors } from '../page_template/color-themes'
 import { colorFromCycle, useColors } from '../page_template/colors'
 import { MobileArticlePointers, rowExpandedKey, useSetting, useSettings } from '../page_template/settings'
-import { Universe, useUniverse } from '../universe'
+import { Universe, useDefinedUniverse, useUniverse } from '../universe'
 import { withButtonRole } from '../utils/a11y'
 import { assert } from '../utils/defensive'
 import { HumanReadableName, reifyReact, reifyString } from '../utils/human-readable-name'
@@ -1223,8 +1223,7 @@ function Percentile(props: {
     simpleOrdinals: boolean
     onNavigate?: (newArticle: string) => void
 }): ReactNode {
-    const currentUniverse = useUniverse()
-    assert(currentUniverse !== undefined, 'no universe')
+    const currentUniverse = useDefinedUniverse()
     const inScreenshot = useScreenshotMode()
     // Bump to reset if we navigate back to the same page
     const [editableFieldKey, setEditableFieldKey] = useState(0)
@@ -1300,8 +1299,7 @@ function Ordinal(props: {
     simpleOrdinals: boolean
     onNavigate?: (newArticle: string) => void
 }): ReactNode {
-    const currentUniverse = useUniverse()
-    assert(currentUniverse !== undefined, 'no universe')
+    const currentUniverse = useDefinedUniverse()
     const onNewNumber = async (number: number): Promise<void> => {
         if (props.onNavigate === undefined) {
             return
@@ -1364,8 +1362,7 @@ function Ordinal(props: {
 
 // Lacks some customization since its column is not show in the comparison view
 function PointerButtonsIndex(props: { ordinal?: number, statpath: string, type: string, total: number, longname: string, overallFirstLast?: FirstLastStatus }): ReactNode {
-    const currentUniverse = useUniverse()
-    assert(currentUniverse !== undefined, 'no universe')
+    const currentUniverse = useDefinedUniverse()
     const getData = async (): Promise<ArticleOrderingListInternal> => await loadOrdering(currentUniverse, props.statpath, props.type)
     return (
         <span style={{ margin: 'auto', whiteSpace: 'nowrap' }}>

--- a/react/src/stat/StatisticPanelTable.tsx
+++ b/react/src/stat/StatisticPanelTable.tsx
@@ -7,10 +7,9 @@ import { CellSpec, SuperHeaderSpec, TableContents } from '../components/supertab
 import { ColumnIdentifier } from '../components/table'
 import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
-import { useUniverse } from '../universe'
+import { useDefinedUniverse } from '../universe'
 import { orderNonNan } from '../urban-stats-script/constants/table'
 import { TypeEnvironment } from '../urban-stats-script/types-values'
-import { assert } from '../utils/defensive'
 import { reifyString } from '../utils/human-readable-name'
 import { sanitize } from '../utils/paths'
 
@@ -71,8 +70,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, 
 
     const columnWidth = (100 - widthLeftHeader) / (data.table.length === 0 ? 1 : data.table.length)
 
-    const currentUniverse = useUniverse()
-    assert(currentUniverse !== undefined, 'no universe')
+    const currentUniverse = useDefinedUniverse()
 
     const onlyColumns: ColumnIdentifier[] = data.hideOrdinalsPercentiles ? ['statval', 'statval_unit'] : ['statval', 'statval_unit', 'statistic_ordinal', 'statistic_percentile']
 

--- a/react/src/stat/StatisticPanelTable.tsx
+++ b/react/src/stat/StatisticPanelTable.tsx
@@ -4,7 +4,7 @@ import { isNoValue, StatisticCellRenderingInfo } from '../components/load-articl
 import { PointerArrow } from '../components/pointer-cell'
 import { computeComparisonWidthColumns, MaybeScroll } from '../components/scrollable'
 import { CellSpec, SuperHeaderSpec, TableContents } from '../components/supertable'
-import { ColumnIdentifier } from '../components/table'
+import { ColumnIdentifier, valueOnlyColumns } from '../components/table'
 import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
 import { useDefinedUniverse } from '../universe'
@@ -72,7 +72,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, 
 
     const currentUniverse = useDefinedUniverse()
 
-    const onlyColumns: ColumnIdentifier[] = data.hideOrdinalsPercentiles ? ['statval', 'statval_unit'] : ['statval', 'statval_unit', 'statistic_ordinal', 'statistic_percentile']
+    const onlyColumns: ColumnIdentifier[] = data.hideOrdinalsPercentiles ? valueOnlyColumns : ['statval', 'statval_unit', 'statistic_ordinal', 'statistic_percentile']
 
     const allColumnRows: StatisticCellRenderingInfo[][] = data.table.map((col) => {
         return indexRange.map((rangeIdx) => {
@@ -167,10 +167,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, 
                         verticalPlotSpecs={[]}
                         topLeftSpec={topLeftSpec}
                         superHeaderSpec={superHeaderSpec}
-                        widthLeftHeader={widthLeftHeader}
-                        columnWidth={columnWidth}
-                        onlyColumns={onlyColumns}
-                        simpleOrdinals={true}
+                        layout={{ widthLeftHeader, columnWidth, onlyColumns, simpleOrdinals: true }}
                         highlightRowIndex={highlightRowIndex}
                         loading={loading}
                     />

--- a/react/src/universe.ts
+++ b/react/src/universe.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import universes_default from './data/universes_default'
 import universes_ordered from './data/universes_ordered'
+import { assert } from './utils/defensive'
 
 export type Universe = (typeof universes_ordered)[number]
 
@@ -12,6 +13,13 @@ export function useUniverseContext(): UniverseContext | undefined {
 
 export function useUniverse(): Universe | undefined {
     return useUniverseContext()?.universe
+}
+
+/** The current universe, for the components that only render on pages that have one. */
+export function useDefinedUniverse(): Universe {
+    const universe = useUniverse()
+    assert(universe !== undefined, 'no universe')
+    return universe
 }
 
 export function defaultArticleUniverse(articleUniverses: Universe[]): typeof universes_default[number] {


### PR DESCRIPTION
Four commits, each self-contained, meant to be read in order. All behavior-preserving — this is groundwork, not a change to what the tables render.

**Name the two things the tables kept asserting about.** Seven components did `useUniverse()` followed by `assert(universe !== undefined)`; the tables only render on pages that have a universe, so that's `useDefinedUniverse()`. Likewise, the "is this row a representatives row" unwrapping lived inline inside a `useMemo` in the row component — it belongs next to the type it produces.

**Share the statistic naming and expansion logic between the two tables.** The comparison panel imported `computeNameSpecsWithGroups` *from the article panel*, which is the wrong direction for a dependency; it moves to its own module. Its group tally was also quadratic — it re-filtered every spec in the table for each spec, just to learn how big that spec's group is. The two panels also had their own near-identical copies of "which rows are expanded", differing only in which settings they subscribed to.

**Thread the table's column shape as one value.** The four column-layout props were passed down individually and recombined at every level, and the measured column widths were computed inline in the middle of `TableContents`. Grouping them lets each piece of a table take the layout it renders against. `TableFrame` and the row container split out of `TableContents` while there, and the disclaimer-footnote lookup is written once instead of three times.

**Give the article's table its own module, and share the CSV export.** The article panel was more than half table code. Moving it out also gives the comparison panel somewhere to share the CSV export from — both had the same callback, and neither needs to hold the exported rows in render state to produce it.

Checked with `tsc`, `eslint --max-warnings=0`, `knip`, and the unit suite; leaning on CI for the screenshot tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)