### PR TITLE
Fall back to raw.githubusercontent when jsdelivr refuses a file

### DIFF
--- a/react/test/scripts/ci_proxy.ts
+++ b/react/test/scripts/ci_proxy.ts
@@ -24,30 +24,47 @@ import { github } from './github-utils'
 const attemptTimeoutMs = 10_000
 const attempts = 3
 
-const handOffToNextAttempt: proxy.ProxyOptions = {
-    skipToNextHandlerFilter: proxyRes => (proxyRes.statusCode ?? 500) >= 500,
-    proxyErrorHandler: (error, res, next) => { next() },
+const upstream: proxy.ProxyOptions = {
+    timeout: attemptTimeoutMs,
+    userResHeaderDecorator(headers, userReq) {
+        const fileExtension = (/\.(.+)$/.exec(userReq.path))?.[1]
+        const mimeType = fileExtension ? { html: 'text/html', js: 'text/javascript' }[fileExtension] : undefined
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-restricted-syntax -- We're removing the context-security-policy header via destructuring
+        const { 'content-security-policy': _, ...filteredHeaders } = headers
+        return {
+            ...filteredHeaders,
+            'content-type': mimeType ?? headers['content-type'],
+        }
+    },
 }
 
-function jsdelivrProxy(sha: string, retryOnFailure: boolean): express.RequestHandler {
+function jsdelivrProxy(sha: string): express.RequestHandler {
     return proxy(`https://cdn.jsdelivr.net`, {
-        timeout: attemptTimeoutMs,
+        ...upstream,
         proxyReqPathResolver(req) {
             // We must get by SHA, since if we used branch name jsdelvir would cache the result for 12 hours and we couldn't get new changes from the branch
             return `/gh/densitydb/densitydb.github.io@${sha}${req.path}`
         },
-        userResHeaderDecorator(headers, userReq) {
-            const fileExtension = (/\.(.+)$/.exec(userReq.path))?.[1]
-            const mimeType = fileExtension ? { html: 'text/html', js: 'text/javascript' }[fileExtension] : undefined
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-restricted-syntax -- We're removing the context-security-policy header via destructuring
-            const { 'content-security-policy': _, ...filteredHeaders } = headers
-            return {
-                ...filteredHeaders,
-                'content-type': mimeType ?? headers['content-type'],
-            }
+        // A 404 is jsdelivr telling us the file isn't there, which is an answer. Anything else means
+        // it didn't answer, so hand off to the next attempt and eventually to raw.githubusercontent.
+        skipToNextHandlerFilter: (proxyRes) => {
+            const status = proxyRes.statusCode ?? 500
+            return status !== 404 && (status < 200 || status > 299)
         },
-        // Hand off to the next attempt. The last one has no successor, so it reports what it got.
-        ...(retryOnFailure ? handOffToNextAttempt : {}),
+        proxyErrorHandler: (error, res, next) => { next() },
+    })
+}
+
+/**
+ * densitydb.github.io is around ninety times jsdelivr's 50MB package limit, so jsdelivr serves it
+ * only as long as it doesn't have to weigh the package. When it does, it answers 403 and caches
+ * that answer for twelve hours, which retries can't get past. raw has no size limit, and since we
+ * only reach it when jsdelivr has already failed it never carries the bulk of the traffic.
+ */
+function rawGithubProxy(sha: string): express.RequestHandler {
+    return proxy(`https://raw.githubusercontent.com`, {
+        ...upstream,
+        proxyReqPathResolver: req => `/densitydb/densitydb.github.io/${sha}${req.path}`,
     })
 }
 
@@ -85,8 +102,13 @@ export async function startProxy(): Promise<void> {
                 next()
             })
         }
-        handlers.push(jsdelivrProxy(branch.commit.sha, attempt < attempts))
+        handlers.push(jsdelivrProxy(branch.commit.sha))
     }
+    handlers.push((req, res, next) => {
+        console.warn(`jsdelivr did not serve ${req.path}; falling back to raw.githubusercontent`)
+        next()
+    })
+    handlers.push(rawGithubProxy(branch.commit.sha))
 
     app.use(express.static('test/density-db'), ...handlers)
 


### PR DESCRIPTION
jsdelivr returns 403 for files in `densitydb.github.io` and caches that 403 for twelve hours, which is what has been causing the sitemap e2e flake. This adds `raw.githubusercontent.com` as a fallback when jsdelivr fails.

The repo is about 4.3 GB, roughly ninety times jsdelivr's 50 MB package limit:

```
$ curl https://data.jsdelivr.com/v1/packages/gh/densitydb/densitydb.github.io@168a73aa
{"status": 403, "message": "Package size exceeded the configured limit of 50 MB."}
```

jsdelivr serves the repo anyway as long as it never has to weigh the package as a whole, but when it does it answers 403 with `cache-control: public, max-age=604800, s-maxage=43200`. A query-string cache-buster doesn't get around it either, since the shield normalizes the query away and returns the same `HIT`.

So one shard goes bad and stays bad for the rest of the day, and the sitemap test's random URL sampling decides whether a given run visits an article backed by it. The logging in #2208 caught it:

```
jsdelivr answered 403 for /data/0/6/shard_8966.gz
Proxy served 403 for /data/0/6/shard_8966.gz after 1477ms
From Browser: [shard-fetch] /data/0/6/shard_8966.gz returned 403 Forbidden
From Browser: Error loading page Error: Could not find article 23846, USA
   1) AssertionError: expected 'error' to not deeply equal 'error'
```

That job's second attempt drew a different sample and passed, which is why it went green.

Retrying can't get past a cached refusal, so the three existing jsdelivr attempts were never going to help and the last resort has to be a different host. raw has no package size limit and serves the exact file that 403'd. We only reach it once jsdelivr has already failed, so it doesn't carry meaningful traffic and its own rate limits aren't a concern.

404 deliberately still short-circuits. That is jsdelivr answering rather than failing, and falling back on it would route every genuinely-missing file through raw for nothing. Everything else that isn't 2xx now hands off, which also picks up 403 and 429; previously only 5xx did, so a 403 was passed straight through to the browser.

The fallback logs a line when it fires, so that if it starts absorbing requests in bulk we find out rather than having the problem hidden. The header decorator is now shared between the two upstreams, since raw sets a strict CSP and serves `.html` as `text/plain` and needs the same treatment jsdelivr already had.

I ran the handler chain against the real hosts:

```
/data/0/6/shard_8966.gz   -> 200 63976 bytes   (jsdelivr, no fallback)
/shape/                   -> 403, 2 retries, fallback -> 404
/definitely-not-a-file.gz -> 404               (no fallback request fired)
/robots.txt               -> 200 5383 bytes    (jsdelivr, no fallback)
```

Independent of #2208, which is observability only. Neither needs the other to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)