### PR TITLE
Time out and retry jsdelivr stalls in the CI proxy

### DIFF
--- a/react/test/scripts/ci_proxy.ts
+++ b/react/test/scripts/ci_proxy.ts
@@ -16,6 +16,41 @@ import { port } from '../../port'
 
 import { github } from './github-utils'
 
+/**
+ * jsdelivr occasionally stalls on a file and answers with a 504 a full minute later, which is
+ * long enough on its own to blow a test's time limit. This is a socket inactivity timeout, so a
+ * large file that is downloading slowly but steadily isn't affected.
+ */
+const attemptTimeoutMs = 10_000
+const attempts = 3
+
+const handOffToNextAttempt: proxy.ProxyOptions = {
+    skipToNextHandlerFilter: proxyRes => (proxyRes.statusCode ?? 500) >= 500,
+    proxyErrorHandler: (error, res, next) => { next() },
+}
+
+function jsdelivrProxy(sha: string, retryOnFailure: boolean): express.RequestHandler {
+    return proxy(`https://cdn.jsdelivr.net`, {
+        timeout: attemptTimeoutMs,
+        proxyReqPathResolver(req) {
+            // We must get by SHA, since if we used branch name jsdelvir would cache the result for 12 hours and we couldn't get new changes from the branch
+            return `/gh/densitydb/densitydb.github.io@${sha}${req.path}`
+        },
+        userResHeaderDecorator(headers, userReq) {
+            const fileExtension = (/\.(.+)$/.exec(userReq.path))?.[1]
+            const mimeType = fileExtension ? { html: 'text/html', js: 'text/javascript' }[fileExtension] : undefined
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-restricted-syntax -- We're removing the context-security-policy header via destructuring
+            const { 'content-security-policy': _, ...filteredHeaders } = headers
+            return {
+                ...filteredHeaders,
+                'content-type': mimeType ?? headers['content-type'],
+            }
+        },
+        // Hand off to the next attempt. The last one has no successor, so it reports what it got.
+        ...(retryOnFailure ? handOffToNextAttempt : {}),
+    })
+}
+
 export async function startProxy(): Promise<void> {
     const { octokit } = await github()
 
@@ -42,25 +77,18 @@ export async function startProxy(): Promise<void> {
 
     app.use(compression({ enforceEncoding: 'gzip' }))
 
-    app.use(
-        express.static('test/density-db'),
-        proxy(`https://cdn.jsdelivr.net`, {
-            proxyReqPathResolver(req) {
-                // We must get by SHA, since if we used branch name jsdelvir would cache the result for 12 hours and we couldn't get new changes from the branch
-                return `/gh/densitydb/densitydb.github.io@${branch.commit.sha}${req.path}`
-            },
-            userResHeaderDecorator(headers, userReq) {
-                const fileExtension = (/\.(.+)$/.exec(userReq.path))?.[1]
-                const mimeType = fileExtension ? { html: 'text/html', js: 'text/javascript' }[fileExtension] : undefined
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-restricted-syntax -- We're removing the context-security-policy header via destructuring
-                const { 'content-security-policy': _, ...filteredHeaders } = headers
-                return {
-                    ...filteredHeaders,
-                    'content-type': mimeType ?? headers['content-type'],
-                }
-            },
-        }),
-    )
+    const handlers: express.RequestHandler[] = []
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        if (attempt > 1) {
+            handlers.push((req, res, next) => {
+                console.warn(`jsdelivr did not serve ${req.path}; starting attempt ${attempt}`)
+                next()
+            })
+        }
+        handlers.push(jsdelivrProxy(branch.commit.sha, attempt < attempts))
+    }
+
+    app.use(express.static('test/density-db'), ...handlers)
 
     app.listen(port())
 }


### PR DESCRIPTION
## Why

Analyzing the last 30 `check` runs on `main` (2026-07-26 → 08-06): 6 were red and 23 had at least one e2e test that only passed on a retry. The single largest contributor was this:

```
Error: Could not find feature Cottage Grove Neighborhood, Youngstown City, Ohio, USA
       in shard /shape/1/d/shard_35869.gz
```

Ten occurrences across 8 runs, **a different feature and a different shard every time**, always passing on the next attempt. A genuinely missing feature would fail deterministically, so this was never a data problem.

The cause is jsdelivr. `ci_proxy` forwards anything outside the local build to it, and it intermittently stalls on a file and answers with a 504 about a minute later. Node imposes no timeout on the proxied connection, so the page just hangs for that minute. From `sitemap` in run [30880635629](https://github.com/kavigupta/urbanstats/actions/runs/30880635629), where every other article takes ~3s:

```
05:46:38.747  .../article.html?longname=Bozeman+CCD...
05:46:41.799  .../article.html?longname=Youngstown+city%2C+Ohio%2C+USA
05:47:44.802  .../article.html?longname=17901%2C+USA
```

That pattern holds for all ten: each is preceded by a **61–68s** stall, in tests whose median gap between requests is under 2.5s and whose second-largest gap is far smaller. One run happened to print the status directly and corroborates it — `Failed to fetch` at 05:03:26.810, then `got 504: Gateway Timeout` at 05:04:27.198.

It surfaces as "could not find" rather than "could not fetch" because `loadFeatureFromConsolidatedShard` passes `errorOnMissing: false`, so any non-2xx silently becomes `undefined`.

## Decisions

**Fixed in the CI proxy, not in `load_json.ts`.** The retry belongs where the flaky hop is. Production serves these files directly with no jsdelivr in the path, so putting retry logic in the frontend fetch would add risk for real users to fix a problem they don't have.

**The last attempt doesn't retry.** If it did, a persistent failure would fall through to express's default handler and return a 404 — indistinguishable from a genuinely missing file, which is the confusion this is trying to end. The final copy reports whatever it actually got.

**10s, and it's an inactivity timeout.** `express-http-proxy`'s `timeout` maps to `socket.setTimeout`, so a large file downloading slowly but steadily is never aborted; 10s of *no data* is unambiguously a stall. Worst case goes from an unbounded ~60s hang to 30s.

## Verification

Against a local origin that stalls or 503s for the first N requests (500ms timeout to keep it quick):

| request | status | retries | elapsed | |
|---|---|---|---|---|
| `/hang-0` | 200 | 0 | 31ms | healthy, no retry |
| `/hang-1` | 200 | 1 | 509ms | one stall, recovers on attempt 2 |
| `/hang-2` | 200 | 2 | 1014ms | two stalls, recovers on attempt 3 |
| `/hang-9` | 504 | 2 | 1519ms | never recovers: real status, bounded at 3×timeout |
| `/fail-1` | 200 | 1 | 6ms | one 503, recovers |
| `/fail-9` | 503 | 2 | 5ms | origin's status reported, not a 404 |
| `/missing-0` | 200 | 0 | 2ms | 404 is not a retryable status |

And against real jsdelivr through `startProxy`: `/index.html` and both shard indices return 200 with correct content types, and a nonexistent path 404s with no retries.

## Not included

Real users still get no retry, and `errorOnMissing: false` still reports a transport failure as a missing feature. Both are worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
