### PR TITLE
Stop restoring a 484MB environment on every e2e shard

### DIFF
--- a/.github/actions/docker_image/action.yml
+++ b/.github/actions/docker_image/action.yml
@@ -4,6 +4,10 @@ inputs:
   dockerfile:
     description: "Path to the Dockerfile"
     required: true
+  extra-hash-files:
+    description: "Space separated files the Dockerfile copies in, which must also change the tag"
+    required: false
+    default: ""
   repository:
     description: "The docker respository"
     required: false
@@ -22,9 +26,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Create the tag by hashing the dockerfile
+    - name: Create the tag by hashing the dockerfile and whatever it copies in
       id: tag
-      run: echo "tag=$(shasum -a 256 ${{ inputs.dockerfile }} | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+      run: echo "tag=$(shasum -a 256 ${{ inputs.dockerfile }} ${{ inputs.extra-hash-files }} | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: concat the Docker image name

--- a/.github/actions/python_environment/action.yml
+++ b/.github/actions/python_environment/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Hash requirements.txt
-      run: echo "cache_key=requirements_txt_2_$(shasum -a 256 requirements.txt requirements_torch.txt urbanstats-persistent-data/requirements.txt | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+      run: echo "cache_key=requirements_txt_2_$(shasum -a 256 requirements.txt requirements_screenshots.txt requirements_torch.txt urbanstats-persistent-data/requirements.txt | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
       shell: bash
       id: hash
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: ./.github/actions/docker_image
         with:
           dockerfile: react/test/Dockerfile
+          extra-hash-files: requirements_screenshots.txt
           token: ${{ secrets.GITHUB_TOKEN }}
         id: image
 
@@ -150,7 +151,8 @@ jobs:
       - *checkout
       - run: git fetch origin ${{ github.base_ref }} --depth=1 # needed so test runner can diff tests against base ref
         if: ${{ github.base_ref != '' }}
-      - uses: ./.github/actions/python_environment
+      # No python_environment here: the image carries what check_images.py needs, and the
+      # full venv is a 484MB restore that every shard would pay for.
       - uses: ./.github/actions/node_modules
       - uses: actions/download-artifact@v4
         with:

--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -38,4 +38,9 @@ RUN apt-get -y install xdg-user-dirs
 # needed for emoji display in tests
 RUN apt-get -y install fonts-noto-color-emoji fonts-noto-core
 
+# Screenshot comparison is all the Python the e2e jobs do, so they install it here rather
+# than restoring the full environment. Last, so editing it doesn't rebuild the apt layers.
+COPY requirements_screenshots.txt /tmp/requirements_screenshots.txt
+RUN pip3 install -r /tmp/requirements_screenshots.txt && pip3 cache purge
+
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ] 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pygeos==0.14.0
 # necessary for the geopandas version
 fiona==1.9.6
 pandas==2.0.0
-numpy==1.26.4
+-r requirements_screenshots.txt
 permacache==3.9.0
 more_itertools
 cached_property
@@ -27,7 +27,6 @@ matplotlib==3.5.3
 disjoint_union==0.4.4
 openpyxl==3.1.3
 netCDF4==1.6.5
-Pillow==9.5.0
 dask==2025.4.1
 scikit-learn
 protobuf==6.33.5

--- a/requirements_screenshots.txt
+++ b/requirements_screenshots.txt
@@ -1,0 +1,4 @@
+# Everything tests/check_images.py needs. Kept apart from requirements.txt so the e2e
+# image can install just this, rather than restoring the full environment on every shard.
+numpy==1.26.4
+Pillow==9.5.0


### PR DESCRIPTION
Each e2e shard spent 16 seconds restoring the full Python environment, torch and all, in order to run one script. `tests/check_images.py` imports numpy and PIL and nothing else, and the proxy and test runner are TypeScript, so that's the entire Python surface of the job. The cache log tells the story: `Cache Size: ~484 MB`, 4s to download and 12s to untar, on every shard.

Those two pins move to their own requirements file, which the e2e image installs and `requirements.txt` includes with `-r`, so there's still one place the versions live.

## Keeping the pins and the image honest

A mismatch between the image and the pins would surface as screenshot differences, which is a miserable thing to debug. Two things guard it:

- the image tag now depends on that file, via a new `extra-hash-files` input — otherwise editing a pin would leave the tag unchanged and the old numpy in place
- the venv cache key hashes it too, for the same reason

Both image tags therefore change once and rebuild on the next run.

## Not done

Baking `node_modules` into the image the same way would save another 9 seconds per shard, but the workspace is a bind mount over that path, so it would need installing elsewhere and linking back. Not worth the fragility for 9 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)