### PR TITLE
Scope the reference-screenshot rsync to the tests just run

### DIFF
--- a/react/test/README.md
+++ b/react/test/README.md
@@ -14,8 +14,14 @@
 
   ```
   npm run test:e2e -- '--test=test/mapper-edit-text-boxes-desktop.test.ts' --docker --browser=chromium --compare=true
-  rsync -a --exclude='*.error.png' changed_screenshots/ ../reference_test_screenshots/
+  rsync -a --exclude='*.error.png' \
+    changed_screenshots/mapper-edit-text-boxes-desktop/ \
+    ../reference_test_screenshots/mapper-edit-text-boxes-desktop/
   ```
+
+  Name the tests you just ran, rather than syncing `changed_screenshots/` whole. A run
+  only clears that directory for its own test, so it accumulates output from every
+  earlier run — and those stale images would overwrite references the run never looked at.
 
 - Run the tests off-screen on a Mac, in a container built for the host's architecture:
 


### PR DESCRIPTION
The README tells you to regenerate references with:

```
rsync -a --exclude='*.error.png' changed_screenshots/ ../reference_test_screenshots/
```

That syncs the directory whole. But a run only clears `changed_screenshots/` for its own test — [`run-e2e-tests.ts:186`](../react/test/scripts/run-e2e-tests.ts#L186) globs on `${test}` — so everything any earlier run left there is still sitting around. My checkout had ~50 such directories, some of them from tests I hadn't run in a long time.

Following the instruction after a single-test run therefore copies all of that into `reference_test_screenshots/`, overwriting references for tests the run never looked at. The failure mode is quiet: the stale images become the new references, so the next comparison passes against them, and a real regression can get baked in while the test stays green. Committing the result would then hide it in a diff of a hundred-odd binary files.

So the command now names its test on both sides. I hit this while generating references for #2207 and copied by hand instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)