### PR TITLE
Let the tree change shape while a screenshot is being set up

### DIFF
--- a/react/src/components/ScreenshotAwareLayer.tsx
+++ b/react/src/components/ScreenshotAwareLayer.tsx
@@ -10,9 +10,6 @@ import { useScreenshotCallback } from './screenshot'
  * Use instead of react-map-gl's <Layer> so screenshots wait for the layer.
  * This solves the problem of the layer not being present even after the `render` screenshot phase.
  * If this happens, then map.loaded() doesn't wait for the layer.
- *
- * This component should not be used under a screenshot-mode dependent `key`,
- * as this causes it to not be part of the screenshot render process.
  */
 export function ScreenshotAwareLayer(props: LayerProps & { id: string }): ReactNode {
     const { current: map } = useMap()
@@ -30,7 +27,9 @@ export function ScreenshotAwareLayer(props: LayerProps & { id: string }): ReactN
                 await new Promise(resolve => requestAnimationFrame(resolve))
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Linter is too dumb
                 if (cancelled) {
-                    return // Try again in the next effect
+                    // Either the effect is about to re-run, or we unmounted -- in which case
+                    // unregistering has already settled the screenshot's wait for us.
+                    return
                 }
                 if (map._removed) {
                     break // Nothing will add the layer now, don't stall the screenshot

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -176,9 +176,71 @@ export async function screencapElement(ref: HTMLElement, overallWidth: number, {
 
 export type ReadyForScreenshotCallback = () => void
 
+type ScreenshotSubscriber = (callback: ReadyForScreenshotCallback | undefined) => void
+
 export interface ScreenshotContextType {
-    render: Set<(callback: ReadyForScreenshotCallback | undefined) => void>
-    wait: Set<(callback: ReadyForScreenshotCallback | undefined) => void>
+    render: Set<ScreenshotSubscriber>
+    wait: Set<ScreenshotSubscriber>
+}
+
+/**
+ * Settles the wait for a subscriber a capture is currently blocked on. Entering screenshot mode
+ * changes what is rendered -- that is the point of it -- so a subscriber can unmount before it
+ * ever signals ready, and its unregistering has to settle the wait or the capture hangs forever.
+ */
+const settleWaitForSubscriber = new WeakMap<ScreenshotSubscriber, () => void>()
+
+function unregisterSubscriber(subscribers: Set<ScreenshotSubscriber>, subscriber: ScreenshotSubscriber): void {
+    subscribers.delete(subscriber)
+    settleWaitForSubscriber.get(subscriber)?.()
+}
+
+/**
+ * Guards against a pathological tree that mounts a fresh subscriber every time it is put into
+ * screenshot mode, which would otherwise loop forever.
+ */
+const maxNotifyRounds = 10
+
+/**
+ * Puts every subscriber into screenshot mode and waits for each to signal ready or go away.
+ *
+ * Entering screenshot mode is what mounts some of the subscribers -- the footnotes below a table,
+ * or a map layer rebuilt at full resolution -- so this keeps going until a round adds nobody new.
+ * Notifying only whoever was registered up front would render those components interactively into
+ * the screenshot, and would capture without waiting for them.
+ */
+async function notifySubscribers(subscribers: Set<ScreenshotSubscriber>, phase: string): Promise<void> {
+    const notified = new Set<ScreenshotSubscriber>()
+    for (let round = 1; ; round++) {
+        const pending = Array.from(subscribers).filter(subscriber => !notified.has(subscriber))
+        if (pending.length === 0) {
+            return
+        }
+        if (round > maxNotifyRounds) {
+            console.warn(`screenshot: ${pending.length} ${phase} subscriber(s) still appearing after ${maxNotifyRounds} rounds, capturing without them`)
+            return
+        }
+        debugLog('withScreenshotMode:', phase, 'round', round, 'notifying', pending.length, 'subscriber(s)')
+        let ready = 0
+        await Promise.all(pending.map((subscriber) => {
+            notified.add(subscriber)
+            return new Promise<void>((resolve) => {
+                let settled = false
+                const settle = (): void => {
+                    if (settled) {
+                        return
+                    }
+                    settled = true
+                    settleWaitForSubscriber.delete(subscriber)
+                    ready++
+                    debugLog('withScreenshotMode:', phase, 'subscriber', ready, '/', pending.length, 'ready')
+                    resolve()
+                }
+                settleWaitForSubscriber.set(subscriber, settle)
+                subscriber(() => settle)
+            })
+        }))
+    }
 }
 
 export async function withScreenshotMode<T>(context: ScreenshotContextType, fn: () => Promise<T>): Promise<T> {
@@ -186,26 +248,12 @@ export async function withScreenshotMode<T>(context: ScreenshotContextType, fn: 
     // and wait for all to signal ready. This causes React to re-render and commit any
     // DOM changes (like remounting map sources with tolerance=0) before phase 2 starts.
     debugLog('withScreenshotMode: notifying', context.render.size, 'render subscriber(s)')
-    let renderResolved = 0
-    await Promise.all(Array.from(context.render).map(setCallback => new Promise<void>((resolve) => {
-        setCallback(() => () => {
-            renderResolved++
-            debugLog('withScreenshotMode: render subscriber', renderResolved, '/', context.render.size, 'ready')
-            resolve()
-        })
-    })))
+    await notifySubscribers(context.render, 'render')
     debugLog('withScreenshotMode: all render subscribers ready, notifying', context.wait.size, 'wait subscriber(s)')
 
     // Phase 2: trigger wait callbacks (e.g. waiting for map tiles/sources to finish rendering),
     // which run after all render-phase DOM changes have been committed.
-    let waitResolved = 0
-    await Promise.all(Array.from(context.wait).map(setCallback => new Promise<void>((resolve) => {
-        setCallback(() => () => {
-            waitResolved++
-            debugLog('withScreenshotMode: wait subscriber', waitResolved, '/', context.wait.size, 'ready')
-            resolve()
-        })
-    })))
+    await notifySubscribers(context.wait, 'wait')
     debugLog('withScreenshotMode: all subscribers ready, running capture')
     try {
         return await fn()
@@ -296,7 +344,7 @@ export function useScreenshotCallback(kind: 'render' | 'wait'): ReadyForScreensh
         const set = kind === 'render' ? context.render : context.wait
         set.add(setCallback)
         return () => {
-            set.delete(setCallback)
+            unregisterSubscriber(set, setCallback)
         }
     }, [context, kind])
 


### PR DESCRIPTION
Entering screenshot mode changes what is rendered — that is the point of it — so components mount and unmount while `withScreenshotMode` is waiting for its subscribers to signal ready. It handled neither case, and both are reachable from ordinary UI.

**Unmounting hung the capture.** A subscriber that goes away never calls its callback, so the `Promise.all` it was part of never settled: the screenshot button's spinner turns forever and the download never arrives. Unregistering now settles the wait — a component that is gone has nothing left for the screenshot to wait on. I hit this from a page whose table drops rows when it enters screenshot mode.

**Mounting was silently skipped.** Subscribers were snapshotted up front, so anything mounted *as a result* of entering screenshot mode never heard that a capture was happening. Two consequences: it renders its interactive UI into the screenshot, and if it is a `ScreenshotAwareLayer` it isn't awaited at all, so the capture can run before its layer has reached the map. That is the shape of the map-export flakiness in #2024 / #2098. Subscribers are now notified in rounds until a round adds nobody new, capped so a tree that mounts a fresh subscriber on every round can't spin forever.

Handling the mounting side removes the rule that `ScreenshotAwareLayer` must not sit under a screenshot-mode dependent `key`, which existed only because remounting used to drop it out of the process.

## Testing

`cross_source_border_disclaimer`, `comparison_x1` and `article-representatives` all pass (35 tests) — between them they cover screenshot-mode footnotes, transposed comparison captures, dark-mode downloads, and the map exports this is most likely to affect. The two behaviours here are about a tree changing shape mid-capture, which the existing suite doesn't set up on purpose; a test that does is easier to write against the page that prompted this, so it lands with that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)