### PR TITLE
Fix the e2e docker image, broken since numpy/Pillow moved out of requirements.txt

### DIFF
--- a/react/test/scripts/run-e2e-tests-docker.Dockerfile
+++ b/react/test/scripts/run-e2e-tests-docker.Dockerfile
@@ -3,11 +3,6 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /urbanstats
 
-# Just what tests/check_images.py needs, rather than all of requirements.txt: the rest is unused here,
-# and pygeos has no arm64 wheel, so installing everything would rule out running on ARM.
-COPY requirements.txt requirements.txt
-RUN pip3 install $(grep -E '^(numpy|Pillow)==' requirements.txt)
-
 # Install node_modules at root so that it doesn't conflict with the volume that will be mounted
 ENV NODE_PATH=/node_modules
 COPY react/package.json react/package-lock.json /


### PR DESCRIPTION
`--docker` has been failing at image build since #2197. That PR moved numpy and Pillow into `requirements_screenshots.txt` and installed them in the base `urbanstats-test` image, but `run-e2e-tests-docker.Dockerfile` still grepped them out of `requirements.txt`. The grep now matches nothing, so `pip3 install` got an empty argument list and exited 1:

```
ERROR: You must give at least one requirement to install (see "pip help install")
```

Rather than repoint the grep at the new file, this drops the layer. Its comment explained that it installed a subset because the full `requirements.txt` was too heavy and pygeos has no arm64 wheel — but #2197 already carved out exactly those two packages for exactly that reason, one image down. Installing them again here would just be a slower no-op.

Worth noting for anyone auditing the blast radius: CI builds and runs the base image directly and never touches this Dockerfile, so nothing in the pipeline was affected. It only broke the local `--docker` path, which is also what you need to regenerate reference screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)