### PR TITLE
Narrow the top-left header spec to the cells that can be one

### DIFF
--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -32,7 +32,7 @@ import { createScreenshot, ScreencapElements, ScreenshotContext, ScreenshotConte
 import { computeComparisonWidthColumns, computeMaxColumns, MaybeScroll } from './scrollable'
 import { SearchBox } from './search'
 import { computeNameSpecsWithGroups } from './statistic-name-specs'
-import { TableContents, CellSpec, PlotSpec, TableLayout } from './supertable'
+import { TableContents, CellSpec, PlotSpec, TableLayout, TopLeftCellSpec } from './supertable'
 import { ColumnIdentifier, valueOnlyColumns } from './table'
 
 interface ComparisonPanelProps {
@@ -344,7 +344,7 @@ function ComparisonPanelContents(props: ComparisonPanelProps & { screenshotConte
             : undefined,
     )
 
-    const topLeftSpec: CellSpec = { type: 'comparison-top-left-header', statNameOverride: transpose ? 'Region' : undefined }
+    const topLeftSpec: TopLeftCellSpec = { type: 'comparison-top-left-header', statNameOverride: transpose ? 'Region' : undefined }
 
     const layout: TableLayout = {
         widthLeftHeader: leftMarginPercent * 100,

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -84,7 +84,7 @@ export interface TableContentsProps {
     rowSpecs: CellSpec[][]
     horizontalPlotSpecs: (PlotSpec | undefined)[]
     verticalPlotSpecs: (PlotSpec | undefined)[]
-    topLeftSpec: CellSpec
+    topLeftSpec: TopLeftCellSpec
     /** Warnings shown in place of the statistics they are about. */
     warningRows?: WarningRow[]
     /**
@@ -234,7 +234,7 @@ export function TableContents(props: TableContentsProps): ReactNode {
 function TableFrame(props: {
     layout: MeasuredTableLayout
     superHeaderSpec?: SuperHeaderSpec
-    topLeftSpec: CellSpec
+    topLeftSpec: TopLeftCellSpec
     blankColumns?: number[]
     minHeight?: string
     children: ReactNode
@@ -515,3 +515,6 @@ export interface StatisticRowCellProps {
 export interface TopLeftHeaderProps {
     statNameOverride?: string
 }
+
+/** The cells that can serve as a table's top-left header; the comparison's carries a color bar. */
+export type TopLeftCellSpec = Extract<CellSpec, TopLeftHeaderProps>

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -517,4 +517,4 @@ export interface TopLeftHeaderProps {
 }
 
 /** The cells that can serve as a table's top-left header; the comparison's carries a color bar. */
-export type TopLeftCellSpec = Extract<CellSpec, TopLeftHeaderProps>
+export type TopLeftCellSpec = Extract<CellSpec, { type: 'comparison-top-left-header' | 'top-left-header' }>

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -32,7 +32,7 @@ import { PointerArrow, useSinglePointerCell } from './pointer-cell'
 import { useScreenshotMode } from './screenshot'
 import { SearchBox } from './search'
 import { MaybeStagingControlsSidebarSection, SettingsSidebarSection, SidebarForStatisticChoice, useSidebarFontSize, useSidebarSectionContentClassName } from './sidebar'
-import { Cell, CellSpec, ComparisonLongnameCellProps, StatisticPanelLongnameCellProps, TopLeftHeaderProps, StatisticNameCellProps } from './supertable'
+import { Cell, CellSpec, ComparisonLongnameCellProps, StatisticPanelLongnameCellProps, TopLeftCellSpec, TopLeftHeaderProps, StatisticNameCellProps } from './supertable'
 
 export type ColumnIdentifier = 'statval' | 'statval_unit' | 'statistic_percentile' | 'statistic_ordinal' | 'pointer_in_class' | 'pointer_overall'
 
@@ -306,7 +306,7 @@ export function TopLeftHeader(props: TopLeftHeaderProps & { width: number }): Re
 }
 
 export function MainHeaderRow(props: {
-    topLeftSpec: CellSpec
+    topLeftSpec: TopLeftCellSpec
     topLeftWidth: number
     columnWidth: number
     onlyColumns: ColumnIdentifier[]

--- a/react/src/stat/StatisticPanelTable.tsx
+++ b/react/src/stat/StatisticPanelTable.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent, ReactNode, useContext, useEffect, useMemo, useRef, 
 import { isNoValue, StatisticCellRenderingInfo } from '../components/load-article'
 import { PointerArrow } from '../components/pointer-cell'
 import { computeComparisonWidthColumns, MaybeScroll } from '../components/scrollable'
-import { CellSpec, SuperHeaderSpec, TableContents } from '../components/supertable'
+import { CellSpec, SuperHeaderSpec, TableContents, TopLeftCellSpec } from '../components/supertable'
 import { ColumnIdentifier, valueOnlyColumns } from '../components/table'
 import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
@@ -115,7 +115,7 @@ export function StatisticPanelTable({ view, stat, data, set, tableRef, loading, 
         } satisfies CellSpec))
     })
 
-    const topLeftSpec: CellSpec = {
+    const topLeftSpec: TopLeftCellSpec = {
         type: 'top-left-header',
         statNameOverride: 'Name',
     }


### PR DESCRIPTION
Split out of the article edit-mode branch, which is stacked on top of this.

`topLeftSpec` was typed as the whole `CellSpec` union, so `TableContents`, `TableFrame`, and `MainHeaderRow` would all accept a statistic row or a blank cell as a table's top-left header and only fail by rendering the wrong thing. Only two of the union's members take `TopLeftHeaderProps`, so this names that subset as `TopLeftCellSpec` and asks for it instead.

Type-only change; no behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)