### PR TITLE
Tell agents how to run the tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Urban Stats (urbanstats.org) is a website for viewing statistics of geographic a
 - **Protobuf** is used for data serialization between Python and the frontend — changes to `.proto` files require running `bash scripts/build-protos.sh`
 - **`permacache`** caches Python function results to disk; changing a cached function's signature, module path, or the arguments it's called with can silently break or invalidate the cache
 - `src/data/` in the frontend contains generated files — do not edit manually
-- **Running the tests** is documented in `react/test/AGENTS.md` (e2e) and `react/unit/AGENTS.md` (unit) — read these before trying to run them
+- **Running the tests** is documented in `react/test/AGENTS.md` (e2e) and `react/unit/AGENTS.md` (unit) — read these before trying to run them. DO NOT run tests in code reviews.
 
 ## What to Flag in Code Reviews
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Urban Stats (urbanstats.org) is a website for viewing statistics of geographic a
 - **Protobuf** is used for data serialization between Python and the frontend — changes to `.proto` files require running `bash scripts/build-protos.sh`
 - **`permacache`** caches Python function results to disk; changing a cached function's signature, module path, or the arguments it's called with can silently break or invalidate the cache
 - `src/data/` in the frontend contains generated files — do not edit manually
-- **Running the e2e tests** is documented in `react/test/AGENTS.md` — read it before trying to run them
+- **Running the tests** is documented in `react/test/AGENTS.md` (e2e) and `react/unit/AGENTS.md` (unit) — read these before trying to run them
 
 ## What to Flag in Code Reviews
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Urban Stats (urbanstats.org) is a website for viewing statistics of geographic a
 - **Protobuf** is used for data serialization between Python and the frontend — changes to `.proto` files require running `bash scripts/build-protos.sh`
 - **`permacache`** caches Python function results to disk; changing a cached function's signature, module path, or the arguments it's called with can silently break or invalidate the cache
 - `src/data/` in the frontend contains generated files — do not edit manually
+- **Running the e2e tests** is documented in `react/test/AGENTS.md` — read it before trying to run them
 
 ## What to Flag in Code Reviews
 

--- a/react/test/AGENTS.md
+++ b/react/test/AGENTS.md
@@ -16,6 +16,9 @@ That's the whole thing. In particular:
   shell doesn't expand it first. To narrow further, use `test.only` inside the test file.
 - Don't run the whole suite. The runner works through the matched files one at a
   time, whereas CI gives each file its own job — leave it to CI.
+- **Don't pipe the output through `head`, `tail`, or `grep`.** A run you truncate is a
+  run you have to do again, and these take minutes. The output is small enough to read
+  in full; if you find it too noisy to work with, say so instead of filtering it.
 
 ## Ports
 

--- a/react/test/AGENTS.md
+++ b/react/test/AGENTS.md
@@ -1,0 +1,30 @@
+# Running the e2e tests
+
+Run from `react/`:
+
+```
+direnv exec . npm run test:e2e -- '--test=test/checkbox_bug.test.ts'
+```
+
+That's the whole thing. In particular:
+
+- **Assume a dev server is already running, and don't start one.** The test runner
+  doesn't start or manage it. If nothing is serving the site, ask rather than
+  starting your own — a rebuild takes a long time.
+- `--test` is required. It may be a glob (`'test/mapper-*.test.ts'`); quote it so the
+  shell doesn't expand it first. To narrow further, use `test.only` inside the test file.
+- Don't run the whole suite. It takes hours; CI runs it in parallel per file.
+
+## Ports
+
+Tests target `http://localhost:$PORT`, defaulting to 8000. A checkout that runs
+alongside another one sets `PORT` and `TESTCAFE_PORT` in `.envrc`, and `direnv`
+only applies those to interactive shells — so a non-interactive shell will silently
+test against the wrong site (or fail to connect) unless you go through
+`direnv exec .`. `URBANSTATS_TEST_TARGET` overrides the URL entirely.
+
+## Other flags
+
+`--live` watches the test file and re-runs it, `--compare=true` runs the screenshot
+comparison, and `--docker` runs in a CI-equivalent container. See [README.md](README.md)
+for worked examples.

--- a/react/test/AGENTS.md
+++ b/react/test/AGENTS.md
@@ -10,10 +10,12 @@ That's the whole thing. In particular:
 
 - **Assume a dev server is already running, and don't start one.** The test runner
   doesn't start or manage it. If nothing is serving the site, ask rather than
-  starting your own — a rebuild takes a long time.
+  starting your own — `npm run watch` needs the path to the site repository, which
+  you have no way to guess.
 - `--test` is required. It may be a glob (`'test/mapper-*.test.ts'`); quote it so the
   shell doesn't expand it first. To narrow further, use `test.only` inside the test file.
-- Don't run the whole suite. It takes hours; CI runs it in parallel per file.
+- Don't run the whole suite. The runner works through the matched files one at a
+  time, whereas CI gives each file its own job — leave it to CI.
 
 ## Ports
 

--- a/react/unit/AGENTS.md
+++ b/react/unit/AGENTS.md
@@ -1,0 +1,31 @@
+# Running the unit tests
+
+Run from `react/`:
+
+```
+direnv exec . npm run test:unit -- '--test=unit/load_json.test.ts'
+```
+
+- `--test` is required. It may be a glob (`'unit/urban-stats-script-*.test.ts'`); quote
+  it so the shell doesn't expand it first. Running the whole suite with
+  `'unit/*.test.ts'` is fine — unlike the e2e tests, these are quick.
+- `test.only` is ignored unless you also pass `--only=true`.
+- `--parallel=N` sets how many files run at once; it defaults to the CPU count.
+
+## These tests need the dev server too
+
+Not obvious from the name: [util/fetch.ts](util/fetch.ts) points `global.fetch` at
+`http://localhost:$PORT`, so every test that loads site data (`load_json`, `search`,
+`random`, `relationship`, `map-partition`, ...) needs a dev server running, exactly like
+the e2e tests. Assume one is already running rather than starting one, and see
+[../test/AGENTS.md](../test/AGENTS.md) for why the command above goes through
+`direnv exec .` — `PORT` comes from `.envrc`, which doesn't reach a non-interactive
+shell. Getting this wrong points the tests at the wrong site, or at nothing.
+
+`fetch failed` / `ECONNRESET` from one of those tests means the dev server didn't
+serve the file, not that your change broke something.
+
+## Coverage
+
+`npm run test:unit:coverage` takes the same arguments. [README.md](README.md) covers
+viewing the results in VSCode.

--- a/react/unit/AGENTS.md
+++ b/react/unit/AGENTS.md
@@ -3,12 +3,16 @@
 Run from `react/`:
 
 ```
-direnv exec . npm run test:unit -- '--test=unit/load_json.test.ts'
+direnv exec . npm run test:unit -- '--test=unit/load_json.test.ts' --reporter=dot
 ```
 
 - `--test` is required. It may be a glob (`'unit/urban-stats-script-*.test.ts'`); quote
   it so the shell doesn't expand it first. Running the whole suite with
   `'unit/*.test.ts'` is fine — unlike the e2e tests, these are quick.
+- **Pass `--reporter=dot`, and don't pipe the output through `head`, `tail`, or
+  `grep`.** The default `spec` reporter prints a line per test, which buries the
+  result; `dot` prints one character per test and still ends with the full failure
+  detail, so a whole-suite run is short enough to read.
 - `test.only` is ignored unless you also pass `--only=true`.
 - `--parallel=N` sets how many files run at once; it defaults to the CPU count.
 

--- a/react/unit/AGENTS.md
+++ b/react/unit/AGENTS.md
@@ -26,9 +26,6 @@ the e2e tests. Assume one is already running rather than starting one, and see
 `direnv exec .` — `PORT` comes from `.envrc`, which doesn't reach a non-interactive
 shell. Getting this wrong points the tests at the wrong site, or at nothing.
 
-`fetch failed` / `ECONNRESET` from one of those tests means the dev server didn't
-serve the file, not that your change broke something.
-
 ## Coverage
 
 `npm run test:unit:coverage` takes the same arguments. [README.md](README.md) covers

--- a/react/unit/scripts/run-unit-tests.ts
+++ b/react/unit/scripts/run-unit-tests.ts
@@ -1,7 +1,7 @@
 /* c8 ignore start */
 import os from 'node:os'
 import { run } from 'node:test'
-import { spec } from 'node:test/reporters'
+import { dot, spec } from 'node:test/reporters'
 
 import { globSync } from 'glob'
 import { z } from 'zod'
@@ -16,6 +16,7 @@ const options = argumentParser({
         test: z.array(z.string()).default(() => { throw new Error(`Missing --test=<glob> argument. E.g. npm run test:unit -- --test='unit/*.test.ts'`) }),
         parallel: z.string().transform(string => parseInt(string)).default(os.cpus().length.toString()),
         only: booleanArgument({ defaultValue: false }),
+        reporter: z.union([z.literal('spec'), z.literal('dot')]).default('spec'),
     }).strict(),
 }).parse(process.argv.slice(2))
 
@@ -39,7 +40,7 @@ const testStream = run({
     only: options.only,
 })
 
-testStream.compose(spec).pipe(process.stdout)
+testStream.compose(options.reporter === 'dot' ? dot : spec).pipe(process.stdout)
 
 testStream.on('test:summary', (event) => {
     if (event.file === undefined) {


### PR DESCRIPTION
Agents repeatedly get test-running wrong in this repo, in ways that are invisible from the code: they try to build and serve the site themselves, or they run against port 8000 while the checkout they're in serves on another port, because `direnv` doesn't apply `.envrc` to non-interactive shells. The unit tests make this worse by not being self-contained — `unit/util/fetch.ts` points `global.fetch` at the dev server, so a good number of "unit" tests need the same running server as the e2e tests, which nothing about the name suggests.

So this adds `react/test/AGENTS.md` and `react/unit/AGENTS.md`, colocated with the tests they describe so nested-agent-file conventions pick them up, plus a pointer from `CLAUDE.md` for agents that only read that. Both commands in them were run to confirm they work.

The one code change is a `--reporter` option on the unit runner. The docs tell agents not to pipe test output through `head`/`tail`/`grep` — truncating a run you then have to repeat is a bad trade — but that instruction wasn't followable for the unit tests, where the `spec` reporter prints a line per test and a whole-suite run buries its own result. `dot` keeps the full failure detail and fits on a screen. `spec` stays the default so CI logs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)