### PR TITLE
Narrow what a statistic checkbox re-renders

### DIFF
--- a/react/src/components/article-panel.tsx
+++ b/react/src/components/article-panel.tsx
@@ -4,8 +4,7 @@ import './article.css'
 import React, { ReactNode, useContext, useMemo, useRef } from 'react'
 
 import { Navigator } from '../navigation/Navigator'
-import { useSettings } from '../page_template/settings'
-import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
+import { StatGroupSettings } from '../page_template/statistic-settings'
 import { PageTemplate } from '../page_template/template'
 import { Universe, universeContext, useUniverse } from '../universe'
 import { sanitize } from '../utils/paths'
@@ -37,9 +36,6 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
     const headerTextClass = useHeaderTextClass()
     const subHeaderTextClass = useSubHeaderTextClass()
     const comparisonHeadStyle = useComparisonHeadStyle('right')
-
-    const settings = useSettings(groupYearKeys())
-    const filteredRows = rows(settings)[0]
 
     const articles = useMemo(() => [article], [article])
     const csvExportCallback = useCSVExport(articles, rows, true, article.longname)
@@ -74,7 +70,7 @@ export function ArticlePanel({ article, rows, universe }: { article: Article, ro
 
                     <div ref={tableRef}>
                         <ArticleTable
-                            filteredRows={filteredRows}
+                            rows={rows}
                             article={article}
                         />
                     </div>

--- a/react/src/components/article-table.tsx
+++ b/react/src/components/article-table.tsx
@@ -2,7 +2,8 @@ import React, { ReactNode, useContext } from 'react'
 
 import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
-import { useSetting } from '../page_template/settings'
+import { useSetting, useSettings } from '../page_template/settings'
+import { groupYearKeys, StatGroupSettings } from '../page_template/statistic-settings'
 import { useDefinedUniverse } from '../universe'
 import { Article } from '../utils/protos'
 import { useMobileLayout } from '../utils/responsive'
@@ -51,20 +52,25 @@ function useArticleTableLayout(): TableLayout {
 }
 
 export function ArticleTable(props: {
-    filteredRows: ArticleRow[]
+    rows: (settings: StatGroupSettings) => ArticleRow[][]
     article: Article
 }): ReactNode {
     const currentUniverse = useDefinedUniverse()
     const layout = useArticleTableLayout()
     const navContext = useContext(Navigator.Context)
 
+    // Subscribed to here rather than in the panel, so that changing which statistics are
+    // shown only re-renders the table, not the map and the surrounding page.
+    const settings = useSettings(groupYearKeys())
+    const filteredRows = props.rows(settings)[0]
+
     const { updatedNameSpecs: leftHeaderSpecs, groupNames } = computeNameSpecsWithGroups(
-        nameSpecsForRows(props.filteredRows, props.article.longname, currentUniverse),
+        nameSpecsForRows(filteredRows, props.article.longname, currentUniverse),
     )
 
-    const plotSpecs = useExpandedPlotSpecs(props.filteredRows, props.article)
+    const plotSpecs = useExpandedPlotSpecs(filteredRows, props.article)
 
-    const cellSpecs: CellSpec[][] = props.filteredRows.map(row => [({
+    const cellSpecs: CellSpec[][] = filteredRows.map(row => [({
         type: 'statistic-row',
         longname: props.article.longname,
         row,

--- a/react/src/components/checkbox-setting.tsx
+++ b/react/src/components/checkbox-setting.tsx
@@ -11,20 +11,34 @@ import { isStagedChange, SettingsDictionary, useSetting, useSettingInfo } from '
 // type representing a key of SettingsDictionary that have boolean values
 export type BooleanSettingKey = keyof { [K in keyof SettingsDictionary as SettingsDictionary[K] extends boolean | undefined ? K : never]: boolean }
 
+/** What a checkbox needs to render a boolean setting, wherever the checkbox itself lives. */
+export function useBooleanSetting(settingKey: BooleanSettingKey, forcedOn?: boolean): {
+    checked: boolean
+    setChecked: (checked: boolean) => void
+    highlight: boolean
+} {
+    const [checked, setChecked] = useSetting(settingKey)
+    const info = useSettingInfo(settingKey)
+    return {
+        checked: (checked ?? false) || (forcedOn ?? false),
+        setChecked,
+        highlight: isStagedChange(info),
+    }
+}
+
 export function CheckboxSetting(props: { name: string, settingKey: BooleanSettingKey, classNameToUse?: string, id?: string, testId?: string, forcedOn?: boolean, fontSize?: string }): ReactNode {
-    const [checked, setChecked] = useSetting(props.settingKey)
-    const info = useSettingInfo(props.settingKey)
+    const { checked, setChecked, highlight } = useBooleanSetting(props.settingKey, props.forcedOn)
 
     return (
         <CheckboxSettingCustom
             name={props.name}
-            checked={(checked ?? false) || (props.forcedOn ?? false)}
+            checked={checked}
             forcedOn={props.forcedOn}
             onChange={setChecked}
             classNameToUse={props.classNameToUse}
             id={props.id}
             testId={props.testId}
-            highlight={isStagedChange(info)}
+            highlight={highlight}
             fontSize={props.fontSize}
         />
     )

--- a/react/src/components/checkbox-setting.tsx
+++ b/react/src/components/checkbox-setting.tsx
@@ -12,7 +12,7 @@ import { isStagedChange, SettingsDictionary, useSetting, useSettingInfo } from '
 export type BooleanSettingKey = keyof { [K in keyof SettingsDictionary as SettingsDictionary[K] extends boolean | undefined ? K : never]: boolean }
 
 /** What a checkbox needs to render a boolean setting, wherever the checkbox itself lives. */
-export function useBooleanSetting(settingKey: BooleanSettingKey, forcedOn?: boolean): {
+function useBooleanSetting(settingKey: BooleanSettingKey, forcedOn?: boolean): {
     checked: boolean
     setChecked: (checked: boolean) => void
     highlight: boolean

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -154,8 +154,11 @@ export function ComparisonPanel(props: {
 
     const validOrdinalsByStat = dataByStatArticle.map(statData => statData.every(value => value.kind !== 'metadata' && value.disclaimer !== 'heterogenous-sources'))
 
+    // Ordinals are only meaningful between regions of the same type.
+    const allSameArticleType = localArticlesToUse.every(article => article.articleType === localArticlesToUse[0].articleType)
+
     const includeOrdinals = (
-        localArticlesToUse.every(article => article.articleType === localArticlesToUse[0].articleType)
+        allSameArticleType
         && (validOrdinalsByStat.length === 0 || validOrdinalsByStat.some(x => x))
     )
 
@@ -195,7 +198,7 @@ export function ComparisonPanel(props: {
 
     const navContext = useContext(Navigator.Context)
 
-    const sharedTypeOfAllArticles = localArticlesToUse.every(article => article.articleType === localArticlesToUse[0].articleType) ? localArticlesToUse[0].articleType : undefined
+    const sharedTypeOfAllArticles = allSameArticleType ? localArticlesToUse[0].articleType : undefined
 
     const rowToDisplayForStat = (statIndex: number): ArticleRow => {
         return dataByStatArticle[statIndex].find(row => row.extraStats.length > 0) ?? dataByStatArticle[statIndex][0]


### PR DESCRIPTION
Prep for the edit-mode branch (`article-edit`), split off because none of it depends on edit mode existing. No behavior change — all three of these are refactors.

**Move the group/year/source subscription out of `ArticlePanel` and into `ArticleTable`.** The panel was subscribing to every one of those settings only so it could filter the rows and hand them to the table. That made a checkbox click re-render the headers, the map, the related buttons and the external links, none of which depend on which statistics are selected. The table now takes the `rows` callback and filters for itself.

This matters more on the edit-mode branch, where the statistic tree lives on the table and gets clicked a lot, but it is worth having on its own.

**Extract `useBooleanSetting` from `CheckboxSetting`.** The `useSetting` / `useSettingInfo` / `isStagedChange` trio is what a checkbox needs to back a boolean setting; it was fused to the one component that renders the sidebar's checkbox markup. Splitting it lets a checkbox with different markup reuse the same state. There is only one caller here — the second one arrives with edit mode.

**Hoist `allSameArticleType` in `ComparisonPanel`.** The same `.every(...)` over article types was being computed twice, 40 lines apart, once named and once inline. Now computed once, with a comment saying why ordinals need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)