### PR TITLE
Hold unchanged test files to the same e2e time limit as changed ones

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -172,6 +172,8 @@ jobs:
         with:
           name: frontend-build
           path: react/test/density-db
+      # The time limit is roughly 1.4x the longest test file, which leaves room for the
+      # ~1.3x swing a single file shows between runs.
       - name: Run tests
         run: |
           npm run test:e2e -- \

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -21,7 +21,7 @@ const options = argumentParser({
         headless: booleanArgument({ defaultValue: true }),
         video: booleanArgument({ defaultValue: false }),
         compare: booleanArgument({ defaultValue: false }),
-        timeLimitSeconds: z.optional(z.coerce.number().int()), // Enforced at 1x if the test file has changed compared to `baseRef`. Otherwise, enforced at 2x
+        timeLimitSeconds: z.optional(z.coerce.number().int()),
         tries: z.optional(z.coerce.number().int()).default(1), // Enforced at 1x if the test file has changed compared to `baseRef`. Otherwise, enforced at 2x
         baseRef: z.optional(z.string()),
         live: booleanArgument({ defaultValue: false }),
@@ -198,7 +198,7 @@ async function runTest(test: string): Promise<TestResult> {
         return { status: 'ran' as const, assertionsPassed: failed === 0, duration: Date.now() - start }
     })()
 
-    const timeLimitSeconds = options.live ? 1_000_000 : (options.timeLimitSeconds ?? 10_000) * (await testFileDidChange(test) ? 1 : 2)
+    const timeLimitSeconds = options.live ? 1_000_000 : (options.timeLimitSeconds ?? 10_000)
 
     const result = await withTimeout(runningTests, async () => timeLimitSeconds + await getTOTPWait(test))
 


### PR DESCRIPTION
The per-test kill timer has been doubled for files unchanged against the base ref since #1202. That existed because the two longest files genuinely ran past it: `sitemap` at 777s and `quiz_auth` at 754s against a 600s limit. Editing either would have failed the PR outright; they passed on main only because they were untouched. Splitting them in #2195 removed the reason, and nothing is above 435s now.

The allowance was also unenforceable in the case it most needed to fire. Two tries at 1200s is 40 minutes against `timeout-minutes: 30`, so a genuinely hung unchanged test got cancelled by GitHub with no explanation rather than by our own timer with the "took too long!" message. At a flat 600s that worst case is 20 minutes and the timer wins.

**The 600s constant is deliberately unchanged.** It has been retuned nine times (300 → 360 → 1000 → 500 → 700 → 300 → 500 → 300 → 600), so it seemed worth measuring before touching it again. Across five runs — the final #2195 PR run plus four on main — the longest file is `mapper-ux_x0` at 435s, and a single file's run-to-run spread has a median of 1.17x and reaches 1.25–1.35x (`mapper-ux_x1` swings 334→416s). 435 × 1.25 = 544, so anything under roughly 570s starts failing PRs for being unlucky. 600s is 1.38x the observed max, which is about right.

I also considered deriving the limit from `E2E_TEST_DURATIONS` the way #2196 derives the packer's bin size, and decided against it: that variable is written from successful runs, so a slow run would ratchet the limit up and it would never come back down.

The `tries` doubling is untouched — that is flake tolerance, which is a separate concern from detecting a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)