### PR TITLE
Cut the comments that just restate the code

### DIFF
--- a/react/src/components/ScreenshotAwareLayer.tsx
+++ b/react/src/components/ScreenshotAwareLayer.tsx
@@ -27,8 +27,8 @@ export function ScreenshotAwareLayer(props: LayerProps & { id: string }): ReactN
                 await new Promise(resolve => requestAnimationFrame(resolve))
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Linter is too dumb
                 if (cancelled) {
-                    // Either the effect is about to re-run, or we unmounted -- in which case
-                    // unregistering has already settled the screenshot's wait for us.
+                    // The cleanup has either unregistered us or is about to re-run the effect,
+                    // so the screenshot's wait is not ours to settle any more.
                     return
                 }
                 if (map._removed) {

--- a/react/src/components/article-table.tsx
+++ b/react/src/components/article-table.tsx
@@ -59,8 +59,8 @@ export function ArticleTable(props: {
     const layout = useArticleTableLayout()
     const navContext = useContext(Navigator.Context)
 
-    // Subscribed to here rather than in the panel, so that changing which statistics are
-    // shown only re-renders the table, not the map and the surrounding page.
+    // Subscribed to here rather than in the panel, so changing the statistics shown doesn't
+    // re-render the map and the surrounding page.
     const settings = useSettings(groupYearKeys())
     const filteredRows = props.rows(settings)[0]
 

--- a/react/src/components/comparison-panel.tsx
+++ b/react/src/components/comparison-panel.tsx
@@ -189,8 +189,6 @@ function ComparisonPanelContents(props: ComparisonPanelProps & { screenshotConte
     )
     const numExpandedExtras = expandedByStatIndex.filter(v => v).length
 
-    // Transposed, a warning stands in for a column, so it takes up a column's worth of width
-    // alongside the statistics that are still shown.
     const numTransposedColumns = dataByArticleStat[0].length + warningPlacements.length
 
     let widthColumns = computeComparisonWidthColumns(localArticlesToUse.length, includeOrdinals)
@@ -267,11 +265,7 @@ function ComparisonPanelContents(props: ComparisonPanelProps & { screenshotConte
 
     const { updatedNameSpecs: statisticNameHeaderSpecs, groupNames: statisticNameGroupNames } = computeNameSpecsWithGroups(statisticNameHeaderSpecsOriginal)
 
-    /**
-     * Transposed, a warning stands in for a column, so it takes a column's worth of space in the
-     * header and in every row. Each warning shifts the ones after it along by one, so the nth
-     * warning's own column ends up n places later than the statistic it displaces.
-     */
+    // Each warning inserted shifts the ones after it along by one.
     const warningColumnAt = (warningIndex: number): number => warningPlacements[warningIndex].index + warningIndex
 
     function insertWarningColumns<T>(values: T[], valueForWarning: (warning: WarningRow) => T): T[] {
@@ -353,10 +347,8 @@ function ComparisonPanelContents(props: ComparisonPanelProps & { screenshotConte
         simpleOrdinals: true,
     }
 
-    // Transposing swaps which axis the statistics run along, so it swaps the headers, the row
-    // specs, which direction the expanded plots stretch in, and whether a warning stands in for
-    // a row or a column. With no statistics at all there are no transposed rows to hang columns
-    // off, so the warnings fall back to rows there.
+    // With no statistics at all there are no transposed rows to hang warning columns off, so the
+    // warnings fall back to rows there.
     const orientedSpecs = transpose
         ? {
                 superHeaderSpec: { headerSpecs: transposedHeaderSpecs, showBottomBar: false, groupNames: transposedGroupNames },

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -110,8 +110,6 @@ export function TableContents(props: TableContentsProps): ReactNode {
         [leftHeaderSpecs, superHeaderSpecs],
     )
 
-    // In screenshot mode the disclaimers move into numbered footnotes below the table, so the
-    // cells that carry one need to show the symbol that points at theirs.
     const withFootnote = (spec: CellSpec): CellSpec =>
         screenshotMode && spec.type === 'statistic-name' && spec.row?.disclaimer !== undefined
             ? { ...spec, footnoteSymbol: disclaimerFootnotes.getSymbol(spec.row.disclaimer) }
@@ -143,8 +141,7 @@ export function TableContents(props: TableContentsProps): ReactNode {
         ? undefined
         : { ...props.superHeaderSpec, headerSpecs: props.superHeaderSpec.headerSpecs.map(withFootnote) }
 
-    // Warnings are interleaved with the statistic rows, so the striping has to be counted out
-    // over both rather than read off the statistic's index.
+    // Warnings are interleaved with the statistic rows, so the stripes are counted over both.
     const warningRows = props.warningRows ?? []
     const bodyRows: ReactNode[] = []
     let nextWarning = 0

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -166,8 +166,7 @@ export function missingGroups(
     const ambiguousSources = findAmbiguousSourcesAll(statPathsAll)
 
     const missingReason = (group: Group): MissingGroupReason | undefined => {
-        // Which years the group has data for is asked of this page rather than of the whole tree,
-        // so that a page that only goes back to 2010 says so instead of naming a year it lacks.
+        // Restricted to this page, so a page that only goes back to 2010 doesn't name an earlier year.
         const paths = Array.from(group.statPaths).filter(path => pageStatPaths.has(path))
         if (paths.some(path => statIsEnabled(path, settings, ambiguousSources))) {
             return undefined
@@ -179,9 +178,8 @@ export function missingGroups(
             return year === null || selectedYears.includes(year)
         })
         if (pathsInSelectedYears.length > 0) {
-            // Everything in the selected years is disabled by its source, so we can name that source
-            // category if they agree on one -- unless the group has a statistic from an enabled
-            // source in another year, which would make "all of them are disabled" a lie.
+            // Blaming a source category requires that no year of the group has it enabled,
+            // otherwise "all of them are disabled" would be a lie.
             const categories = new Set(pathsInSelectedYears.map(path => statParents.get(path)!.source.category))
             const [category] = categories
             if (categories.size === 1
@@ -189,7 +187,6 @@ export function missingGroups(
                 return { kind: 'source', category }
             }
         }
-        // Otherwise it is the years that are missing: the ones selecting would bring the group back.
         const yearsToSelect = new Set(fromEnabledSources.map(path => statParents.get(path)!.year))
         const years = allYears.filter(year => yearsToSelect.has(year))
         return years.length > 0 ? { kind: 'year', years } : undefined

--- a/react/test/comparison_warnings.test.ts
+++ b/react/test/comparison_warnings.test.ts
@@ -33,7 +33,6 @@ test('comparison-warnings-in-place', async (t) => {
     await selectMainWithoutYears(t)
     await t.expect(await warningRowNames()).eql(missingMainGroups)
     await t.expect(warningNamed('Select 2020, 2010, or 2000 to see this statistic.', 'Population').exists).ok()
-    // The warnings stand where the statistics would have been, above the ones that are still shown
     const rows = Selector('.for-testing-table-row')
     await t.expect(rows.nth(0).find('[data-test-id=article-warning]').exists).ok()
     await t.expect(rows.nth(3).find('[data-test-id=article-warning]').exists).notOk()
@@ -41,8 +40,7 @@ test('comparison-warnings-in-place', async (t) => {
     await screencap(t)
 })
 
-// Comparing across countries is what makes the data sources choosable rather than forced on, so
-// it is the only place the sources can all be turned off.
+// Comparing across countries is the only place all the sources can be turned off.
 urbanstatsFixture('comparison warnings across data sources', comparisonPage([
     'Ontario, Canada',
     'California, USA',
@@ -52,7 +50,6 @@ test('comparison-warnings-all-sources-disabled', async (t) => {
     // GHSL is off by default, so turning off the two censuses leaves nothing enabled
     await checkTextboxes(t, ['US Census', 'Canadian Census'])
     await t.expect(warningNamed('All Population Sources are disabled. Enable one to see this statistic.', 'Population').exists).ok()
-    // Statistics that don't come from a Population source are unaffected
     await t.expect(Selector('a').withExactText('Area').exists).ok()
     await screencap(t)
 })
@@ -72,8 +69,7 @@ test('comparison-warnings-year-missing-from-enabled-source', async (t) => {
     await t.expect(warningNamed('Select 2020 to see this statistic.', 'Population').exists).ok()
 })
 
-// Six regions against three warning columns and two statistics, which is enough regions that the
-// table is narrower transposed.
+// Enough regions that the table is narrower transposed.
 urbanstatsFixture('transposed comparison warnings', comparisonPage([
     'Santa Clarita city, California, USA',
     'Santa Clara city, California, USA',
@@ -86,15 +82,12 @@ urbanstatsFixture('transposed comparison warnings', comparisonPage([
 test('comparison-transposed-warnings-are-columns', async (t) => {
     await selectMainWithoutYears(t)
     await t.expect(Selector('span.serif.value').withExactText('Region').exists).ok('the table should have transposed')
-    // Transposed, the statistics run along the columns, so each warning stands in for a column:
-    // its group's name heads the column and the message is drawn down it.
     const warnings = Selector('[data-test-id=article-warning]')
     await t.expect(warnings.count).eql(missingMainGroups.length)
     await t.expect(warnings.nth(0).innerText).contains('Select 2020, 2010, or 2000 to see this statistic.')
-    // The names are in the super header, ahead of the statistics that are still shown
     const columnNames = await columnHeaderNames()
     await t.expect(columnNames).eql([...missingMainGroups, 'Area', 'Compactness'])
-    // Warnings stand in for columns here, so none of them takes a row
+    // The warnings are columns here, so none of them takes a row
     await t.expect(Selector('[data-test-id=article-warning-name]').exists).notOk()
     await screencap(t)
 })

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -200,7 +200,7 @@ async function runTest(test: string): Promise<TestResult> {
         return { ...result, timeLimitSeconds }
     }
 
-    // Assertion failures take precedence: a test that fails stops early, so its screenshots aren't comparable
+    // A test that fails stops early, so its screenshots aren't comparable
     if (!result.assertionsPassed) {
         return { status: 'failure', duration: result.duration, reason: 'assertions' }
     }

--- a/react/test/scripts/util.ts
+++ b/react/test/scripts/util.ts
@@ -38,7 +38,6 @@ export const testHistorySchema = z.array(z.object({
     result: z.discriminatedUnion('status', [
         z.object({ status: z.literal('timeout'), timeLimitSeconds: z.number() }),
         z.object({ status: z.literal('success'), duration: z.number() }),
-        // The reason is displayed as-is, so that failure reports say what to go look at
         z.object({ status: z.literal('failure'), duration: z.number(), reason: z.enum(['assertions', 'screenshots']) }),
     ]),
     retries: z.number(),

--- a/react/unit/missing-groups.test.ts
+++ b/react/unit/missing-groups.test.ts
@@ -11,8 +11,8 @@ import type { StatGroupKey, StatSourceKey, StatYearKey } from '../src/page_templ
 import type { StatGroupSettings } from '../src/page_template/statistic-settings'
 import type { StatPath } from '../src/page_template/statistic-tree'
 
-// Only the hooks in statistic-settings go through the navigator, which builds the whole router as
-// it loads. These tests hand the statistics and the settings over directly instead.
+// Importing the navigator builds the whole router. These tests only use the non-hook exports,
+// which take the statistics and settings directly.
 mock.module('../src/navigation/Navigator', { namedExports: { Navigator: {} } })
 
 const { getAvailableGroups, getAvailableTree, getAvailableYears, groupYearKeys, missingGroups } = await import('../src/page_template/statistic-settings')

--- a/react/unit/warning-placement.test.ts
+++ b/react/unit/warning-placement.test.ts
@@ -10,25 +10,22 @@ function order(path: StatPath): number {
     return result!
 }
 
-// Real paths, in tree order: the Population group, then Population Density, then Area. Area has no
-// year, so it is the row that survives when the years are deselected.
+// Real paths, in tree order. Area has no year, so it survives deselecting the years.
 const population: StatPath = 'population'
 const populationDensity: StatPath = 'ad_1'
 const area: StatPath = 'area'
 
 // A metadata path, and two densities that sort after it. Metadata renders at the end of the table
-// rather than in tree order, so these three are rendered out of order relative to each other.
+// rather than in tree order, so these three render out of order relative to each other.
 const fips: StatPath = 'metadata_show_metadata_fips'
 const quarterKmDensity: StatPath = 'ad_0.25'
 const halfKmDensity: StatPath = 'ad_0.5'
 
 void test('a warning goes where its statistics would have been', () => {
-    // Population is missing, so its warning belongs above the density and area rows.
     assert.deepStrictEqual(
         warningRowIndices([populationDensity, area], [order(population)]),
         [0],
     )
-    // Density is missing, so its warning belongs between them.
     assert.deepStrictEqual(
         warningRowIndices([population, area], [order(populationDensity)]),
         [1],
@@ -59,8 +56,8 @@ void test('metadata rows at the end of the table do not displace warnings', () =
         order(fips) < order(quarterKmDensity) && order(quarterKmDensity) < order(halfKmDensity),
         'this test needs a metadata path that sorts before both densities',
     )
-    // The FIPS row sorts before the missing density but renders after it, so counting the rows that
-    // precede the warning would wrongly push it past the density row it belongs above.
+    // FIPS sorts before the missing density but renders after it, so counting preceding rows
+    // would wrongly push the warning past the density row it belongs above.
     assert.deepStrictEqual(
         warningRowIndices([population, halfKmDensity, fips], [order(quarterKmDensity)]),
         [1],


### PR DESCRIPTION
The recent warning-placement work (#2120 onwards) accumulated a lot of comments that narrate the line below them. They cost attention without adding anything, and they go stale the moment the code moves.

This removes those and trims the rest down to the clause that isn't recoverable from reading the code — e.g. the `warningColumnAt` doc comment is now the one sentence explaining the `+ warningIndex`, rather than a paragraph re-describing what transposing does.

Deliberately kept are the comments carrying knowledge from outside the file:

- the ECONNRESET explanation in the unit-test fetch setup, which is the kind of thing nobody would rederive
- the `D extends unknown` typing trick in `settings.ts`
- why the source category is repeated on each source in the exported metadata
- the fixture comments explaining why a particular set of regions was picked (six regions is what makes the comparison table transpose — deleting a region silently changes what the test covers)

Comments only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)