### PR TITLE
Mirror the dev server's output to a log agents can read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 *Copy1.ipynb*
 .DS_Store
 react/test/density-db
+react/dev-server.log
 venv/
 .envrc
 densitydb-site-repo/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,8 @@ python create_website.py --site-folder <location> --mode dev --target scripts
 ```
 
 in bash or zsh.
+
+The dev server (`npm run watch`, from `react/`) mirrors its output to
+`react/dev-server.log`, trimmed to its last few thousand lines. Read that to see
+whether a rebuild succeeded. Its incremental builds sometimes get stuck in a bad
+state; `killall rspack-node` fixes that, and the watcher restarts itself.

--- a/react/rspack.config.js
+++ b/react/rspack.config.js
@@ -7,6 +7,9 @@ import { port } from "./port.js"
 
 const isProduction = process.env.NODE_ENV === 'production'
 
+// dev-server-advice listens on the dev server's websocket, which only exists under `serve`.
+const isServing = process.argv.includes('serve')
+
 // Helpful for debugging loops in watch mode
 class LogChangedFile {
   apply(compiler) {
@@ -18,7 +21,7 @@ class LogChangedFile {
 
 export default env => ({
     entry: {
-        index: ['./src/index.tsx'],
+        index: [...(isServing ? ['./src/dev-server-advice.ts'] : []), './src/index.tsx'],
         loading: ['./src/loading.ts'],
     },
     output: {

--- a/react/src/dev-server-advice.ts
+++ b/react/src/dev-server-advice.ts
@@ -1,0 +1,20 @@
+// Bundled only when serving. The dev-server client already prints compile and
+// type-check errors to the console; this adds what those errors don't say --
+// the page is the last bundle that compiled, and where to look for the rest.
+
+const advice = [
+    `[failtest] The dev server's build is failing, so this page is running the last bundle that compiled.`,
+    `Recent source changes are NOT reflected here, and any test running against this page is testing stale code.`,
+    `The compiler output above is also in react/dev-server.log, along with everything that preceded it.`,
+    `If the build looks stuck rather than broken, run \`killall rspack-node\`; the watcher restarts itself.`,
+].join('\n')
+
+const socket = new WebSocket(`${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws`)
+
+socket.addEventListener('message', (event: MessageEvent<string>) => {
+    const message = JSON.parse(event.data) as { type?: string }
+    // Only errors block the reload. Warnings still ship a fresh bundle.
+    if (message.type === 'errors') {
+        console.error(advice)
+    }
+})

--- a/react/watch.sh
+++ b/react/watch.sh
@@ -10,6 +10,10 @@ cd react
 # fact, without the color escapes. Once the log reaches max lines, drop all but
 # the last keep lines.
 log_tail() {
+    # ^C reaches every process in the pipeline. Ignoring it here keeps awk alive
+    # to drain the last of rspack's output, and keeps the pipeline's exit status
+    # off 130, which would otherwise take this script down with it.
+    trap '' INT
     awk -v f=dev-server.log -v max=4000 -v keep=2000 '
         BEGIN { ansi = sprintf("%c", 27) "\\[[0-9;?]*[a-zA-Z]" }
         { print; fflush(); line = $0; gsub(ansi, "", line)

--- a/react/watch.sh
+++ b/react/watch.sh
@@ -7,10 +7,13 @@ python create_website.py --mode dev --target scripts --site-folder $1
 cd react
 
 # Copy the watcher's output to dev-server.log so that it can be read after the
-# fact. Once the log reaches max lines, drop all but the last keep lines.
+# fact, without the color escapes. Once the log reaches max lines, drop all but
+# the last keep lines.
 log_tail() {
     awk -v f=dev-server.log -v max=4000 -v keep=2000 '
-        { print; fflush(); print > f; fflush(f); buf[++n] = $0 }
+        BEGIN { ansi = sprintf("%c", 27) "\\[[0-9;?]*[a-zA-Z]" }
+        { print; fflush(); line = $0; gsub(ansi, "", line)
+          print line > f; fflush(f); buf[++n] = line }
         n >= max {
             close(f)
             for (i = n - keep + 1; i <= n; i++) print buf[i] > f
@@ -22,7 +25,7 @@ log_tail() {
 }
 
 while true; do
-    rspack serve --mode=development --watch --env directory=$1 2>&1 | log_tail
+    FORCE_COLOR=1 rspack serve --mode=development --watch --env directory=$1 2>&1 | log_tail
     echo 'Restarting watcher... Press ^C again to stop watching.'
     sleep 1
 done

--- a/react/watch.sh
+++ b/react/watch.sh
@@ -6,8 +6,23 @@ cd ..
 python create_website.py --mode dev --target scripts --site-folder $1
 cd react
 
+# Copy the watcher's output to dev-server.log so that it can be read after the
+# fact. Once the log reaches max lines, drop all but the last keep lines.
+log_tail() {
+    awk -v f=dev-server.log -v max=4000 -v keep=2000 '
+        { print; fflush(); print > f; fflush(f); buf[++n] = $0 }
+        n >= max {
+            close(f)
+            for (i = n - keep + 1; i <= n; i++) print buf[i] > f
+            for (i = 1; i <= keep; i++) buf[i] = buf[n - keep + i]
+            for (i = keep + 1; i <= n; i++) delete buf[i]
+            n = keep
+        }
+    '
+}
+
 while true; do
-    rspack serve --mode=development --watch --env directory=$1
+    rspack serve --mode=development --watch --env directory=$1 2>&1 | log_tail
     echo 'Restarting watcher... Press ^C again to stop watching.'
     sleep 1
 done


### PR DESCRIPTION
Agents working in this repo can't see the dev server's terminal, so they had no way to tell whether their change actually compiled — the only options were to guess or to start a competing build. This tees the watcher's output to `react/dev-server.log` (gitignored) so it can be read after the fact.

Some decisions worth calling out:

- **`awk` rather than `tee` + a rotation cron.** The log has to be self-trimming, or it grows without bound over a multi-day watch session. A single `awk` keeps the last few thousand lines in memory and rewrites the file when it hits the cap, so there's no second process and no partial-rotation window.
- **Strip ANSI escapes in the file, keep them on the terminal.** rspack's colors are noise when a model reads the log, but a human watching the terminal still wants them — hence `FORCE_COLOR=1` (the pipe would otherwise disable color entirely) plus a `gsub` on the copy that goes to disk.
- **`trap '' INT` inside the pipeline function.** ^C is delivered to every process in the pipeline. Without the trap, `awk` dies before draining rspack's final output, and the pipeline exits 130, which killed the outer restart loop. Ignoring INT in the tail lets ^C keep meaning "stop the watcher" the way it did before.

CLAUDE.md documents the log and the `killall rspack-node` escape hatch for when incremental builds wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)