### PR TITLE
Make the article warnings unit-testable

### DIFF
--- a/react/src/components/ArticleWarnings.tsx
+++ b/react/src/components/ArticleWarnings.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode } from 'react'
 
-import { checkboxCategoryName } from '../page_template/settings'
 import { useMissingGroups, useSelectedGroups } from '../page_template/statistic-settings'
-import { Category, Group, StatPath, statPathToOrder, Year } from '../page_template/statistic-tree'
+import { Category, Group, StatPath, statPathToOrder } from '../page_template/statistic-tree'
 
 import { useScreenshotMode } from './screenshot'
+import { warningMessage } from './warning-message'
 import { warningRowIndices } from './warning-placement'
 
 /** An explanation of why some statistics aren't there, shown where they would have been. */
@@ -49,33 +49,9 @@ export function useArticleWarnings(): ArticleWarning[] {
         .map(({ groupOrCategory, reason }) => ({
             order: firstStatOrder(groupOrCategory),
             name: groupOrCategory.name,
-            content: reason.kind === 'year'
-                ? (
-                        <>
-                            {'Select '}
-                            <YearList years={reason.years} />
-                            {` to see ${theseStatistics(groupOrCategory)}.`}
-                        </>
-                    )
-                : (
-                        <>
-                            {'All '}
-                            <b>{checkboxCategoryName(reason.category)}</b>
-                            {` are disabled. Enable one to see ${theseStatistics(groupOrCategory)}.`}
-                        </>
-                    ),
+            content: warningMessage(reason, groupOrCategory),
         }))
         .sort((a, b) => a.order - b.order)
-}
-
-/** A category's warning stands in for a whole run of statistics, a group's for just its own. */
-function theseStatistics(groupOrCategory: Group | Category): string {
-    switch (groupOrCategory.kind) {
-        case 'Group':
-            return 'this statistic'
-        case 'Category':
-            return 'these statistics'
-    }
 }
 
 function firstStatOrder(groupOrCategory: Group | Category): number {
@@ -86,39 +62,4 @@ function firstStatOrder(groupOrCategory: Group | Category): number {
 export function placeWarnings(statPaths: StatPath[], warnings: ArticleWarning[]): WarningRow[] {
     const indices = warningRowIndices(statPaths, warnings.map(({ order }) => order))
     return warnings.map(({ name, content }, warningIndex) => ({ index: indices[warningIndex], name, content }))
-}
-
-function YearList({ years }: { years: Year[] }): ReactNode {
-    switch (years.length) {
-        case 0:
-            return null
-        case 1:
-            return <b>{years[0]}</b>
-        case 2:
-            return (
-                <>
-                    <b>{years[0]}</b>
-                    {' or '}
-                    <b>{years[1]}</b>
-                </>
-            )
-        case 3:
-            return (
-                <>
-                    <b>{years[0]}</b>
-                    {', '}
-                    <b>{years[1]}</b>
-                    {', or '}
-                    <b>{years[2]}</b>
-                </>
-            )
-        default:
-            return (
-                <>
-                    <b>{years[0]}</b>
-                    {', '}
-                    <YearList years={years.slice(1)} />
-                </>
-            )
-    }
 }

--- a/react/src/components/warning-message.tsx
+++ b/react/src/components/warning-message.tsx
@@ -1,0 +1,72 @@
+import React, { ReactNode } from 'react'
+
+import { checkboxCategoryName } from '../page_template/settings'
+import type { MissingGroupReason } from '../page_template/statistic-settings'
+import type { Category, Group, Year } from '../page_template/statistic-tree'
+
+/** What a warning says about the setting that is keeping a group's statistics off the page. */
+export function warningMessage(reason: MissingGroupReason, groupOrCategory: Group | Category): ReactNode {
+    switch (reason.kind) {
+        case 'year':
+            return (
+                <>
+                    {'Select '}
+                    <YearList years={reason.years} />
+                    {` to see ${theseStatistics(groupOrCategory)}.`}
+                </>
+            )
+        case 'source':
+            return (
+                <>
+                    {'All '}
+                    <b>{checkboxCategoryName(reason.category)}</b>
+                    {` are disabled. Enable one to see ${theseStatistics(groupOrCategory)}.`}
+                </>
+            )
+    }
+}
+
+/** A category's warning stands in for a whole run of statistics, a group's for just its own. */
+function theseStatistics(groupOrCategory: Group | Category): string {
+    switch (groupOrCategory.kind) {
+        case 'Group':
+            return 'this statistic'
+        case 'Category':
+            return 'these statistics'
+    }
+}
+
+function YearList({ years }: { years: Year[] }): ReactNode {
+    switch (years.length) {
+        case 0:
+            return null
+        case 1:
+            return <b>{years[0]}</b>
+        case 2:
+            return (
+                <>
+                    <b>{years[0]}</b>
+                    {' or '}
+                    <b>{years[1]}</b>
+                </>
+            )
+        case 3:
+            return (
+                <>
+                    <b>{years[0]}</b>
+                    {', '}
+                    <b>{years[1]}</b>
+                    {', or '}
+                    <b>{years[2]}</b>
+                </>
+            )
+        default:
+            return (
+                <>
+                    <b>{years[0]}</b>
+                    {', '}
+                    <YearList years={years.slice(1)} />
+                </>
+            )
+    }
+}

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -152,15 +152,18 @@ function reasonKey(reason: MissingGroupReason): string {
  * Which selected groups are showing no statistics, and why. Groups are consolidated into their
  * category only when the whole category is missing for the same reason.
  */
-export function useMissingGroups(): MissingGroup[] {
-    const selectedGroups = useSelectedGroups()
-    const selectedYears = useSelectedYears()
-    const statPathsAll = useStatPathsAll()
-    const settings = useSettings(groupYearKeys())
-    const consolidateGroups = useConsolidateGroups()
-
-    const pageStatPaths = useMemo(() => new Set(statPathsAll.flat()), [statPathsAll])
-    const ambiguousSources = useMemo(() => findAmbiguousSourcesAll(statPathsAll), [statPathsAll])
+export function missingGroups(
+    { selectedGroups, selectedYears, statPathsAll, settings, availableTree }: {
+        selectedGroups: Group[]
+        selectedYears: Year[]
+        statPathsAll: StatPath[][]
+        settings: StatGroupSettings
+        availableTree: AvailableTree
+    },
+): MissingGroup[] {
+    const consolidateGroups = consolidateGroupsIn(availableTree)
+    const pageStatPaths = new Set(statPathsAll.flat())
+    const ambiguousSources = findAmbiguousSourcesAll(statPathsAll)
 
     const missingReason = (group: Group): MissingGroupReason | undefined => {
         // Which years the group has data for is asked of this page rather than of the whole tree,
@@ -209,13 +212,22 @@ export function useMissingGroups(): MissingGroup[] {
         consolidateGroups(groups).map(groupOrCategory => ({ groupOrCategory, reason })))
 }
 
+export function useMissingGroups(): MissingGroup[] {
+    const selectedGroups = useSelectedGroups()
+    const selectedYears = useSelectedYears()
+    const statPathsAll = useStatPathsAll()
+    const settings = useSettings(groupYearKeys())
+    const availableTree = useAvailableTree()
+
+    return missingGroups({ selectedGroups, selectedYears, statPathsAll, settings, availableTree })
+}
+
 /**
  * If all of the groups in a category are present in-order in the list, replace them with that category
  *
  * `groups` **must** be a subset of available groups
  */
-function useConsolidateGroups(): (groups: Group[]) => (Group | Category)[] {
-    const { categories: availableCategories, groups: availableGroups } = useAvailableTree()
+function consolidateGroupsIn({ categories: availableCategories, groups: availableGroups }: AvailableTree): (groups: Group[]) => (Group | Category)[] {
     return (groups) => {
         const result: (Group | Category)[] = []
         let indexOfGroup = 0
@@ -281,20 +293,24 @@ function getAvailableCategories(contextStatPaths: StatPath[]): Category[] {
     return statsTree.filter(category => intersectsPage(category.statPaths, pageStatPaths))
 }
 
+interface AvailableTree { categories: Category[], groups: Set<Group> }
+
+export function getAvailableTree(statPathsAll: StatPath[][]): AvailableTree {
+    const contextStatPaths = statPathsAll.flat()
+    return {
+        categories: getAvailableCategories(contextStatPaths),
+        groups: new Set(getAvailableGroups(contextStatPaths)),
+    }
+}
+
 /**
  * The parts of the statistic tree this page has data for. Memoized on the page's own stat
  * paths, which only change on navigation: the tree is scanned once per category rendered,
  * and again on every checkbox click and every keystroke in the search box.
  */
-function useAvailableTree(): { categories: Category[], groups: Set<Group> } {
+function useAvailableTree(): AvailableTree {
     const statPathsAll = useStatPathsAll()
-    return useMemo(() => {
-        const contextStatPaths = statPathsAll.flat()
-        return {
-            categories: getAvailableCategories(contextStatPaths),
-            groups: new Set(getAvailableGroups(contextStatPaths)),
-        }
-    }, [statPathsAll])
+    return useMemo(() => getAvailableTree(statPathsAll), [statPathsAll])
 }
 
 export function useAvailableGroups(category?: Category): Group[] {

--- a/react/unit/missing-groups.test.ts
+++ b/react/unit/missing-groups.test.ts
@@ -1,0 +1,92 @@
+import assert from 'assert/strict'
+import { mock, test } from 'node:test'
+
+import { createElement, Fragment } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import './util/localStorage'
+import './util/window'
+import { warningMessage } from '../src/components/warning-message'
+import type { StatGroupKey, StatSourceKey, StatYearKey } from '../src/page_template/settings'
+import type { StatGroupSettings } from '../src/page_template/statistic-settings'
+import type { StatPath } from '../src/page_template/statistic-tree'
+
+// Only the hooks in statistic-settings go through the navigator, which builds the whole router as
+// it loads. These tests hand the statistics and the settings over directly instead.
+mock.module('../src/navigation/Navigator', { namedExports: { Navigator: {} } })
+
+const { getAvailableGroups, getAvailableTree, getAvailableYears, groupYearKeys, missingGroups } = await import('../src/page_template/statistic-settings')
+
+/**
+ * The statistics an article page has, as the site would give them: every path the region has data
+ * for, whatever the settings say about showing it.
+ */
+const california: StatPath[] = [
+    'population', 'population_2010', 'population_change_2010', 'population_2000', 'population_change_2000',
+    'gpw_population',
+    'generation_silent', 'generation_boomer', 'generation_genx',
+    'generation_millenial', 'generation_genz', 'generation_genalpha',
+    'area',
+]
+
+const massachusetts = california
+
+/** A Canadian province: the same statistics, but from the Canadian census instead of the US one. */
+const ontario: StatPath[] = [
+    'population_2021_canada', 'population_2011_canada', 'population_change_2011_canada',
+    'gpw_population',
+    'generation_silent_canada', 'generation_boomer_canada', 'generation_genx_canada',
+    'generation_millenial_canada', 'generation_genz_canada', 'generation_genalpha_canada',
+    'area',
+]
+
+type EnabledKey = StatGroupKey | StatYearKey | StatSourceKey
+
+const populationGroup: EnabledKey[] = ['show_stat_group_population']
+
+function settingsWith(enabled: EnabledKey[]): StatGroupSettings {
+    const settings = Object.fromEntries(groupYearKeys().map(key => [key, false])) as StatGroupSettings
+    for (const key of enabled) {
+        settings[key] = true
+    }
+    return settings
+}
+
+/** The warnings the page would show, as `<statistic name>: <message>` with the bold parts marked. */
+function warnings(statPathsAll: StatPath[][], enabled: EnabledKey[]): string[] {
+    const settings = settingsWith(enabled)
+    const contextStatPaths = statPathsAll.flat()
+    return missingGroups({
+        selectedGroups: getAvailableGroups(contextStatPaths).filter(group => settings[`show_stat_group_${group.id}`]),
+        selectedYears: getAvailableYears(contextStatPaths).filter(year => settings[`show_stat_year_${year}`]),
+        statPathsAll,
+        settings,
+        availableTree: getAvailableTree(statPathsAll),
+    }).map(({ groupOrCategory, reason }) => {
+        const message = renderToStaticMarkup(createElement(Fragment, null, warningMessage(reason, groupOrCategory)))
+        return `${groupOrCategory.name}: ${message.replaceAll(/<\/?b>/g, '**')}`
+    })
+}
+
+void test('a year no enabled source has is about the year', () => {
+    assert.deepStrictEqual(
+        warnings([massachusetts, california], [
+            ...populationGroup, 'show_stat_year_2010', 'show_stat_source_Population_GHSL',
+        ]),
+        ['Population: Select **2020** to see this statistic.'],
+    )
+})
+
+void test('every year the page has is named, not every year the tree has', () => {
+    assert.deepStrictEqual(
+        warnings([california], [...populationGroup, 'show_stat_source_Population_US Census']),
+        ['Population: Select **2020**, **2010**, or **2000** to see this statistic.'],
+    )
+})
+
+void test('no source enabled is about the sources', () => {
+    assert.deepStrictEqual(
+        warnings([california, ontario], [...populationGroup, 'show_stat_year_2020']),
+        ['Population: All **Population Sources** are disabled. Enable one to see this statistic.'],
+    )
+})

--- a/react/unit/util/window.ts
+++ b/react/unit/util/window.ts
@@ -1,0 +1,5 @@
+/**
+ * Enough of a browser for modules that touch `window` as they load. Nothing here is read back --
+ * the code doing the touching is setting up for a page that these tests never render.
+ */
+global.window = { history: {} } as unknown as Window & typeof globalThis


### PR DESCRIPTION
Groundwork for #2164 / #2165: the logic behind "Select 2020 to see this statistic" had no test, because reaching it meant rendering a page.

Two splits, no behavior change:

- `missingGroups` becomes a plain function taking the selected groups, years, settings and stat paths. `useMissingGroups` is now just the hook that reads those off the page. `consolidateGroupsIn` and `getAvailableTree` come along for the same reason.
- The message a warning shows moves out of `ArticleWarnings.tsx` into `warning-message.tsx`, so a test can import it without pulling in screenshot mode and the rest of the table.

`unit/missing-groups.test.ts` then covers the warnings as they read today, message text included. It mocks out the navigator, which `statistic-settings` only needs for its hooks and which builds the whole router as it loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)