### PR TITLE
Don't blame the sources for a year a source doesn't cover

### DIFF
--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -130,7 +130,7 @@ export function useSelectedYears(): Year[] {
 
 /** Why a group that the user selected is nonetheless showing no statistics. */
 export type MissingGroupReason =
-    /** None of `years`, the years this page has the group's statistics for, are selected. */
+    /** None of `years` are selected: the years this page has the group's statistics for from an enabled source. */
     { kind: 'year', years: Year[] } |
     { kind: 'source', category: SourceCategoryIdentifier }
 

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -9,10 +9,15 @@ import { allGroups, allYears, AmbiguousSources, Category, DataSource, DataSource
 export type StatGroupSettings = Record<StatGroupKey | StatYearKey | StatSourceKey, boolean>
 
 export function statIsEnabled(statId: StatPath, settings: StatGroupSettings, sourcesByCategory: AmbiguousSources): boolean {
-    const { group, year, source } = statParents.get(statId)!
+    const { group, year } = statParents.get(statId)!
     return settings[`show_stat_group_${group.id}`]
         && (year !== null ? settings[`show_stat_year_${year}`] : true)
-        && (source !== null ? sourceApplies(source, settings, sourcesByCategory) : true)
+        && statSourceIsEnabled(statId, settings, sourcesByCategory)
+}
+
+function statSourceIsEnabled(statId: StatPath, settings: StatGroupSettings, sourcesByCategory: AmbiguousSources): boolean {
+    const { source } = statParents.get(statId)!
+    return source === null || sourceApplies(source, settings, sourcesByCategory)
 }
 
 function sourceApplies(source: DataSource, settings: StatGroupSettings, sourcesByCategory: AmbiguousSources): boolean {
@@ -165,18 +170,27 @@ export function useMissingGroups(): MissingGroup[] {
         if (paths.some(path => statIsEnabled(path, settings, ambiguousSources))) {
             return undefined
         }
+        // Statistics whose source is enabled are held back by their year alone.
+        const fromEnabledSources = paths.filter(path => statSourceIsEnabled(path, settings, ambiguousSources))
         const pathsInSelectedYears = paths.filter((path) => {
             const { year } = statParents.get(path)!
             return year === null || selectedYears.includes(year)
         })
-        if (pathsInSelectedYears.length === 0) {
-            const yearsOnPage = new Set(paths.map(path => statParents.get(path)!.year))
-            return { kind: 'year', years: allYears.filter(year => yearsOnPage.has(year)) }
+        if (pathsInSelectedYears.length > 0) {
+            // Everything in the selected years is disabled by its source, so we can name that source
+            // category if they agree on one -- unless the group has a statistic from an enabled
+            // source in another year, which would make "all of them are disabled" a lie.
+            const categories = new Set(pathsInSelectedYears.map(path => statParents.get(path)!.source?.category))
+            const [category] = categories
+            if (categories.size === 1 && category !== undefined
+                && !fromEnabledSources.some(path => statParents.get(path)!.source?.category === category)) {
+                return { kind: 'source', category }
+            }
         }
-        // Everything left is disabled by its source, so we can only name a reason if they agree on one.
-        const categories = new Set(pathsInSelectedYears.map(path => statParents.get(path)!.source?.category))
-        const [category] = categories
-        return categories.size === 1 && category !== undefined ? { kind: 'source', category } : undefined
+        // Otherwise it is the years that are missing: the ones selecting would bring the group back.
+        const yearsToSelect = new Set(fromEnabledSources.map(path => statParents.get(path)!.year))
+        const years = allYears.filter(year => yearsToSelect.has(year))
+        return years.length > 0 ? { kind: 'year', years } : undefined
     }
 
     const byReason = new Map<string, { reason: MissingGroupReason, groups: Group[] }>()

--- a/react/test/comparison_warnings.test.ts
+++ b/react/test/comparison_warnings.test.ts
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe'
 
-import { arrayFromSelector, checkTextboxes, comparisonPage, screencap, uncheckAllCategories, urbanstatsFixture, warningNamed, warningRowNames, withHamburgerMenu } from './test_utils'
+import { arrayFromSelector, checkTextboxes, checkTextboxesDirect, comparisonPage, screencap, uncheckAllCategories, urbanstatsFixture, warningNamed, warningRowNames, withHamburgerMenu } from './test_utils'
 
 const mainCheck = 'input[data-test-id=category_main]'
 
@@ -55,6 +55,21 @@ test('comparison-warnings-all-sources-disabled', async (t) => {
     // Statistics that don't come from a Population source are unaffected
     await t.expect(Selector('a').withExactText('Area').exists).ok()
     await screencap(t)
+})
+
+// Two US states, so the US Census and GHSL are both choosable, and GHSL only has 2020.
+urbanstatsFixture('comparison warnings with a year the enabled source lacks', comparisonPage([
+    'Massachusetts, USA',
+    'California, USA',
+]))
+
+test('comparison-warnings-year-missing-from-enabled-source', async (t) => {
+    await withHamburgerMenu(t, async () => {
+        // leaves 2010, the one year GHSL has no data for, as the only year selected
+        await checkTextboxesDirect(t, ['US Census', 'GHSL', '2020', '2010'])
+    })
+    // GHSL is enabled and simply has no data for 2010, so the years are what's missing, not a source
+    await t.expect(warningNamed('Select 2020 or 2000 to see this statistic.', 'Population').exists).ok()
 })
 
 // Six regions against three warning columns and two statistics, which is enough regions that the


### PR DESCRIPTION
A group that has nothing to show reports why, and the two candidate reasons -- a year is unselected, a source is off -- were tried in an order that could produce a false statement. With 2010 as the only selected year and GHSL as the only enabled population source, the Population group warned that *all* population sources were disabled. GHSL was enabled; it simply has no 2010 data, so the year was the real blocker.

The rule is now that a warning only names a source category when it's true of the group: none of its statistics, in any year, comes from an enabled source in that category. Otherwise the years are what's missing. For the same reason the years a warning suggests are drawn only from enabled sources, so it never points at a year that only a disabled source covers.

The new e2e test compares two US states, which is what makes both source checkboxes choosable, and checks the warning names years rather than sources. It fails on the old code with the misleading message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)