### PR TITLE
Skip redundant checks when re-running propagate-stack.sh

### DIFF
--- a/scripts/propagate-stack.sh
+++ b/scripts/propagate-stack.sh
@@ -6,8 +6,9 @@
 # Merging rather than rebasing means the pushes stay fast-forward, so review threads on the
 # PRs survive.
 #
-# Re-running is safe: merges that already happened report "Already up to date". So after
-# resolving a conflict, commit it and run the script again to pick up where it stopped.
+# Re-running is safe: merges that already happened report "Already up to date", and --check
+# rechecks a branch only if its contents changed. So after resolving a conflict, commit it and
+# run the script again to pick up where it stopped.
 #
 #   scripts/propagate-stack.sh                   # merge up the stack
 #   scripts/propagate-stack.sh --from origin/main  # merge main into the bottom branch first
@@ -72,6 +73,10 @@ run_checks() {
     )
 }
 
+# Trees that have already passed, so a re-run after a conflict doesn't recheck the branches
+# below it. Keyed by tree rather than commit, because the checks only look at the worktree.
+checked="$(git rev-parse --git-dir)/propagate-stack-checked"
+
 prev="$base"
 
 while read -r branch; do
@@ -86,7 +91,7 @@ Conflict merging $prev into $branch. Resolve it, then:
     git add -A && git commit --no-edit
     $rerun
 
-Branches already merged are skipped, so the re-run continues from here.
+The re-run starts from the bottom again, but the work below here is already done.
 MSG
             trap - EXIT
             exit 1
@@ -94,12 +99,18 @@ MSG
     fi
 
     if $check; then
-        echo "==> checking $branch"
         git checkout -q "$branch" || exit 1
-        if ! run_checks; then
-            echo "Checks failed on $branch." >&2
-            trap - EXIT
-            exit 1
+        tree=$(git rev-parse HEAD^{tree})
+        if grep -qxF "$tree" "$checked" 2>/dev/null; then
+            echo "==> $branch unchanged since it last passed, skipping checks"
+        else
+            echo "==> checking $branch"
+            if ! run_checks; then
+                echo "Checks failed on $branch." >&2
+                trap - EXIT
+                exit 1
+            fi
+            echo "$tree" >> "$checked"
         fi
     fi
 


### PR DESCRIPTION
`--check` is the expensive part of the stack script: tsc, knip and lint on every branch. Hitting a conflict partway up means resolving it and re-running, and the re-run started over from the bottom, redoing all of that work on branches that hadn't changed.

The script now records the trees that passed in `.git/propagate-stack-checked` and skips a branch whose tree is already there. Keyed by tree rather than commit for two reasons: the checks only read the worktree, so an amend that leaves contents identical shouldn't force a recheck, and when a merge up the stack is a no-op the branch above shares a tree with the one below and gets checked once instead of twice.

The cache is content-only, so it won't notice an `npm install` or a change outside the repo that affects the results. `rm .git/propagate-stack-checked` clears it if that ever bites.

Also drops a claim in the conflict message that already-merged branches are skipped — they aren't, the re-run redoes them as no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)