### PR TITLE
Log the TOTP endpoint's response when it isn't JSON

### DIFF
--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -28,7 +28,18 @@ const passwordInput = Selector('input[type=password]')
 
 async function popTOTP(t: TestController): Promise<string> {
     // https://script.google.com/u/2/home/projects/1CWDP4eezFo8fMhQb327VfSm3DnThl-8xg1fmg4cl9gHnK0NGB8XSz094/edit
-    const { useAfter } = z.object({ useAfter: z.number() }).parse(await (await fetch('https://script.google.com/macros/s/AKfycbxLMtid0yZ_JiX5Ymm02FXfbRXYrpF1AE9nUaDM8P9dhP7uOWJpMRH8SpG5TbCQCRc/exec')).json())
+    const response = await fetch('https://script.google.com/macros/s/AKfycbxLMtid0yZ_JiX5Ymm02FXfbRXYrpF1AE9nUaDM8P9dhP7uOWJpMRH8SpG5TbCQCRc/exec')
+    const body = await response.text()
+    let useAfter: number
+    try {
+        ({ useAfter } = z.object({ useAfter: z.number() }).parse(JSON.parse(body)))
+    }
+    catch (error) {
+        console.warn(`TOTP endpoint failed: ${response.status} ${response.statusText}, redirected to ${response.url}`)
+        console.warn(`headers: ${JSON.stringify(Object.fromEntries(response.headers))}`)
+        console.warn(`body: ${body}`)
+        throw error
+    }
     const wait = useAfter - Date.now()
     if (wait > 0) {
         console.warn(`TOTP waiting ${wait} ms...`)

--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -36,7 +36,7 @@ async function popTOTP(t: TestController): Promise<string> {
     }
     catch (error) {
         console.warn(`TOTP endpoint failed: ${response.status} ${response.statusText}, redirected to ${response.url}`)
-        console.warn(`headers: ${JSON.stringify(Object.fromEntries(response.headers))}`)
+        console.warn(`headers: ${JSON.stringify(response.headers)}`)
         console.warn(`body: ${body}`)
         throw error
     }


### PR DESCRIPTION
The Apps Script endpoint that gates TOTP usage in the auth e2e tests sometimes returns HTML instead of JSON, and the only evidence was `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. That doesn't distinguish between Google redirecting to a sign-in page (the deployment lost its anonymous-access setting) and the script itself erroring, which need different fixes.

The parse now happens against the body text, and on failure logs the status, the URL after redirects, the response headers, and the body before rethrowing. The rethrow keeps the failure mode identical; this only adds evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)