### PR TITLE
Check out only the build context in the image jobs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,14 @@ jobs:
       image: ${{ steps.image.outputs.image }}
     permissions:
       packages: write
+    env:
+      # Checking out the working tree is ~30s of blob downloads, and every job that needs
+      # the image waits on it. This job only hashes the Dockerfile and hands it to docker
+      # build, so what it checks out is the build context, plus the actions it runs.
+      # Anything a Dockerfile starts COPYing has to be added here.
+      SPARSE_CHECKOUT: |
+        /Dockerfile
+        /.github/actions/*
     steps:
       - &checkout
         name: Checkout repository
@@ -59,6 +67,12 @@ jobs:
       image: ${{ steps.image.outputs.image }}
     permissions:
       packages: write
+    env:
+      # As above: this is the docker build context, not a working tree.
+      SPARSE_CHECKOUT: |
+        /react/test/Dockerfile
+        /requirements*.txt
+        /.github/actions/*
     steps:
       - *checkout
 


### PR DESCRIPTION
Both image jobs cloned the whole working tree in order to hash one Dockerfile and hand it to `docker build`. Every other job waits on the common image, so that checkout is the first thing on the critical path.

I measured the variants against this repo:

| checkout | time |
| --- | --- |
| current (full history, blobless, all-but-two-dirs) | 31.3s |
| `--depth=1`, same file set | 43.6s |
| full history, only the files the job reads | **2.9s** |

So nearly all of it is downloading file blobs, not history — `--depth=1` doesn't help and if anything hurts. Narrowing the file set gets it under 3 seconds using the same per-job `SPARSE_CHECKOUT` override `lint` already uses, so the shared clone is untouched.

## The sharp edge

What these jobs check out **is** the docker build context. A Dockerfile that starts `COPY`ing something has to have it added to the job's list, or the build fails looking for it. The e2e job's list covers the root `requirements*.txt` files for that reason, which also means it composes with #2197 rather than breaking it. The local actions have to be in the list too, since `uses: ./...` resolves them out of the workspace.

I've said this in a comment on both jobs, but it's the thing to watch in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)