### PR TITLE
Say what made a test fail in the CI comment

### DIFF
--- a/react/test/scripts/post-comment.ts
+++ b/react/test/scripts/post-comment.ts
@@ -49,7 +49,7 @@ async function testsComment(): Promise<string | undefined> {
         return true
     }).sort((a, b) => a.test.localeCompare(b.test))
 
-    const failedExecutions = executions.filter(execution => execution.result.status !== 'success')
+    const failedExecutions = executions.flatMap(execution => execution.result.status === 'success' ? [] : [{ ...execution, result: execution.result }])
 
     if (failedExecutions.length === 0) {
         return
@@ -58,7 +58,7 @@ async function testsComment(): Promise<string | undefined> {
     const lines = await Promise.all(failedExecutions.map(async ({ test, result, retries, github: executionGithub }) => {
         const statusText = result.status === 'timeout'
             ? `timeout (limit: ${result.timeLimitSeconds}s)`
-            : 'failure'
+            : `failure (${result.reason})`
         const retriesText = retries === 0 ? '' : ` (${retries} retries)`
 
         const { data } = await gh.octokit.rest.actions.downloadJobLogsForWorkflowRun({

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -124,7 +124,7 @@ function printResult({ test, result, retries }: { test: string, result: TestResu
             console.warn(chalkTemplate`{green.bold ${testFile(test)} succeeded (${retries} retries)}`)
             break
         case 'failure':
-            console.warn(chalkTemplate`{red.bold ${testFile(test)} failed (${retries} retries)}`)
+            console.warn(chalkTemplate`{red.bold ${testFile(test)} failed due to ${result.reason} (${retries} retries)}`)
             break
         case 'timeout':
             console.error(chalkTemplate`{red ${testFile(test)} took too long! (allowed duration ${result.timeLimitSeconds}s) (${retries} retries)}`)
@@ -187,24 +187,29 @@ async function runTest(test: string): Promise<TestResult> {
             selectorTimeout: 5000,
             disableMultipleWindows: true,
         })
-        return { status: failed === 0 ? 'success' as const : 'failure' as const, duration: Date.now() - start }
+        return { status: 'ran' as const, assertionsPassed: failed === 0, duration: Date.now() - start }
     })()
 
     const timeLimitSeconds = options.live ? 1_000_000 : (options.timeLimitSeconds ?? 10_000) * (await testFileDidChange(test) ? 1 : 2)
 
     const result = await withTimeout(runningTests, async () => timeLimitSeconds + await getTOTPWait(test))
 
-    const comparisonResult = await maybeCompare(test, result.status === 'success')
-
-    if (result.status === 'success' && !comparisonResult) {
-        return { ...result, status: 'failure' }
-    }
+    const screenshotsPassed = await maybeCompare(test, result.status === 'ran' && result.assertionsPassed)
 
     if (result.status === 'timeout') {
         return { ...result, timeLimitSeconds }
     }
 
-    return result
+    // Assertion failures take precedence: a test that fails stops early, so its screenshots aren't comparable
+    if (!result.assertionsPassed) {
+        return { status: 'failure', duration: result.duration, reason: 'assertions' }
+    }
+
+    if (!screenshotsPassed) {
+        return { status: 'failure', duration: result.duration, reason: 'screenshots' }
+    }
+
+    return { status: 'success', duration: result.duration }
 }
 
 async function maybeCompare(test: string, success: boolean): Promise<boolean> {

--- a/react/test/scripts/util.ts
+++ b/react/test/scripts/util.ts
@@ -37,7 +37,9 @@ export const testHistorySchema = z.array(z.object({
     test: z.string(),
     result: z.discriminatedUnion('status', [
         z.object({ status: z.literal('timeout'), timeLimitSeconds: z.number() }),
-        z.object({ status: z.enum(['success', 'failure']), duration: z.number() }),
+        z.object({ status: z.literal('success'), duration: z.number() }),
+        // The reason is displayed as-is, so that failure reports say what to go look at
+        z.object({ status: z.literal('failure'), duration: z.number(), reason: z.enum(['assertions', 'screenshots']) }),
     ]),
     retries: z.number(),
     github: z.optional(z.object({


### PR DESCRIPTION
A bare `failure` in the CI comment doesn't tell you whether to go read the job logs or open the screenshot diff viewer — very different follow-ups. Screenshot mismatches are now recorded separately from assertion failures, so the comment says which one it was:

```
- test/foo.test.ts: failure (screenshots)
- test/bar.test.ts: failure (assertions) (1 retries)
```

The reason is stored in the test history as the string that gets displayed, rather than a code that needs a mapping function on the other end.

When both are broken, we report `assertions`. A failing test stops early, so the screenshots it did take aren't a trustworthy comparison — an "assertions and screenshots" reason would have needed the comparison to ignore screenshots the run never got to, and it isn't worth that complexity when the assertion failure is the thing to fix first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)