### PR TITLE
Actually reuse the cached CI images instead of rebuilding them every run

### DIFF
--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -35,16 +35,21 @@ runs:
     - name: Check for existing image
       id: existing-image
       run: |
-        GHCR_TOKEN=$(echo -n ${{ inputs.token }} | base64)
+        # -w0 because base64 otherwise wraps at 76 columns, and a newline in the header
+        # value makes ghcr.io answer 400 to every query, which reads as "image missing".
+        GHCR_TOKEN=$(echo -n "${{ inputs.token }}" | base64 -w0)
         # --http1.1 because ghcr.io intermittently kills the HTTP/2 stream, which curl
         # reports as exit 92. If curl fails anyway, the step fails here rather than
         # guessing about the registry's contents.
         response=$(curl -s -o /dev/null -w "%{http_code}" --http1.1 --retry 3 --retry-all-errors -H "Authorization: Bearer ${GHCR_TOKEN}" https://${{ inputs.registry }}/v2/${{ inputs.repository }}/manifests/${{ steps.tag.outputs.tag }})
         echo "Manifest query returned $response"
-        # Only a 200 means the image is really there. Anything else has to build, because
-        # skipping the build leaves every job that runs in this container to fail on an
-        # unpullable image.
-        echo "exists=$([ "$response" = 200 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+        case "$response" in
+          200) echo "exists=true" >> $GITHUB_OUTPUT ;;
+          404) echo "exists=false" >> $GITHUB_OUTPUT ;;
+          # Treating an unrecognized response as "missing" is how the 400 above went
+          # unnoticed: every run rebuilt, and nothing failed to say so.
+          *) echo "Unexpected response from the registry"; exit 1 ;;
+        esac
       shell: bash
 
     - name: Log in to the Container registry


### PR DESCRIPTION
The registry existence check in `docker_image` has been answering "missing" for every query, so both the common and e2e images were rebuilt on **every single run**. In a recent run on main, both jobs logged `Manifest query returned 400` and went straight to `exporting to image`, despite the image being present in the registry.

The cause is that GNU `base64` wraps at 76 columns. The token is longer than 57 bytes, so the encoded value contained a newline, and ghcr.io answers 400 to any request with a newline in the header value. I reproduced this directly: the same query with the newline stripped returns 200 and a full manifest, and a deliberately re-introduced newline returns 400. The checkout step in `check.yml` already passes `-w0` for exactly this reason.

Worth about 2 minutes of rebuild per run, of which roughly 55 seconds is on the critical path, since the e2e image gates the e2e jobs.

## The judgement call

An unrecognized response is now a hard failure rather than a silent rebuild. Falling back to "rebuild" is safe for the pipeline but invisible, which is exactly why this went unnoticed for however long. `--retry --retry-all-errors` already covers 5xx/429, and I verified an unknown tag returns 404 rather than something exotic, so what's left is genuinely anomalous. Easy to soften to a warning if you'd rather never have the registry block a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)