### PR TITLE
Key stat-source settings by the (category, source) pairs that exist

### DIFF
--- a/react/src/page_template/settings.ts
+++ b/react/src/page_template/settings.ts
@@ -9,7 +9,7 @@ import { DefaultMap } from '../utils/DefaultMap'
 import { useObserverSets } from '../utils/useObserverSets'
 
 import { Theme } from './color-themes'
-import { allGroups, allYears, CategoryIdentifier, DataSource, GroupIdentifier, SourceCategoryIdentifier, SourceIdentifier, StatPath, statsTree, Year } from './statistic-tree'
+import { allGroups, allYears, CategoryIdentifier, DataSource, GroupIdentifier, SourceCategoryIdentifier, StatPath, statsTree, Year } from './statistic-tree'
 
 export type RelationshipKey = `related__${string}__${string}`
 
@@ -26,7 +26,8 @@ export type StatGroupKey<G extends GroupIdentifier = GroupIdentifier> = `show_st
 export type StatCategorySavedIndeterminateKey<C extends CategoryIdentifier = CategoryIdentifier> = `stat_category_saved_indeterminate_${C}`
 export type StatCategoryExpandedKey<C extends CategoryIdentifier = CategoryIdentifier> = `stat_category_expanded_${C}`
 export type StatYearKey<Y extends Year = Year> = `show_stat_year_${Y}`
-export type StatSourceKey<C extends SourceCategoryIdentifier = SourceCategoryIdentifier, S extends SourceIdentifier = SourceIdentifier> = `show_stat_source_${C}_${S}`
+// Distributes over the sources, so that only the (category, name) pairs that exist are keys
+export type StatSourceKey<D extends DataSource = DataSource> = D extends unknown ? `show_stat_source_${D['category']}_${D['name']}` : never
 
 export type TemperatureUnit = 'fahrenheit' | 'celsius'
 
@@ -57,7 +58,7 @@ export type SettingsDictionary = {
 & { [C in CategoryIdentifier as StatCategorySavedIndeterminateKey<C>]: GroupIdentifier[] }
 & { [C in CategoryIdentifier as StatCategoryExpandedKey<C>]: boolean }
 & { [Y in Year as StatYearKey<Y>]: boolean }
-& { [D in DataSource as StatSourceKey<D['category'], D['name']>]: boolean }
+& { [D in DataSource as StatSourceKey<D>]: boolean }
 & { [P in StatPathWithExtra as RowExpandedKey<P>]: boolean }
 & { [P in Exclude<StatPath, StatPathWithExtra> as RowExpandedKey<P>]?: undefined }
 
@@ -69,8 +70,8 @@ export function rowExpandedKey<P extends StatPath>(statpath: P): RowExpandedKey<
     return `expanded__${statpath}`
 }
 
-export function sourceEnabledKey<C extends SourceCategoryIdentifier, S extends SourceIdentifier>(d: { category: C, name: S }): StatSourceKey<C, S> {
-    return `show_stat_source_${d.category}_${d.name}`
+export function sourceEnabledKey<D extends DataSource>(d: D): StatSourceKey<D> {
+    return `show_stat_source_${d.category}_${d.name}` as StatSourceKey<D>
 }
 
 export function checkboxCategoryName(category: SourceCategoryIdentifier): string {


### PR DESCRIPTION
`StatSourceKey` took the source category and the source name as independent type parameters, so its default expansion (`StatSourceKey` with no arguments, as used for `StatGroupSettings`) was their full cross product. That is only correct because `Population` is currently the sole source category — the moment a second one exists, the type names combinations like `show_stat_source_Weather_GHSL` that have no corresponding setting, and `StatGroupSettings` starts demanding keys `SettingsDictionary` doesn't have.

Distribute over `DataSource` instead, so the key type contains exactly the (category, name) pairs that occur. The conditional (`D extends unknown ? … : never`) is what makes the template literal evaluate per union member rather than taking the union of each hole independently.

Inside `SettingsDictionary`'s mapped type this is a no-op — `D` is already a single member there — so this changes nothing about today's behavior. It's a type-only change; the emitted JS is identical.

The cast in `sourceEnabledKey` is unavoidable: TypeScript widens `` `show_stat_source_${d.category}_${d.name}` `` by unioning each hole separately, so it can't see that the two reads are correlated through the same `D`. I tried the cast-free variants (non-generic signature, and a non-distributive alias for the return type) — the first fails the same way, the second just moves the cross product to the call sites.

Verified: `tsc --noEmit` and `eslint` clean, 438 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)