### PR TITLE
Cut more comments that only restate the code

### DIFF
--- a/react/src/components/ArticleWarnings.tsx
+++ b/react/src/components/ArticleWarnings.tsx
@@ -7,11 +7,9 @@ import { useScreenshotMode } from './screenshot'
 import { warningMessage } from './warning-message'
 import { warningRowIndices } from './warning-placement'
 
-/** An explanation of why some statistics aren't there, shown where they would have been. */
 export interface ArticleWarning {
     /** Where the missing statistics sit in statistic tree order. */
     order: number
-    /** Goes in the left header, where the statistic's name would be. */
     name?: string
     content: ReactNode
 }
@@ -58,7 +56,6 @@ function firstStatOrder(groupOrCategory: Group | Category): number {
     return Math.min(...Array.from(groupOrCategory.statPaths).map(path => statPathToOrder.get(path)!))
 }
 
-/** Places each warning at the row its statistics would have gone in, given the table's rows. */
 export function placeWarnings(statPaths: StatPath[], warnings: ArticleWarning[]): WarningRow[] {
     const indices = warningRowIndices(statPaths, warnings.map(({ order }) => order))
     return warnings.map(({ name, content }, warningIndex) => ({ index: indices[warningIndex], name, content }))

--- a/react/src/components/article-table.tsx
+++ b/react/src/components/article-table.tsx
@@ -18,7 +18,6 @@ import { ColumnIdentifier } from './table'
 
 const allColumns: ColumnIdentifier[] = ['statval', 'statval_unit', 'statistic_percentile', 'statistic_ordinal', 'pointer_in_class', 'pointer_overall']
 
-/** A plot for each row whose extras are currently expanded, and undefined for the rest. */
 function useExpandedPlotSpecs(rows: ArticleRow[], article: Article): (PlotSpec | undefined)[] {
     const colors = useColors()
     const expanded = useExpandedByStat(rows.map(row => row.statpath), index => rows[index].extraStats.length > 0)

--- a/react/src/components/checkbox-setting.tsx
+++ b/react/src/components/checkbox-setting.tsx
@@ -3,15 +3,9 @@ import React, { CSSProperties, ReactNode, useEffect, useId, useRef } from 'react
 import { useColors } from '../page_template/colors'
 import { isStagedChange, SettingsDictionary, useSetting, useSettingInfo } from '../page_template/settings'
 
-/**
- * The checkbox controls, which started out in the sidebar but are used all over: the
- * mapper's editors, the quiz, the histogram.
- */
-
 // type representing a key of SettingsDictionary that have boolean values
 export type BooleanSettingKey = keyof { [K in keyof SettingsDictionary as SettingsDictionary[K] extends boolean | undefined ? K : never]: boolean }
 
-/** What a checkbox needs to render a boolean setting, wherever the checkbox itself lives. */
 function useBooleanSetting(settingKey: BooleanSettingKey, forcedOn?: boolean): {
     checked: boolean
     setChecked: (checked: boolean) => void
@@ -63,7 +57,6 @@ type CheckboxSettingCustomProps = CheckboxSettingCustomJustInputProps & {
     classNameToUse?: string
 }
 
-/** Marks a control whose value staging is currently changing. */
 export function useHighlightStyle(highlight: boolean | undefined): CSSProperties {
     const colors = useColors()
     return {

--- a/react/src/components/congressional-table/model.ts
+++ b/react/src/components/congressional-table/model.ts
@@ -17,10 +17,7 @@ export interface CongressionalColumnData {
     representatives: CongressionalRepresentativeEntry[]
 }
 
-/**
- * Returns undefined for rows that aren't a representatives metadata row. Takes the
- * row structurally so it works with both ArticleRow and StatisticCellRenderingInfo.
- */
+/** Takes the row structurally so it works with both ArticleRow and StatisticCellRenderingInfo. */
 export function congressionalDataForRow(
     row: { kind: 'statistic' } | { kind: 'metadata', statval: MetadataStatValue },
     longname: string,

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -16,8 +16,6 @@ import { ArticleRow } from './load-article'
 export type CSVExportData = () => { csvData: string[][], csvFilename: string }
 
 /**
- * The CSV export for a table of articles, named after `filenameBase`.
- *
  * The rows are built from the settings read at the moment the export is requested, so the
  * caller doesn't have to hold them for the export's sake.
  */

--- a/react/src/components/plots.tsx
+++ b/react/src/components/plots.tsx
@@ -207,10 +207,7 @@ function resolveStatYears(rows: ArticleRow[], statIndex: number): { idx: number,
     return chosen
 }
 
-/**
- * Whether each statistic's extras are currently expanded, in statistic order. Only the
- * statistics that have extras are subscribed to, since the rest can never be expanded.
- */
+/** Only the statistics that have extras are subscribed to, since the rest can never be expanded. */
 export function useExpandedByStat(statpaths: StatPath[], hasExtras: (statIndex: number) => boolean): boolean[] {
     const expandedSettings = useSettings(statpaths.filter((_, index) => hasExtras(index)).map(rowExpandedKey))
     return statpaths.map(statpath => expandedSettings[rowExpandedKey(statpath)] ?? false)

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -202,8 +202,6 @@ function unregisterSubscriber(subscribers: Set<ScreenshotSubscriber>, subscriber
 const maxNotifyRounds = 10
 
 /**
- * Puts every subscriber into screenshot mode and waits for each to signal ready or go away.
- *
  * Entering screenshot mode is what mounts some of the subscribers -- the footnotes below a table,
  * or a map layer rebuilt at full resolution -- so this keeps going until a round adds nobody new.
  * Notifying only whoever was registered up front would render those components interactively into

--- a/react/src/components/statistic-name-specs.ts
+++ b/react/src/components/statistic-name-specs.ts
@@ -70,7 +70,6 @@ export function computeNameSpecsWithGroups(nameSpecs: NameSpec[]): { updatedName
     return { updatedNameSpecs, groupNames }
 }
 
-/** The name cell spec for each row, before `computeNameSpecsWithGroups` fills in display names. */
 export function nameSpecsForRows(rows: ArticleRow[], longname: string, currentUniverse: Universe): NameSpec[] {
     return rows.map(row => ({
         type: 'statistic-name',

--- a/react/src/components/supertable.tsx
+++ b/react/src/components/supertable.tsx
@@ -36,7 +36,6 @@ export interface DisclaimerFootnote {
     text: string
 }
 
-/** The column shape a table's rows are laid out against. */
 export interface TableLayout {
     widthLeftHeader: number
     columnWidth: number
@@ -44,25 +43,22 @@ export interface TableLayout {
     simpleOrdinals: boolean
 }
 
-/** A `TableLayout` with its columns measured, which is what rows are actually rendered against. */
 export interface MeasuredTableLayout extends TableLayout {
-    /** One entry per column, which is also what the column count is read from. */
     columnWidthsInfo: (CommonLayoutInformation | undefined)[]
-    /** The space reserved to the right of each column, which a vertical plot occupies. */
     extraSpaceRight: number[]
 }
 
 /**
- * Measures each column against the rows it contains. A column with no rows goes unmeasured
- * rather than measuring as zero, which would cap its header's text at no width at all.
+ * A column with no rows goes unmeasured rather than measuring as zero, which would cap its
+ * header's text at no width at all.
  */
 function measureColumns(columnRows: StatisticCellRenderingInfo[][], universe: Universe, simpleOrdinals: boolean): (CommonLayoutInformation | undefined)[] {
     return columnRows.map(rows => rows.length === 0 ? undefined : maxLayoutInformation(rows, universe, simpleOrdinals))
 }
 
 /**
- * The layout rows are rendered against. `extraSpaceRight` is asked for per column rather
- * than passed as an array, so it can't disagree with the measurements about the column count.
+ * `extraSpaceRight` is asked for per column rather than passed as an array, so it can't
+ * disagree with the measurements about the column count.
  */
 function measuredLayout(layout: TableLayout, columnWidthsInfo: (CommonLayoutInformation | undefined)[], extraSpaceRight: (columnIndex: number) => number): MeasuredTableLayout {
     return {
@@ -72,7 +68,6 @@ function measuredLayout(layout: TableLayout, columnWidthsInfo: (CommonLayoutInfo
     }
 }
 
-/** Each column's width including the space reserved to its right. */
 function columnFullWidths(layout: MeasuredTableLayout): number[] {
     return layout.extraSpaceRight.map(extra => layout.columnWidth + extra)
 }
@@ -85,12 +80,8 @@ export interface TableContentsProps {
     horizontalPlotSpecs: (PlotSpec | undefined)[]
     verticalPlotSpecs: (PlotSpec | undefined)[]
     topLeftSpec: TopLeftCellSpec
-    /** Warnings shown in place of the statistics they are about. */
     warningRows?: WarningRow[]
-    /**
-     * Warnings that stand in for a column rather than a row, drawn once down the column. The
-     * column itself must already be in `rowSpecs` and the super header, as a blank cell.
-     */
+    /** The column itself must already be in `rowSpecs` and the super header, as a blank cell. */
     warningColumns?: WarningColumn[]
     highlightRowIndex?: number
     loading?: boolean
@@ -223,11 +214,6 @@ export function TableContents(props: TableContentsProps): ReactNode {
     )
 }
 
-/**
- * Everything a table has above its rows -- the optional super header, and the main header
- * row of column names -- plus the positioned container the rows themselves live in, which
- * the vertical plots are absolutely positioned against.
- */
 function TableFrame(props: {
     layout: MeasuredTableLayout
     superHeaderSpec?: SuperHeaderSpec
@@ -265,12 +251,6 @@ function TableFrame(props: {
     )
 }
 
-/**
- * An explanation of why some statistics aren't there, laid out like the row they stand in for:
- * the group's name in the left header, and the warning across the columns the values would fill.
- * A warning about no group in particular has no name to put in the left header, so it spans the
- * whole row rather than starting at an empty one.
- */
 function WarningTableRow(props: { layout: MeasuredTableLayout, stripeIndex: number, name?: string, content: ReactNode }): ReactNode {
     const colors = useColors()
     const contentWidth = props.name === undefined
@@ -293,10 +273,6 @@ function WarningTableRow(props: { layout: MeasuredTableLayout, stripeIndex: numb
     )
 }
 
-/**
- * The message for a warning that stands in for a column, drawn once down the blank column its
- * statistics would have filled.
- */
 function WarningColumnMessage(props: { layout: MeasuredTableLayout, columnIndex: number, content: ReactNode }): ReactNode {
     const colors = useColors()
     const fullWidths = columnFullWidths(props.layout)
@@ -360,11 +336,6 @@ function SuperTableRow(props: {
     )
 }
 
-/**
- * The shape every statistic row has: a left header followed by a cell per column, and below
- * it the blocks the row's extras call for -- its expanded plot and its representatives
- * table. Callers differ only in what they put in the left header.
- */
 function StatisticTableRow(props: {
     layout: MeasuredTableLayout
     index: number
@@ -405,11 +376,6 @@ function StatisticTableRow(props: {
     )
 }
 
-/**
- * A row's cells, each followed by the space its column reserves to the right. Statistic
- * cells are given their column's measured widths here, so every table that renders a row
- * of cells lines its columns up the same way.
- */
 function RowCells(props: { layout: MeasuredTableLayout, cellSpecs: CellSpec[] }): ReactNode {
     const { columnWidth, extraSpaceRight, columnWidthsInfo } = props.layout
     return props.cellSpecs.map((spec, colIndex) => (
@@ -423,7 +389,6 @@ function RowCells(props: { layout: MeasuredTableLayout, cellSpecs: CellSpec[] })
     ))
 }
 
-/** The representatives tables a row's cells call for, in column order. */
 function congressionalRegionsForCells(cellSpecs: CellSpec[]): CongressionalColumnData[] {
     return cellSpecs.flatMap((cell) => {
         if (cell.type !== 'statistic-row') {
@@ -440,7 +405,6 @@ export type CellSpec = ({ type: 'comparison-longname' } & ComparisonLongnameCell
     ({ type: 'statistic-panel-longname' } & StatisticPanelLongnameCellProps) |
     ({ type: 'comparison-top-left-header' } & TopLeftHeaderProps) |
     ({ type: 'top-left-header' } & TopLeftHeaderProps) |
-    /** Holds a column's width open without drawing anything, e.g. under a warning column. */
     { type: 'blank' }
 
 export function Cell(props: CellSpec & { width: number }): ReactNode {
@@ -513,5 +477,4 @@ export interface TopLeftHeaderProps {
     statNameOverride?: string
 }
 
-/** The cells that can serve as a table's top-left header; the comparison's carries a color bar. */
 export type TopLeftCellSpec = Extract<CellSpec, { type: 'comparison-top-left-header' | 'top-left-header' }>

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -36,7 +36,6 @@ import { Cell, CellSpec, ComparisonLongnameCellProps, StatisticPanelLongnameCell
 
 export type ColumnIdentifier = 'statval' | 'statval_unit' | 'statistic_percentile' | 'statistic_ordinal' | 'pointer_in_class' | 'pointer_overall'
 
-/** Just the value, for the tables that have no room for the ordinal and percentile columns. */
 export const valueOnlyColumns: ColumnIdentifier[] = ['statval', 'statval_unit']
 
 const leftBarMargin = 0.02
@@ -314,7 +313,6 @@ export function MainHeaderRow(props: {
     extraSpaceRight: number[]
     simpleOrdinals: boolean
     columnWidthsInfo: (CommonLayoutInformation | undefined)[]
-    /** Columns with no values under them, which get no column names either. */
     blankColumns?: number[]
 }): ReactNode {
     return (
@@ -955,10 +953,6 @@ function SortButton(props: StatisticNameCellProps & { sortInfo: NonNullable<Stat
     )
 }
 
-/**
- * The controls that sit next to a statistic's name: the plot expander and the disclaimer
- * marker.
- */
 function useStatisticNameAdornments(row: ArticleRow | undefined, footnote?: string): ReactNode[] {
     const screenshotMode = useScreenshotMode()
     const adornments: ReactNode[] = []
@@ -1090,10 +1084,6 @@ function ComparisonColorBar({ highlightIndex }: { highlightIndex: number | undef
     )
 }
 
-/**
- * The numbered footnotes a table's disclaimers collapse into for a screenshot, drawn from the
- * statistics its name cells refer to -- the same cells that then show the symbols.
- */
 export function computeDisclaimerFootnotes(specs: CellSpec[]): { getSymbol: (d: Disclaimer) => string, footnotes: { symbol: string, text: string }[] } {
     const uniqueMessages: string[] = []
     for (const spec of specs) {
@@ -1240,7 +1230,6 @@ function computeSizesForRow(row: StatisticCellRenderingInfo, universe: string, s
     }
 }
 
-/** Column widths that fit every row, i.e. the maximum of each row's requirement. */
 export function maxLayoutInformation(rows: StatisticCellRenderingInfo[], universe: string, simpleOrdinals: boolean): CommonLayoutInformation {
     return rows.reduce<CommonLayoutInformation>((acc, row) => {
         const curr = computeSizesForRow(row, universe, simpleOrdinals)

--- a/react/src/components/warning-message.tsx
+++ b/react/src/components/warning-message.tsx
@@ -3,7 +3,6 @@ import React, { ReactNode } from 'react'
 import type { MissingGroupReason, MissingSources } from '../page_template/statistic-settings'
 import type { Category, Group } from '../page_template/statistic-tree'
 
-/** What a warning says about the setting that is keeping a group's statistics off the page. */
 export function warningMessage(reason: MissingGroupReason, groupOrCategory: Group | Category): ReactNode {
     switch (reason.kind) {
         case 'year':
@@ -39,7 +38,6 @@ function enableHowMany({ anySourceSuffices }: MissingSources): string {
     return anySourceSuffices ? 'one' : 'them'
 }
 
-/** A category's warning stands in for a whole run of statistics, a group's for just its own. */
 function theseStatistics(groupOrCategory: Group | Category): string {
     switch (groupOrCategory.kind) {
         case 'Group':

--- a/react/src/page_template/settings.ts
+++ b/react/src/page_template/settings.ts
@@ -308,14 +308,13 @@ function useStagedSettingKeys(): (keyof SettingsDictionary)[] | undefined {
     return settings.useStagedKeys()
 }
 
-/** Whether staging is changing this setting, which the UI highlights. */
 export function isStagedChange<K extends keyof SettingsDictionary>(info: SettingInfo<K>): boolean {
     return 'stagedValue' in info && info.stagedValue !== info.persistedValue
 }
 
 /**
- * The value the setting has right now, which is the staged one while staging. Keyed off the
- * presence of `stagedValue`, since some settings can legitimately be staged as undefined.
+ * Keyed off the presence of `stagedValue`, since some settings can legitimately be staged as
+ * undefined.
  */
 export function settingValue<K extends keyof SettingsDictionary>(info: SettingInfo<K>): SettingsDictionary[K] {
     return 'stagedValue' in info ? info.stagedValue! : info.persistedValue

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -128,16 +128,15 @@ export function useSelectedYears(): Year[] {
 }
 
 /**
- * The sources to name in a warning, and whether enabling any single one of them is enough. We could present
- * something more complex like a list of subsets, but that would be confusing and not very useful.
- * So instead, we just say "enable one of these sources" or "enable all of these sources".
+ * We could present something more complex like a list of subsets, but that would be confusing
+ * and not very useful. So instead, we just say "enable one of these sources" or "enable all of
+ * these sources".
  */
 export interface MissingSources {
     sources: SourceIdentifier[]
     anySourceSuffices: boolean
 }
 
-/** Why a group that the user selected is nonetheless showing no statistics. */
 export type MissingGroupReason =
     /** None of `years` are selected: the years this page has the group's statistics for from an enabled source. */
     { kind: 'year', years: Year[] } |
@@ -174,10 +173,7 @@ function sortSources(sources: Iterable<SourceIdentifier>): SourceIdentifier[] {
     return Array.from(new Set(sources)).sort((a, b) => sourceOrder.get(a)! - sourceOrder.get(b)!)
 }
 
-/**
- * Which selected groups are showing no statistics, and why. Groups are consolidated into their
- * category only when the whole category is missing for the same reason.
- */
+/** Which selected groups are showing no statistics, and why. */
 export function missingGroups(
     { selectedGroups, selectedYears, statPathsAll, settings, availableTree }: {
         selectedGroups: Group[]
@@ -213,7 +209,6 @@ export function missingGroups(
         }
         const blocked = Array.from(new Set(blockedEach.flat()))
 
-        /** The disabled sources standing in the way, across the regions missing the group. */
         const missingSources = (candidates: (paths: StatPath[]) => StatPath[]): MissingSources => {
             const eachRegion = blockedEach.map(paths => new Set(candidates(paths).map(path => statParents.get(path)!.source.name)))
             const sources = sortSources(eachRegion.flatMap(region => Array.from(region)))
@@ -223,7 +218,6 @@ export function missingGroups(
             }
         }
 
-        // Statistics whose source is enabled are held back by their year alone.
         const heldBackByYear = blocked.filter(sourceEnabled)
         if (heldBackByYear.length > 0) {
             return { kind: 'year', years: yearsOf(heldBackByYear) }
@@ -309,7 +303,6 @@ export function useStatPathsAll(): StatPath[][] {
     return useContext(Navigator.Context).useStatPathsAll() ?? (() => { throw new Error('Current page does not have StatPath information') })()
 }
 
-/** Whether a group's or category's statistics include any that the page has loaded. */
 function intersectsPage(statPaths: Set<StatPath>, pageStatPaths: Set<StatPath>): boolean {
     for (const statPath of statPaths) {
         if (pageStatPaths.has(statPath)) {
@@ -344,9 +337,9 @@ export function getAvailableTree(statPathsAll: StatPath[][]): AvailableTree {
 }
 
 /**
- * The parts of the statistic tree this page has data for. Memoized on the page's own stat
- * paths, which only change on navigation: the tree is scanned once per category rendered,
- * and again on every checkbox click and every keystroke in the search box.
+ * Memoized on the page's own stat paths, which only change on navigation: the tree is scanned
+ * once per category rendered, and again on every checkbox click and every keystroke in the
+ * search box.
  */
 function useAvailableTree(): AvailableTree {
     const statPathsAll = useStatPathsAll()

--- a/react/src/universe.ts
+++ b/react/src/universe.ts
@@ -15,7 +15,6 @@ export function useUniverse(): Universe | undefined {
     return useUniverseContext()?.universe
 }
 
-/** The current universe, for the components that only render on pages that have one. */
 export function useDefinedUniverse(): Universe {
     const universe = useUniverse()
     assert(universe !== undefined, 'no universe')

--- a/react/test/comparison_warnings.test.ts
+++ b/react/test/comparison_warnings.test.ts
@@ -18,7 +18,6 @@ async function selectMainWithoutYears(t: TestController): Promise<void> {
 
 const missingMainGroups = ['Population', 'PW Density (r=1km)', 'AW Density']
 
-/** The statistic names heading each column, which transposed is where a warning's name goes. */
 async function columnHeaderNames(): Promise<string[]> {
     const names = await arrayFromSelector(Selector('[data-test-id=statistic-link]'))
     return Promise.all(names.map(async name => (await name.innerText).trim()))

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -67,7 +67,6 @@ export async function uncheckAllCategories(t: TestController): Promise<void> {
     }
 }
 
-/** The name cell of the warning row carrying `message`, which stands where a statistic's name would. */
 export function warningNamed(message: string, name: string): Selector {
     return Selector('.for-testing-table-row')
         .withText(message)
@@ -75,7 +74,6 @@ export function warningNamed(message: string, name: string): Selector {
         .withExactText(name)
 }
 
-/** The statistics each warning row stands in for, in the order the rows appear. */
 export async function warningRowNames(): Promise<string[]> {
     const cells = await arrayFromSelector(Selector('[data-test-id=article-warning-name]'))
     return Promise.all(cells.map(async cell => (await cell.innerText).trim()))

--- a/scripts/propagate-stack.sh
+++ b/scripts/propagate-stack.sh
@@ -120,7 +120,6 @@ done <<< "$branches"
 if $push; then
     echo "==> pushing"
     # --atomic, so a rejection leaves every branch unpushed rather than half the stack.
-    # Without it git pushes each ref independently and only the rejected one stays behind.
     git push --atomic origin $branches || exit 1
 fi
 


### PR DESCRIPTION
A follow-up to #2170, over the rest of the recent table/warnings work.

Two patterns went in there that don't earn their keep: docstrings that
name the function again (`columnFullWidths` -- "each column's width
including the space reserved to its right"), and block comments that
narrate the JSX underneath them (`TableFrame`, `WarningTableRow`,
`StatisticTableRow`, `RowCells`). The second kind is the worse of the two:
the markup is right there, and the prose is what goes stale when the
layout moves.

Several comments opened by restating the declaration and *then* said
something the code can't -- why a column with no rows goes unmeasured
rather than measuring as zero, why the screenshot notification keeps
looping, why the available tree is memoized. Those keep everything but
the first sentence.

The test comments explaining why each fixture produces the warning it
does are all still there; they aren't derivable from the assertions.

Typecheck, knip and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)