### PR TITLE
Make the sitemap shard failures say what actually went wrong

### DIFF
--- a/react/src/load_json.ts
+++ b/react/src/load_json.ts
@@ -8,6 +8,7 @@ import { dataLink, indexLink, orderingDataLink, orderingLink, shapeLink } from '
 import { Universe } from './universe'
 import { makeDebugLogger } from './utils/debug-logging'
 import { assert } from './utils/defensive'
+import { sanitize } from './utils/paths'
 import {
     Article, ConsolidatedArticles, ConsolidatedShapes, CountsByArticleUniverseAndType, DataLists,
     Feature, IOrderList, OrderList,
@@ -23,6 +24,7 @@ import {
     ArticleUniverseList,
     DefaultUniverseTable,
 } from './utils/protos'
+import { shardBytesFullNum } from './utils/shardHash'
 import { NormalizeProto } from './utils/types'
 
 const debugPerformance = makeDebugLogger('searchPerformance')
@@ -64,6 +66,8 @@ export async function loadProtobuf(filePath: string, name: string, errorOnMissin
     const response = await fetch(filePath)
     if (response.status < 200 || response.status > 299) {
         if (!errorOnMissing) {
+            // Otherwise this is indistinguishable from the shard not containing the longname
+            console.error(`[shard-fetch] ${filePath} returned ${response.status} ${response.statusText}`)
             return undefined
         }
         throw new Error(`Expected response status 2xx for ${filePath}, got ${response.status}: ${response.statusText}`)
@@ -151,6 +155,14 @@ async function getConsolidatedShapesShard(shardUrl: string): Promise<Consolidate
     return loadProtobuf(shardUrl, 'ConsolidatedShapes', false)
 }
 
+/** The shard downloaded fine but does not contain the longname, so either the shard index sent us to
+ * the wrong shard or the longname was never built. Logs the hashes the index reasoned about. */
+function logShardMiss(shardUrl: string, longname: string, names: string[]): void {
+    const hashOf = (name: string): string => shardBytesFullNum(sanitize(name)).toString(16).padStart(8, '0')
+    const hashes = names.map(hashOf).sort()
+    console.error(`[shard-miss] ${longname} (hash ${hashOf(longname)}) absent from ${shardUrl}, which holds ${names.length} names spanning ${hashes[0]}..${hashes[hashes.length - 1]}`)
+}
+
 /** Load one article from a consolidated shard (fetch whole .gz via loadProtobuf, find by longname). Resolves symlinks to target. */
 export async function loadArticleFromConsolidatedShard(shardUrl: string, longname: string): Promise<Article | undefined> {
     const shard = await getConsolidatedArticlesShard(shardUrl)
@@ -162,6 +174,7 @@ export async function loadArticleFromConsolidatedShard(shardUrl: string, longnam
         const target = shard.symlinkTargetNames[symIdx]
         return loadArticleFromConsolidatedShard(await dataLink(target), target)
     }
+    logShardMiss(shardUrl, longname, [...shard.longnames, ...shard.symlinkLinkNames])
     return undefined
 }
 
@@ -176,6 +189,7 @@ export async function loadFeatureFromConsolidatedShard(shardUrl: string, longnam
         const target = shard.symlinkTargetNames[symIdx]
         return loadFeatureFromConsolidatedShard(await shapeLink(target), target)
     }
+    logShardMiss(shardUrl, longname, [...shard.longnames, ...shard.symlinkLinkNames])
     return undefined
 }
 

--- a/react/test/scripts/ci_proxy.ts
+++ b/react/test/scripts/ci_proxy.ts
@@ -36,7 +36,13 @@ function jsdelivrProxy(sha: string, retryOnFailure: boolean): express.RequestHan
             // We must get by SHA, since if we used branch name jsdelvir would cache the result for 12 hours and we couldn't get new changes from the branch
             return `/gh/densitydb/densitydb.github.io@${sha}${req.path}`
         },
-        userResHeaderDecorator(headers, userReq) {
+        userResHeaderDecorator(headers, userReq, userRes, proxyReq, proxyRes) {
+            const status = proxyRes.statusCode ?? 0
+            if (status < 200 || status > 299) {
+                // 404 and 429 are not retried, and the frontend turns a missing shard into a
+                // "could not find feature" error, so this is where that trail starts
+                console.warn(`jsdelivr answered ${status} for ${userReq.path}`)
+            }
             const fileExtension = (/\.(.+)$/.exec(userReq.path))?.[1]
             const mimeType = fileExtension ? { html: 'text/html', js: 'text/javascript' }[fileExtension] : undefined
             // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-restricted-syntax -- We're removing the context-security-policy header via destructuring
@@ -76,6 +82,16 @@ export async function startProxy(): Promise<void> {
     const app = express()
 
     app.use(compression({ enforceEncoding: 'gzip' }))
+
+    app.use((req, res, next) => {
+        const start = Date.now()
+        res.on('finish', () => {
+            if (res.statusCode >= 400) {
+                console.warn(`Proxy served ${res.statusCode} for ${req.path} after ${Date.now() - start}ms`)
+            }
+        })
+        next()
+    })
 
     const handlers: express.RequestHandler[] = []
     for (let attempt = 1; attempt <= attempts; attempt++) {


### PR DESCRIPTION
The sitemap e2e jobs have been failing intermittently with an error that cannot be acted on:

```
Error: Could not find feature 50201, USA in shard /shape/7/c/shard_23420.gz
```

A different article each run, which is what makes it read as flake — the test samples URLs randomly, so a fixed set of broken pages would surface differently every time. The failing longname is usually *not* the article under test; it arrives via `polygonFeatureCollection`, which batch-loads every polygon on the article's map.

This PR does not fix the failure. It makes the failure legible, because right now the error is ambiguous by construction and there is no way to tell the candidate causes apart from CI logs.

## Why the current message can't be debugged

The shard loaders call `loadProtobuf(..., errorOnMissing: false)`, so a non-2xx silently becomes `undefined`, and the caller reports it identically to a shard that downloaded fine but genuinely lacks the longname. The e2e harness doesn't cover the gap either — it logs CDP `loadingFailed`, but a 404 completes normally and is never reported. So a fetch failure and a data problem are indistinguishable today.

## What the logging discriminates

- `[shard-fetch]` names the status when a non-2xx is swallowed. The only two callers passing `errorOnMissing: false` are the shard loaders, so this can't become background noise.
- `[shard-miss]` fires when the shard *did* download but lacks the name, printing the requested hash against the span of hashes the shard holds. Inside the span means the name was never built; outside means the shard index sent us to the wrong shard.

## Why the proxy is in scope

Tracing this turned up something that reframes the problem: `build-frontend` runs `--target scripts`, which maps to an empty build-step set, so `test/density-db` contains only compiled scripts. Every `/shape/**` and `/data/**` request — including the shard index — falls through to jsdelivr. The sitemap test visits hundreds of article pages, each firing a burst of parallel shard requests for map polygons, all at a public CDN.

And the retry chain only retries on `statusCode >= 500`. A 404, or a 429 from rate limiting, passes straight through to the frontend, gets swallowed, and surfaces as `Could not find feature`. The three attempts never engage for the status codes most likely under that load.

So the proxy now reports what jsdelivr answered per attempt, and the final status the browser received. With the frontend logging this gives one correlatable trail per path: what the CDN said, what the proxy returned, what the app did with it.

If the hypothesis holds, a failure will show `jsdelivr answered 429` immediately before the error. If instead `[shard-miss]` reports the hash *inside* the shard's span, it's a data/index problem and the CDN is exonerated.

Worth flagging separately: the retry filter not covering 429 looks like a real gap regardless of what's causing these failures. Left alone here so this change stays observability-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)