### PR TITLE
Add a script for propagating fixes up a stacked chain of PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Urban Stats (urbanstats.org) is a website for viewing statistics of geographic a
 - **`permacache`** caches Python function results to disk; changing a cached function's signature, module path, or the arguments it's called with can silently break or invalidate the cache
 - `src/data/` in the frontend contains generated files — do not edit manually
 - **Running the tests** is documented in `react/test/AGENTS.md` (e2e) and `react/unit/AGENTS.md` (unit) — read these before trying to run them. DO NOT run tests in code reviews.
+- **Stacked PRs** (a change split into `01-*`, `02-*`, ... branches, each based on the last) have their own rules — read `scripts/AGENTS.md` before moving commits between them
 
 ## What to Flag in Code Reviews
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,46 @@
+# Working on a stacked chain of PRs
+
+A large change is sometimes split into a chain of branches, each based on the one below it
+and each with its own PR: `01-foo` off `main`, `02-bar` off `01-foo`, and so on. GitHub
+retargets a PR to `main` automatically when its base branch merges, as long as the repo
+deletes branches on merge — which this one does.
+
+## Rules
+
+**Merge up the chain, never rebase it.** Rebasing rewrites every branch above the one you
+touched, which needs a force push, which drops the line comments reviewers have already left.
+Merging keeps every push a fast-forward.
+
+**A fix belongs in the lowest branch that has the problem**, then gets merged upwards. Fixing
+it separately on each branch produces conflicts at every level.
+
+**Every branch has to pass CI on its own**, because each one is reviewed and merged
+separately. In particular `npm run unused-exports` runs `knip --include exports`, which fails
+on an exported symbol nothing imports — so a branch cannot widen a symbol's visibility for the
+benefit of a later branch. Export it in the branch that first consumes it.
+
+## The script
+
+`scripts/propagate-stack.sh` does the merging. It takes the local branches matching
+`[0-9][0-9]-*` in name order and merges each into the next.
+
+```bash
+scripts/propagate-stack.sh                     # merge up the stack
+scripts/propagate-stack.sh --from origin/main  # merge main into the bottom branch first
+scripts/propagate-stack.sh --check             # tsc, knip and lint each branch
+scripts/propagate-stack.sh --push              # push every branch afterwards
+scripts/propagate-stack.sh --pattern 'feat-*'  # a differently named chain
+```
+
+Re-running is how you recover from a conflict: merges that already happened report "Already
+up to date", so resolve the conflict, `git add -A && git commit --no-edit`, and run the script
+again to continue from where it stopped. It leaves you on the branch that failed; otherwise it
+returns you to the branch you started on.
+
+`--check` is worth running before `--push`. An intermediate branch can typecheck on its own
+but break once the branch below it changes, and CI will only tell you that one branch at a
+time.
+
+Screenshot tests are a separate matter: a visual change low in the stack invalidates the
+reference screenshots for every branch above it. Regenerate them through CI's
+`!updateScreenshots` command rather than locally.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -37,6 +37,9 @@ up to date", so resolve the conflict, `git add -A && git commit --no-edit`, and 
 again to continue from where it stopped. It leaves you on the branch that failed; otherwise it
 returns you to the branch you started on.
 
+If that branch is old enough to predate this script, the script won't be in the working tree
+to re-run. Copy it somewhere outside the repo first, or finish the chain by hand.
+
 `--check` is worth running before `--push`. An intermediate branch can typecheck on its own
 but break once the branch below it changes, and CI will only tell you that one branch at a
 time.

--- a/scripts/propagate-stack.sh
+++ b/scripts/propagate-stack.sh
@@ -16,7 +16,13 @@
 
 set -uo pipefail
 
-argv="$*"
+# The re-run command printed on a conflict. Absolute, because it is run from a branch that
+# may predate this script, and re-quoted, so an argument the shell would glob-expand survives
+# the copy-paste.
+self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+rerun=$(printf '%q ' "$self" "$@")
+rerun=${rerun% }
+
 pattern='[0-9][0-9]-*'
 base=''
 check=false
@@ -78,7 +84,7 @@ while read -r branch; do
 Conflict merging $prev into $branch. Resolve it, then:
 
     git add -A && git commit --no-edit
-    scripts/propagate-stack.sh $argv
+    $rerun
 
 Branches already merged are skipped, so the re-run continues from here.
 MSG
@@ -102,8 +108,9 @@ done <<< "$branches"
 
 if $push; then
     echo "==> pushing"
-    # One push, so a rejection leaves every branch unpushed rather than half the stack.
-    git push origin $branches || exit 1
+    # --atomic, so a rejection leaves every branch unpushed rather than half the stack.
+    # Without it git pushes each ref independently and only the rejected one stays behind.
+    git push --atomic origin $branches || exit 1
 fi
 
 echo "==> done"

--- a/scripts/propagate-stack.sh
+++ b/scripts/propagate-stack.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Propagate commits up a stacked-PR chain: merge each branch into the one above it, so a fix
+# made low in the stack reaches every branch built on top of it.
+#
+# The stack is the local branches matching --pattern, in name order (01-foo, 02-bar, ...).
+# Merging rather than rebasing means the pushes stay fast-forward, so review threads on the
+# PRs survive.
+#
+# Re-running is safe: merges that already happened report "Already up to date". So after
+# resolving a conflict, commit it and run the script again to pick up where it stopped.
+#
+#   scripts/propagate-stack.sh                   # merge up the stack
+#   scripts/propagate-stack.sh --from origin/main  # merge main into the bottom branch first
+#   scripts/propagate-stack.sh --check           # typecheck, knip and lint each branch
+#   scripts/propagate-stack.sh --push            # push every branch afterwards
+
+set -uo pipefail
+
+argv="$*"
+pattern='[0-9][0-9]-*'
+base=''
+check=false
+push=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --from) base="$2"; shift 2 ;;
+        --pattern) pattern="$2"; shift 2 ;;
+        --check) check=true; shift ;;
+        --push) push=true; shift ;;
+        --help|-h) awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print; next } NR > 1 { exit }' "$0"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+if [ -e "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+    echo "A merge is already in progress. Finish or abort it first." >&2
+    exit 1
+fi
+
+# Untracked files are left alone by checkout and merge, so they don't block us.
+if [ -n "$(git status --porcelain -uno)" ]; then
+    echo "You have uncommitted changes to tracked files. Commit or stash first." >&2
+    exit 1
+fi
+
+branches=$(git branch --list "$pattern" --sort=refname --format='%(refname:short)')
+
+if [ -z "$branches" ]; then
+    echo "No branches match '$pattern'." >&2
+    exit 1
+fi
+
+original=$(git rev-parse --abbrev-ref HEAD)
+trap 'git checkout -q "$original"' EXIT
+
+# Each branch's checks must pass on its own, since each is reviewed and merged separately.
+run_checks() {
+    (
+        cd react || exit 1
+        ./node_modules/.bin/tsc --noEmit -p tsconfig.json &&
+            npm run --silent unused-exports &&
+            npm run --silent lint:ci
+    )
+}
+
+prev="$base"
+
+while read -r branch; do
+    if [ -n "$prev" ]; then
+        echo "==> merging $prev into $branch"
+        git checkout -q "$branch" || exit 1
+        if ! git merge --no-edit "$prev"; then
+            cat >&2 <<MSG
+
+Conflict merging $prev into $branch. Resolve it, then:
+
+    git add -A && git commit --no-edit
+    scripts/propagate-stack.sh $argv
+
+Branches already merged are skipped, so the re-run continues from here.
+MSG
+            trap - EXIT
+            exit 1
+        fi
+    fi
+
+    if $check; then
+        echo "==> checking $branch"
+        git checkout -q "$branch" || exit 1
+        if ! run_checks; then
+            echo "Checks failed on $branch." >&2
+            trap - EXIT
+            exit 1
+        fi
+    fi
+
+    prev="$branch"
+done <<< "$branches"
+
+if $push; then
+    echo "==> pushing"
+    # One push, so a rejection leaves every branch unpushed rather than half the stack.
+    git push origin $branches || exit 1
+fi
+
+echo "==> done"


### PR DESCRIPTION
Splitting a large change into a chain of branches (`01-*` off `main`, `02-*` off `01-*`, ...) means every fix made low in the chain has to reach the branches above it. The obvious tool for that, `rebase`, is the wrong one here: it rewrites every branch above the one you touched, which requires a force push, which drops the line comments reviewers have already left. `scripts/propagate-stack.sh` merges instead, so every push stays a fast-forward.

Two decisions worth calling out:

- **Re-running the script *is* the conflict recovery path.** Merges that already happened report "Already up to date", so there's no separate `--continue` to implement or get wrong — resolve, commit, run it again.
- **`--check` runs tsc/knip/lint on each branch separately**, because an intermediate branch can typecheck on its own and then break once the branch below it changes. CI reports one branch at a time, so without this you find out serially.

`scripts/AGENTS.md` documents the constraints that aren't visible from the code — most importantly that `npm run unused-exports` (knip) fails any branch exporting a symbol that only a later branch imports, so exports have to land with their first consumer rather than being staged ahead of time. That one shaped how an in-flight stack had to be split.

No behaviour change to the site; this is tooling and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)