### PR TITLE
Log CDP details when a request fails in an e2e test

### DIFF
--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -338,7 +338,6 @@ async function throwIfTestFailFromConsole(t: TestController): Promise<void> {
 }
 
 const networkEnabled = new WeakSet()
-const requests = new Map<string, unknown>()
 
 async function printFailedNetworkRequests(t: TestController): Promise<void> {
     const cdp = await t.getCurrentCDPSession()
@@ -346,15 +345,56 @@ async function printFailedNetworkRequests(t: TestController): Promise<void> {
         return
     }
     networkEnabled.add(cdp)
-    cdp.Network.on('requestWillBeSent', (event) => {
-        requests.set(event.requestId, event.request)
+
+    const inFlight = new Map<Protocol.Network.RequestId, { sent: Protocol.Network.RequestWillBeSentEvent, response?: Protocol.Network.Response }>()
+
+    cdp.Network.on('requestWillBeSent', (sent) => {
+        inFlight.set(sent.requestId, { sent })
     })
-    cdp.Network.on('loadingFailed', (event) => {
-        if (!event.canceled) {
-            console.error(chalkTemplate`{red Request failed}`, event, requests.get(event.requestId))
+    cdp.Network.on('responseReceived', (event) => {
+        const inFlightRequest = inFlight.get(event.requestId)
+        if (inFlightRequest !== undefined) {
+            inFlightRequest.response = event.response
         }
     })
+    cdp.Network.on('loadingFinished', (event) => {
+        inFlight.delete(event.requestId)
+    })
+    cdp.Network.on('loadingFailed', (event) => {
+        const inFlightRequest = inFlight.get(event.requestId)
+        inFlight.delete(event.requestId)
+        // `inspector` means withInterceptedRequests failed this one on purpose
+        if (event.canceled || event.blockedReason === 'inspector') {
+            return
+        }
+        const { sent, response } = inFlightRequest ?? {}
+        const details = [
+            `${event.errorText} after ${Math.round((event.timestamp - (sent?.timestamp ?? event.timestamp)) * 1000)}ms, type ${event.type}`,
+            ...event.blockedReason === undefined ? [] : [`blocked: ${event.blockedReason}`],
+            ...event.corsErrorStatus === undefined ? [] : [`cors: ${event.corsErrorStatus.corsError} (${event.corsErrorStatus.failedParameter})`],
+            // A response means the headers arrived and the failure was partway through the body
+            ...response === undefined ? [] : [`response: ${response.status} ${response.statusText} from ${response.remoteIPAddress}, headers ${JSON.stringify(response.headers)}`],
+            ...(sent?.initiator.stack?.callFrames ?? []).slice(0, 5).map(frame => `at ${frame.functionName || '<anonymous>'} (${frame.url}:${frame.lineNumber})`),
+        ]
+        console.error(chalkTemplate`{red Request failed} ${sent?.request.method ?? '???'} ${sent?.request.url ?? event.requestId}\n${details.map(line => `    ${line}`).join('\n')}`)
+    })
+
     await cdp.Network.enable({ })
+
+    // The search and script workers fetch too, and requests are only reported on the session of
+    // the target that made them
+    await cdp.Target.setDiscoverTargets({ discover: true })
+    cdp.Target.on('targetCreated', ({ targetInfo }) => {
+        if (targetInfo.type !== 'worker' && targetInfo.type !== 'service_worker') {
+            return
+        }
+        void (async () => {
+            const { sessionId } = await cdp.Target.attachToTarget({ ...targetInfo, flatten: true })
+            await cdpSessionWithSessionId(cdp, sessionId).Network.enable({})
+        })().catch((error: unknown) => {
+            console.warn(chalkTemplate`{yellow Could not watch requests of ${targetInfo.url}}`, error)
+        })
+    })
 }
 
 export function urbanstatsFixture(name: string, url: string, beforeEach?: (t: TestController) => Promise<void>, { afterEach, requestHooks = [] }: {


### PR DESCRIPTION
Flaky e2e runs tend to end with a bare `TypeError: Failed to fetch`, which tells you nothing about what the browser was doing. We already had a `Network.loadingFailed` listener, but it had two problems: it dumped the raw event object, and it only watched the page's CDP session — so the search and script workers, which fetch the search index, reported nothing at all. The search index load is one of the flakier fetches, so the case we most wanted to see was exactly the one we were blind to.

Two decisions worth calling out:

**Worker coverage via target discovery, not auto-attach.** TestCafe already calls `Target.setAutoAttach` with `waitForDebuggerOnStart`, so my first attempt just listened for `attachedToTarget` and enabled `Network` on each new session. That event never arrives on the session `getCurrentCDPSession()` hands back — it belongs to a different client. So this uses `setDiscoverTargets` + `attachToTarget`, the same approach `networkUsage` in `network_test_utils.ts` already relies on.

**Skipping `blockedReason: 'inspector'`.** That's `withInterceptedRequests` failing a request on purpose. Now that worker sessions are watched, the offline tests would otherwise print red "Request failed" blocks for the very failures they exist to create, and a grep for `Request failed` in CI logs would be mostly noise.

What gets printed for a real failure:

```
Request failed GET http://localhost:8001/index/pages_all.gz
    net::ERR_CONNECTION_RESET after 1043ms, type Fetch
    response: 200 OK from 127.0.0.1, headers {...}
    at <anonymous> (http://localhost:8001/scripts/...js:3066)
```

The elapsed time separates a stall from an instant reject, and the response line only appears when headers had already arrived — that distinguishes a connection that died partway through the body from one that never opened. The initiator stack names the app code that issued the fetch.

## Testing

Verified with a throwaway test making failing fetches from both the page and a blob worker: both logged, with initiator stacks. Re-ran `search.test.ts`'s `initial loading indicator` (which blocks `pages_all` deliberately): passes, and no longer logs the intentional block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)