### PR TITLE
Build the CI image unless the registry says it exists

### DIFF
--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -36,7 +36,9 @@ runs:
       id: existing-image
       run: |
         GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
-        response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})
+        # --http1.1 because ghcr.io intermittently kills the HTTP/2 stream, which curl
+        # reports as exit 92.
+        response=$(curl -s -o /dev/null -w "%{http_code}" --http1.1 --retry 3 --retry-all-errors -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }}) || response="curl exit $?"
         echo "Manifest query returned $response"
         # Only a 200 means the image is really there. Anything else (an auth failure, a
         # rate limit, a curl error) has to build, because skipping the build leaves every

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -37,12 +37,13 @@ runs:
       run: |
         GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
         # --http1.1 because ghcr.io intermittently kills the HTTP/2 stream, which curl
-        # reports as exit 92.
-        response=$(curl -s -o /dev/null -w "%{http_code}" --http1.1 --retry 3 --retry-all-errors -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }}) || response="curl exit $?"
+        # reports as exit 92. If curl fails anyway, the step fails here rather than
+        # guessing about the registry's contents.
+        response=$(curl -s -o /dev/null -w "%{http_code}" --http1.1 --retry 3 --retry-all-errors -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})
         echo "Manifest query returned $response"
-        # Only a 200 means the image is really there. Anything else (an auth failure, a
-        # rate limit, a curl error) has to build, because skipping the build leaves every
-        # job that runs in this container to fail on an unpullable image.
+        # Only a 200 means the image is really there. Anything else has to build, because
+        # skipping the build leaves every job that runs in this container to fail on an
+        # unpullable image.
         echo "exists=$([ "$response" = 200 ] && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -36,11 +36,16 @@ runs:
       id: existing-image
       run: |
         GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
-        echo "response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
+        response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})
+        echo "Manifest query returned $response"
+        # Only a 200 means the image is really there. Anything else (an auth failure, a
+        # rate limit, a curl error) has to build, because skipping the build leaves every
+        # job that runs in this container to fail on an unpullable image.
+        echo "exists=$([ "$response" = 200 ] && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Log in to the Container registry
-      if: ${{ steps.existing-image.outputs.response == '404' }}
+      if: ${{ steps.existing-image.outputs.exists == 'false' }}
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
@@ -48,7 +53,7 @@ runs:
         password: ${{ inputs.token }}
 
     - name: Build and push Docker image
-      if: ${{ steps.existing-image.outputs.response == '404' }}
+      if: ${{ steps.existing-image.outputs.exists == 'false' }}
       uses: docker/build-push-action@v6
       with:
         context: .


### PR DESCRIPTION
The `docker_image` action decides whether to build the container that most of `check` runs in by curling the GHCR manifest endpoint, and it only built when the status was exactly `404`. That made the check fail-open: any other answer read as "the image already exists", so the build and push were skipped and the tag never appeared in the registry.

That's what happened on #2183, which changes both Dockerfiles and so needs two new image tags. Both `build-and-push-*` jobs "succeeded" in ~17 seconds with the login and build steps skipped, and then `lint`, `build-frontend`, and `run-unit-tests` each failed with `Error response from daemon: manifest unknown` — three jobs downstream of the real problem, with nothing in their logs pointing back at it.

CI here then exposed *why* the check came back non-404: curl exits 92, an HTTP/2 stream error from ghcr.io. The old code wrapped the call in `echo "response=$(curl ...)"`, so echo's exit status won and curl's failure was invisible — the empty result just looked like "not a 404, must exist".

So the rule is now that the check only ever acts on an answer it actually got:

- Only a `200` counts as present. An ambiguous status costs a rebuild, which is harmless, instead of breaking every job that needs the container.
- If curl itself fails, the step fails. An unreachable registry says nothing about whether the image exists, and crashing is loud and re-runnable, where guessing "missing" would spend a full rebuild on every network blip.
- `--http1.1` to dodge the ghcr HTTP/2 flake, plus retries, so that crash stays rare. The status code is echoed too — previously it went straight to `$GITHUB_OUTPUT` and was invisible when diagnosing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)