### PR TITLE
Stop unit tests reusing dead keep-alive sockets

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -99,6 +99,7 @@
         "tsx": "^4.19.4",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.0.1",
+        "undici": "6.24.1",
         "xml-formatter": "^3.6.6",
         "zodcli": "^0.0.4"
       }

--- a/react/package.json
+++ b/react/package.json
@@ -68,6 +68,7 @@
     "tsx": "^4.19.4",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.1",
+    "undici": "6.24.1",
     "xml-formatter": "^3.6.6",
     "zodcli": "^0.0.4"
   },

--- a/react/unit/util/fetch.ts
+++ b/react/unit/util/fetch.ts
@@ -1,4 +1,11 @@
+import { Agent, setGlobalDispatcher } from 'undici'
+
 import { port } from '../../port'
+
+// Unit tests block the event loop for seconds at a time, which is long enough for the dev server to
+// close an idle keep-alive connection without undici getting a chance to evict it from its pool.
+// Reusing one of those connections fails with ECONNRESET, so don't reuse connections at all.
+setGlobalDispatcher(new Agent({ pipelining: 0 }))
 
 const originalFetch = global.fetch
 global.fetch = (path, ...args) => {


### PR DESCRIPTION
`unit/random.test.ts`'s `by-pop-usa-only` was failing with `fetch failed` / `ECONNRESET` out of `loadProtobuf`, before it could assert anything. Nothing is wrong with `byPopulation('USA')` — it passes fine in isolation.

The dev server sends `Keep-Alive: timeout=5`, so it closes idle connections after 5s. Each of these tests then blocks the event loop for 3-4s running 500,000 synchronous iterations, which is long enough that undici's socket-eviction timers never get to run. Tracing undici's diagnostics channels shows what happens:

```
[21ms]   socket 1 connected
[22ms]     -> socket 1 /index/pages_all.gz      <- 'uniform'
[3431ms] socket 2 connected
[3431ms]   -> socket 2 /index/pages_all.gz      <- 'by-pop'
[3432ms] socket 3 connected
[3432ms]   -> socket 3 /index/best_population_estimate.json
[7498ms]   -> socket 1 /index/pages_all.gz      <- 'by-pop-usa-only'
[7500ms]   !! error ECONNRESET
```

Socket 1 went idle at 22ms and the server closed it around 5s. undici never noticed, so the third test got the corpse. `by-pop-usa-only` is just the first test whose fetch lands more than 5s after a pooled socket went idle — its position in the file is what matters, not its argument, and `uniform-kenya-only` passes right afterwards because the reset purged the pool.

So this turns off connection reuse in the test fetch shim rather than reordering or rebalancing the tests around the timeout. The hazard applies to any unit test that does real work between fetches, and there's no pooling win to give up when the server is on localhost. Doing it through a dispatcher also means the fix doesn't depend on reasoning about undici's timer ordering.

That needs `undici` promoted from a transitive dependency to an explicit devDependency, pinned to the 6.24.1 already in the tree. One caveat: `setGlobalDispatcher` reaches Node's built-in fetch through a shared `Symbol.for('undici.globalDispatcher.1')` global, so a future Node that bumps that symbol version would stop applying the override. The failure mode there is this test failing loudly again, not silently passing on bad data.

Full unit suite passes (444 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)