### PR TITLE
Pack e2e jobs against the longest test rather than a fixed ten minutes

### DIFF
--- a/react/test/scripts/list-e2e-tests.ts
+++ b/react/test/scripts/list-e2e-tests.ts
@@ -73,8 +73,27 @@ for (let t = 0; t < knownTests.length; t++) {
     model.addConstr(constr, '==', 1)
 }
 
-// The longest we want a job to be
-const durationLimit = 10 * 60 * 1000
+/*
+ * The e2e phase takes as long as its longest job, so the job count is only a means to
+ * a wall-clock time. Runner minutes are free on a public repo, so the reason not to
+ * shard further is that jobs past the account's concurrency ceiling queue instead of
+ * running, which adds latency rather than removing it. 28 shards have been observed
+ * starting together; this leaves room for the rest of the pipeline on top.
+ */
+const jobBudget = 36
+
+/*
+ * A single test file cannot be divided, so the longest one sets a floor under the whole
+ * phase and packing below it just buys jobs that finish early while everyone waits on
+ * that file anyway. Taking the max means splitting up a long test file is what turns
+ * into a faster pipeline, with no constant here to retune afterwards.
+ */
+const durationLimit = knownTests.length === 0
+    ? 0
+    : Math.max(
+        Math.ceil(knownTests.reduce((total, test) => total + testDurations[test], 0) / jobBudget),
+        ...knownTests.map(test => testDurations[test]),
+    )
 
 // If a test is in a job, that job must be used
 // Also, the tests in a job should not exceed how long we want jobs to be
@@ -82,8 +101,7 @@ const durationLimit = 10 * 60 * 1000
 for (let job = 0; job < knownTests.length; job++) {
     const constr: [number, Var][] = []
     for (let t = 0; t < knownTests.length; t++) {
-        // If a duration is longer than the limit (which sometimes happens), the LP won't be solvable, so clamp it
-        constr.push([Math.min(testDurations[knownTests[t]], durationLimit), testInJob[`${t}_${job}`]])
+        constr.push([testDurations[knownTests[t]], testInJob[`${t}_${job}`]])
     }
     model.addConstr(constr, '<=', [[durationLimit, jobUsed[job]]])
 }
@@ -107,6 +125,8 @@ await execa(
     [
         'test/scripts/lp.lp',
         '--solution_file', 'test/scripts/solution',
+        // Stopping early only costs us a few extra jobs: it is the duration constraint,
+        // not the objective, that decides how long the pipeline takes.
         '--time_limit', '60',
     ],
     { stderr: process.stderr, stdout: process.stderr },
@@ -127,6 +147,13 @@ for (let t = 0; t < knownTests.length; t++) {
             jobs.get(job).push(knownTests[t])
         }
     }
+}
+
+// If the solver gives up without an incumbent, every variable stays unset and the tests
+// silently drop out of the pipeline instead of failing here.
+const assignedCount = Array.from(jobs.values()).reduce((total, jobTests) => total + jobTests.length, 0)
+if (assignedCount !== knownTests.length) {
+    throw new Error(`Solver placed ${assignedCount} of ${knownTests.length} tests into jobs`)
 }
 
 process.stdout.write(JSON.stringify(Array.from(jobs.values())


### PR DESCRIPTION
The duration limit decides how long the e2e phase takes, but it was a constant that had drifted out of any relationship with the tests. It sat at 10 minutes while the longest single test file was 11.58, so the limit was doing nothing for wall-clock time and only splitting the remaining work into more jobs than it needed: **34 jobs to finish in the time one test file takes on its own.**

A test file cannot be divided, so the longest one is a floor under the phase no matter how the rest is packed, and packing below it just buys jobs that sit finished while everyone waits. Deriving the limit from that floor gives the same 11.58 min wall-clock in **22 jobs instead of 34** — I ran the solver against the current `E2E_TEST_DURATIONS` to confirm, and all 75 tests are still covered.

At ~80s of fixed overhead per shard, those 12 jobs are about 16 minutes of runner time and 12 fewer things competing for concurrency.

The job budget only starts to bind once the long files are split, which is the point: splitting one is now what makes the pipeline faster, with no constant here to retune afterwards. Stacked with #2195 the packer produces 25 jobs at a 10.23 min makespan.

## Two smaller things

Since the limit is now at least the longest test, nothing needs clamping. That also makes the solver's time limit uncritical — it's the constraint, not the objective, that bounds wall-clock, so stopping early costs a few extra jobs and nothing else. (Worth knowing: the new formulation does run the solver to its 60s limit rather than proving optimality quickly. `list-e2e-tests` has over two minutes of slack against the image builds, so this doesn't delay anything.)

The one real hazard is a solver that returns no solution at all. The variables would stay unset and the tests would quietly vanish from the pipeline instead of failing, so that's now checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)