### PR TITLE
Infer the unit of a computed quantity

### DIFF
--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -2,16 +2,15 @@ import React, { CSSProperties, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
 import { useSetting } from '../page_template/settings'
-import { classifyStatistic, UnitType } from '../utils/unit'
+import { classifyStatistic, Unit, unitTypeToUnit } from '../utils/unit'
 
-import { getUnitDisplay } from './unit-display'
+import { getQuantityDisplay } from './unit-display'
 
-export function Statistic(props: { style?: React.CSSProperties, statname: string, value: number, isUnit: boolean, unit?: UnitType }): ReactNode {
+export function Statistic(props: { style?: React.CSSProperties, statname: string, value: number, isUnit: boolean, unit?: Unit }): ReactNode {
     const [useImperial] = useSetting('use_imperial')
     const [temperatureUnit] = useSetting('temperature_unit')
 
-    const statisticType = props.unit ?? classifyStatistic(props.statname)
-    const unitDisplay = getUnitDisplay(statisticType)
+    const unitDisplay = getQuantityDisplay(props.unit ?? unitTypeToUnit(classifyStatistic(props.statname)))
     const { value, unit } = unitDisplay.renderValue(props.value, useImperial, temperatureUnit)
 
     return (

--- a/react/src/components/load-article.ts
+++ b/react/src/components/load-article.ts
@@ -10,7 +10,7 @@ import { findAmbiguousSourcesAll, statParents, StatName, StatPath, statPathToOrd
 import { assert } from '../utils/defensive'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { Article, CongressionalRepresentativeTable, ICongressionalRepresentative, ICongressionalRepresentativePointer, IFirstOrLast, IMetadata } from '../utils/protos'
-import { UnitType } from '../utils/unit'
+import { Unit } from '../utils/unit'
 
 import { CountsByUT, forType } from './countsByArticleType'
 import { electionDisclaimerForRow, type Disclaimer } from './disclaimer-text'
@@ -111,7 +111,7 @@ const dataCreditExplanationPageByMetadataIndex = new Map<number, string>(
 interface StatisticCellRenderingInfoCommon {
     articleType: string
     statname: HumanReadableName
-    unit?: UnitType
+    unit?: Unit
     statpath?: StatPath
 }
 

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 
+import { HumanReadableName, reifyReact } from '../utils/human-readable-name'
 import { convertTemperature, displayQuantity, Unit, unitTypeToUnit, UnitType } from '../utils/unit'
 
 import { ElectionResult, GenericPartyChange, GenericPartyPercentage, LeftMargin } from './display-stats'
@@ -37,19 +38,9 @@ const renderMarginInequality: RenderInequality = (value, inequality) => {
     return renderInequality(value, inequality)
 }
 
-/**
- * Renders a unit name, where `^n` denotes a superscript, e.g., km^2.
- */
-export function renderUnitName(name: string): ReactNode {
-    if (name === '') {
-        return <span>&nbsp;</span>
-    }
-    const parts = name.split(/\^(-?[\d.]+)/)
-    return (
-        <span>
-            {parts.map((part, index) => index % 2 === 0 ? part : <sup key={index}>{part}</sup>)}
-        </span>
-    )
+function unitName(name: HumanReadableName): ReactNode {
+    // an empty unit still occupies its column
+    return <span>{name === '' ? '\u00a0' : reifyReact(name)}</span>
 }
 
 const percentageDisplay = (renderNumber: (value: number) => ReactNode, inequality = renderInequality): UnitDisplay => ({
@@ -105,7 +96,7 @@ export function getQuantityDisplay(unit: Unit): UnitDisplay {
                     const rendered = displayQuantity(value, unit, useImperial ?? false)
                     return {
                         value: <span>{rendered.value}</span>,
-                        unit: renderUnitName(rendered.unit),
+                        unit: unitName(rendered.unit),
                     }
                 },
                 renderInequality,

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react'
 
-import { formatToSignificantFigures, separateNumber } from '../utils/text'
-import { convertPrecipitation, convertTemperature, UnitType } from '../utils/unit'
+import { convertTemperature, displayQuantity, Unit, unitTypeToUnit, UnitType } from '../utils/unit'
 
 import { ElectionResult, GenericPartyChange, GenericPartyPercentage, LeftMargin } from './display-stats'
 
@@ -38,238 +37,45 @@ const renderMarginInequality: RenderInequality = (value, inequality) => {
     return renderInequality(value, inequality)
 }
 
-export function getUnitDisplay(unitType: UnitType): UnitDisplay {
-    switch (unitType) {
-        case 'percentage':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <span>{(value * 100).toFixed(2)}</span>,
-                        unit: <span>%</span>,
-                    }
-                },
-                renderInequality,
-            }
-        case 'percentageChange':
-            return {
-                renderValue: (value: number) => {
-                    const displayValue = (value * 100).toFixed(2)
-                    const sign = value >= 0 ? '+' : ''
-                    return {
-                        value: (
-                            <span>
-                                {sign}
-                                {displayValue}
-                            </span>
-                        ),
-                        unit: <span>%</span>,
-                    }
-                },
-                renderInequality,
-            }
-        case 'fatalities':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <span>{separateNumber(value.toFixed(0))}</span>,
-                        unit: <span>&nbsp;</span>,
-                    }
-                },
-                renderInequality,
-            }
-        case 'fatalitiesPerCapita':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <span>{(100_000 * value).toFixed(2)}</span>,
-                        unit: <span>/100k</span>,
-                    }
-                },
-                renderInequality,
-            }
-        case 'density':
-            return {
-                renderValue: (value: number, useImperial?: boolean) => {
-                    let unitName = 'km'
-                    let adjustedValue = value
-                    if (useImperial) {
-                        unitName = 'mi'
-                        adjustedValue *= 1.60934 * 1.60934
-                    }
-                    let places = 2
-                    if (adjustedValue > 10) {
-                        places = 0
-                    }
-                    else if (adjustedValue > 1) {
-                        places = 1
-                    }
-                    return {
-                        value: <span>{separateNumber(adjustedValue.toFixed(places))}</span>,
-                        unit: (
-                            <span>
-                                /&nbsp;
-                                {unitName}
-                                <sup>2</sup>
-                            </span>
-                        ),
-                    }
-                },
-                renderInequality,
-            }
-        case 'population':
-            return {
-                renderValue: (value: number) => {
-                    /*
-                     * Boundaries are at 999.5 * scale rather than 1000 * scale so that a value that
-                     * rounds up to 4 significant digits (e.g. 999999 → 1000k) is promoted to the next
-                     * tier instead. This keeps (value / divisor).toPrecision(3) below 1000, which
-                     * avoids toPrecision returning scientific notation (e.g. "1.00e+3").
-                     */
-                    if (value >= 999.5e6) {
-                        return {
-                            value: <span>{(value / 1e9).toPrecision(3)}</span>,
-                            unit: <span>B</span>,
-                        }
-                    }
-                    if (value >= 999.5e3) {
-                        return {
-                            value: <span>{(value / 1e6).toPrecision(3)}</span>,
-                            unit: <span>m</span>,
-                        }
-                    }
-                    else if (value > 1e4) {
-                        return {
-                            value: <span>{(value / 1e3).toPrecision(3)}</span>,
-                            unit: <span>k</span>,
-                        }
-                    }
-                    else {
-                        return {
-                            value: <span>{separateNumber(value.toFixed(0))}</span>,
-                            unit: <span>&nbsp;</span>,
-                        }
-                    }
-                },
-                renderInequality,
-            }
-        case 'area':
-            return {
-                renderValue: (value: number, useImperial?: boolean) => {
-                    let adjustedValue = value
-                    let unit: React.ReactElement
-                    if (useImperial) {
-                        adjustedValue /= 1.60934 * 1.60934
-                        if (adjustedValue < 1) {
-                            unit = <span>acres</span>
-                            adjustedValue *= 640
-                        }
-                        else {
-                            unit = (
-                                <span>
-                                    mi
-                                    <sup>2</sup>
-                                </span>
-                            )
-                        }
-                    }
-                    else {
-                        if (adjustedValue < 0.01) {
-                            adjustedValue *= 1000 * 1000
-                            unit = (
-                                <span>
-                                    m
-                                    <sup>2</sup>
-                                </span>
-                            )
-                        }
-                        else {
-                            unit = (
-                                <span>
-                                    km
-                                    <sup>2</sup>
-                                </span>
-                            )
-                        }
-                    }
-                    let places = 3
-                    if (adjustedValue > 100) {
-                        places = 0
-                    }
-                    else if (adjustedValue > 10) {
-                        places = 1
-                    }
-                    else if (adjustedValue > 1) {
-                        places = 2
-                    }
-                    let rendered = adjustedValue.toFixed(places)
-                    if (places === 0) {
-                        rendered = separateNumber(rendered)
-                    }
-                    return {
-                        value: <span>{rendered}</span>,
-                        unit,
-                    }
-                },
-                renderInequality,
-            }
-        case 'distanceInKm':
-            return {
-                renderValue: (value: number, useImperial?: boolean) => {
-                    let unit = <span>km</span>
-                    let adjustedValue = value
-                    if (useImperial) {
-                        unit = <span>mi</span>
-                        adjustedValue /= 1.60934
-                    }
-                    return {
-                        value: <span>{adjustedValue.toFixed(2)}</span>,
-                        unit,
-                    }
-                },
-                renderInequality,
-            }
-        case 'distanceInM':
-            return {
-                renderValue: (value: number, useImperial?: boolean) => {
-                    let unitName = 'm'
-                    let adjustedValue = value
-                    if (useImperial) {
-                        unitName = 'ft'
-                        adjustedValue *= 3.28084
-                    }
-                    return {
-                        value: <span>{separateNumber(adjustedValue.toFixed(0))}</span>,
-                        unit: <span>{unitName}</span>,
-                    }
-                },
-                renderInequality,
-            }
+/**
+ * Renders a unit name, where `^n` denotes a superscript, e.g., km^2.
+ */
+export function renderUnitName(name: string): ReactNode {
+    if (name === '') {
+        return <span>&nbsp;</span>
+    }
+    const parts = name.split(/\^(-?[\d.]+)/)
+    return (
+        <span>
+            {parts.map((part, index) => index % 2 === 0 ? part : <sup key={index}>{part}</sup>)}
+        </span>
+    )
+}
+
+const percentageDisplay = (renderNumber: (value: number) => ReactNode, inequality = renderInequality): UnitDisplay => ({
+    renderValue: (value: number) => ({ value: renderNumber(value), unit: <span>%</span> }),
+    renderInequality: inequality,
+})
+
+/**
+ * Renders a quantity in whichever of its unit's display units fits its magnitude, e.g., a value
+ * of 600 minutes as 10 hours. Quantities displayed in party colors are rendered here rather than
+ * as plain numbers, as is a temperature, which the reader can ask for in celsius.
+ */
+export function getQuantityDisplay(unit: Unit): UnitDisplay {
+    switch (unit.presentation) {
         case 'democraticMargin':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <ElectionResult value={value} />,
-                        unit: <span>%</span>,
-                    }
-                },
-                renderInequality: renderMarginInequality,
-            }
+            return percentageDisplay(value => <ElectionResult value={value} />, renderMarginInequality)
+        case 'leftMargin':
+            return percentageDisplay(value => <LeftMargin value={value} />, renderMarginInequality)
         case 'partyPctBlue':
         case 'partyPctRed':
         case 'partyPctOrange':
         case 'partyPctTeal':
         case 'partyPctGreen':
         case 'partyPctPurple': {
-            const capturedUnitType = unitType
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <GenericPartyPercentage value={value} unitType={capturedUnitType} />,
-                        unit: <span>%</span>,
-                    }
-                },
-                renderInequality,
-            }
+            const unitType = unit.presentation
+            return percentageDisplay(value => <GenericPartyPercentage value={value} unitType={unitType} />)
         }
         case 'partyChangeBlue':
         case 'partyChangeRed':
@@ -277,176 +83,29 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'partyChangeTeal':
         case 'partyChangeGreen':
         case 'partyChangePurple': {
-            const capturedUnitType = unitType
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <GenericPartyChange value={value} unitType={capturedUnitType} />,
-                        unit: <span>%</span>,
-                    }
-                },
-                renderInequality,
-            }
+            const unitType = unit.presentation
+            return percentageDisplay(value => <GenericPartyChange value={value} unitType={unitType} />)
         }
-        case 'leftMargin':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <LeftMargin value={value} />,
-                        unit: <span>%</span>,
-                    }
-                },
-                renderInequality: renderMarginInequality,
-            }
         case 'temperature':
             return {
                 renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-                    const { value: adjustedValue, unit } = convertTemperature(value, temperatureUnit ?? 'fahrenheit')
+                    const { value: converted, unit: temperatureName } = convertTemperature(value, temperatureUnit ?? 'fahrenheit')
                     return {
-                        value: <span>{adjustedValue.toFixed(1)}</span>,
-                        unit: <span>{unit}</span>,
+                        value: <span>{converted.toFixed(1)}</span>,
+                        unit: <span>{temperatureName}</span>,
                     }
                 },
                 renderInequality,
             }
-        case 'time':
-            return {
-                renderValue: (value: number) => {
-                    const hours = Math.floor(value)
-                    const minutes = Math.floor((value - hours) * 60)
-                    return {
-                        value: (
-                            <span>
-                                {hours}
-                                :
-                                {minutes.toString().padStart(2, '0')}
-                            </span>
-                        ),
-                        unit: <span>&nbsp;</span>,
-                    }
-                },
-                renderInequality,
-            }
-        case 'distancePerYear':
+        case undefined:
+        case 'percentage':
+        case 'percentageChange':
             return {
                 renderValue: (value: number, useImperial?: boolean) => {
-                    const { value: adjustedValue, unit } = convertPrecipitation(value, useImperial ?? false)
+                    const rendered = displayQuantity(value, unit, useImperial ?? false)
                     return {
-                        value: <span>{adjustedValue.toFixed(1)}</span>,
-                        unit: (
-                            <span>
-                                {unit}
-                                /yr
-                            </span>
-                        ),
-                    }
-                },
-                renderInequality,
-            }
-        case 'contaminantLevel':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <span>{value.toFixed(2)}</span>,
-                        unit: (
-                            <span>
-                                &mu;g/m
-                                <sup>3</sup>
-                            </span>
-                        ),
-                    }
-                },
-                renderInequality,
-            }
-        case 'number':
-            return {
-                renderValue: (value: number) => {
-                    return {
-                        value: <span>{formatToSignificantFigures(value, 3)}</span>,
-                        unit: <span>&nbsp;</span>,
-                    }
-                },
-                renderInequality,
-            }
-        case 'usd':
-            return {
-                renderValue: (value: number) => {
-                    /*
-                     * Boundaries are at 999.5 * scale rather than 1000 * scale so that a value that
-                     * rounds up to 4 significant digits (e.g. 999999 → 1000k) is promoted to the next
-                     * tier instead. This keeps (value / divisor).toPrecision(3) below 1000, which
-                     * avoids toPrecision returning scientific notation (e.g. "1.00e+3").
-                     */
-                    if (value >= 999.5e6) {
-                        return {
-                            value: (
-                                <span>
-                                    $
-                                    {(value / 1e9).toPrecision(3)}
-                                </span>
-                            ),
-                            unit: <span>B</span>,
-                        }
-                    }
-                    if (value >= 999.5e3) {
-                        return {
-                            value: (
-                                <span>
-                                    $
-                                    {(value / 1e6).toPrecision(3)}
-                                </span>
-                            ),
-                            unit: <span>m</span>,
-                        }
-                    }
-                    else if (value > 1e3) {
-                        return {
-                            value: (
-                                <span>
-                                    $
-                                    {(value / 1e3).toPrecision(3)}
-                                </span>
-                            ),
-                            unit: <span>k</span>,
-                        }
-                    }
-                    else {
-                        return {
-                            value: (
-                                <span>
-                                    $
-                                    {separateNumber(value.toFixed(0))}
-                                </span>
-                            ),
-                            unit: <span>&nbsp;</span>,
-                        }
-                    }
-                },
-                renderInequality,
-            }
-        case 'minutes':
-            return {
-                renderValue: (value: number) => {
-                    const hours = Math.floor(value / 60)
-                    const minutes = Math.floor(value % 60)
-
-                    if (hours > 0) {
-                        return {
-                            value: (
-                                <span>
-                                    {hours}
-                                    :
-                                    {minutes.toString().padStart(2, '0')}
-                                </span>
-                            ),
-                            unit: <span>&nbsp;</span>,
-                        }
-                    }
-                    else {
-                        return {
-                            value: <span>{minutes}</span>,
-                            unit: <span>&nbsp;</span>,
-                        }
+                        value: <span>{rendered.value}</span>,
+                        unit: renderUnitName(rendered.unit),
                     }
                 },
                 renderInequality,
@@ -454,6 +113,11 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
     }
 }
 
+export function getUnitDisplay(unitType: UnitType): UnitDisplay {
+    return getQuantityDisplay(unitTypeToUnit(unitType))
+}
+
+// Describes a unit type in prose, for the documentation of the unit constants
 export function getUnit(unit: UnitType): ReactNode {
     switch (unit) {
         case 'percentage':

--- a/react/src/mapper/components/Colorbar.tsx
+++ b/react/src/mapper/components/Colorbar.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { Statistic } from '../../components/display-stats'
-import { getUnitDisplay } from '../../components/unit-display'
+import { getQuantityDisplay } from '../../components/unit-display'
 import { Colors } from '../../page_template/color-themes'
 import { useColors } from '../../page_template/colors'
 import { ScaleInstance } from '../../urban-stats-script/constants/scale'
 import { furthestColor, interpolateColor } from '../../utils/color'
 import { HumanReadableName, reifyReact, reifyString } from '../../utils/human-readable-name'
-import { classifyStatistic, UnitType } from '../../utils/unit'
+import { classifyStatistic, Unit, unitTypeToUnit } from '../../utils/unit'
 import { Keypoints } from '../ramps'
 import { Basemap } from '../settings/utils'
 
@@ -16,7 +16,7 @@ interface EmpiricalRamp {
     scale: ScaleInstance
     interpolations: number[]
     label: HumanReadableName
-    unit?: UnitType
+    unit?: Unit
     hasValuesClampedToStart: boolean
     hasValuesClampedToEnd: boolean
 }
@@ -163,7 +163,7 @@ function RampColorbar({ ramp }: { ramp: EmpiricalRamp }): ReactNode {
 function MaybeInequality({ ramp, index }: { ramp: EmpiricalRamp, index: number }): ReactNode {
     const scaleAscending = ramp.scale.inverse(0) < ramp.scale.inverse(1)
     // Similarly to how we do it with <Statistic/> above
-    const unitDisplay = getUnitDisplay(ramp.unit ?? classifyStatistic(reifyString(ramp.label)))
+    const unitDisplay = getQuantityDisplay(ramp.unit ?? unitTypeToUnit(classifyStatistic(reifyString(ramp.label))))
     const isFirst = index === 0
     const isLast = index === ramp.interpolations.length - 1
     let prefix: string | undefined

--- a/react/src/mapper/map-generator.tsx
+++ b/react/src/mapper/map-generator.tsx
@@ -36,6 +36,7 @@ import { makeDebugLogger } from '../utils/debug-logging'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { ConsolidatedShapes, Feature, ICoordinate } from '../utils/protos'
 import { NormalizeProto } from '../utils/types'
+import { unitTypeToUnit } from '../utils/unit'
 import { useDebouncedResolve } from '../utils/useDebouncedResolve'
 
 import { Colorbar, RampToDisplay, styleFromBasemap } from './components/Colorbar'
@@ -583,7 +584,8 @@ function computeRampToDisplay(value: CommonMap, label: HumanReadableName): RampT
     const hasValuesClampedToStart = value.data.some(val => scale.forward(val) < 0)
     const hasValuesClampedToEnd = value.data.some(val => scale.forward(val) > 1)
     const interpolations = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1].map(scale.inverse)
-    return { type: 'ramp', value: { ramp: value.ramp, interpolations, scale, label, unit: value.unit, hasValuesClampedToStart, hasValuesClampedToEnd } }
+    const unit = value.unit === undefined ? undefined : unitTypeToUnit(value.unit)
+    return { type: 'ramp', value: { ramp: value.ramp, interpolations, scale, label, unit, hasValuesClampedToStart, hasValuesClampedToEnd } }
 }
 
 const canonicalWidth = 1200

--- a/react/src/mapper/map-generator.tsx
+++ b/react/src/mapper/map-generator.tsx
@@ -27,6 +27,7 @@ import { deriveMapLabel } from '../urban-stats-script/derive-human-readable-name
 import { EditorError } from '../urban-stats-script/editor-utils'
 import { noLocation } from '../urban-stats-script/location'
 import { TypeEnvironment, USSOpaqueValue } from '../urban-stats-script/types-values'
+import { deriveMapUnit } from '../urban-stats-script/unit-inference'
 import { AssignmentsResult, executeAsync } from '../urban-stats-script/workerManager'
 import { loadImage } from '../utils/Image'
 import { editIndex, EditSeq } from '../utils/array-edits'
@@ -36,7 +37,7 @@ import { makeDebugLogger } from '../utils/debug-logging'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { ConsolidatedShapes, Feature, ICoordinate } from '../utils/protos'
 import { NormalizeProto } from '../utils/types'
-import { unitTypeToUnit } from '../utils/unit'
+import { Unit, unitTypeToUnit } from '../utils/unit'
 import { useDebouncedResolve } from '../utils/useDebouncedResolve'
 
 import { Colorbar, RampToDisplay, styleFromBasemap } from './components/Colorbar'
@@ -139,6 +140,10 @@ async function makeMapGenerator({ mapSettings, cache, previousGenerator, typeEnv
         label = mapResultMain.value.label
     }
 
+    const unit = mapResultMain.value.unit !== undefined
+        ? unitTypeToUnit(mapResultMain.value.unit)
+        : deriveMapUnit(mapSettings.script.uss, typeEnvironment)
+
     const csvExportCallback: CSVExportData = () => {
         const csvData = generateMapperCSVData(mapResultMain, execResult.assignments)
         const csvFilename = `${mapSettings.geographyKind}-${mapSettings.universe}-data.csv`
@@ -148,7 +153,7 @@ async function makeMapGenerator({ mapSettings, cache, previousGenerator, typeEnv
         }
     }
 
-    const { features, mapComponentCreator, ramp } = await loadMapResult({ mapResultMain, universe: mapSettings.universe, geographyKind: mapSettings.geographyKind, cache, label })
+    const { features, mapComponentCreator, ramp } = await loadMapResult({ mapResultMain, universe: mapSettings.universe, geographyKind: mapSettings.geographyKind, cache, label, unit })
 
     function MapComponent({ props, exportImageRef }: { props: MapUIProps<{ loading: boolean }>, exportImageRef: (fn: () => Promise<HTMLCanvasElement>) => void }): ReactNode {
         const mapsRef: (MapRef | null)[] = []
@@ -419,13 +424,14 @@ type MapComponentCreator = (
     clickable: boolean,
 ) => ReactNode
 
-async function loadMapResult({ mapResultMain: { opaqueType, value }, universe, geographyKind, cache, label }:
+async function loadMapResult({ mapResultMain: { opaqueType, value }, universe, geographyKind, cache, label, unit }:
 {
     mapResultMain: USSOpaqueValue & { opaqueType: 'cMap' | 'cMapRGB' | 'pMap' | 'clusterMap' }
     universe: Universe
     geographyKind: typeof valid_geographies[number]
     cache: MapCache
     label: HumanReadableName
+    unit: Unit | undefined
 }): Promise<{ features: GeoJSON.Feature[], mapComponentCreator: MapComponentCreator, ramp: RampToDisplay }> {
     let ramp: RampToDisplay
     let colors: string[]
@@ -435,12 +441,12 @@ async function loadMapResult({ mapResultMain: { opaqueType, value }, universe, g
         case 'pMap':
         case 'cMap':
             const furthest = furthestColor(value.ramp.map(x => x[1]))
-            const pcMapRamp = computeRampToDisplay(value, label)
+            const pcMapRamp = computeRampToDisplay(value, label, unit)
             ramp = pcMapRamp
             colors = value.data.map(val => interpolateColor(value.ramp, pcMapRamp.value.scale.forward(val), furthest))
             break
         case 'clusterMap':
-            const clusterRamp = computeRampToDisplay(value, label)
+            const clusterRamp = computeRampToDisplay(value, label, unit)
             ramp = clusterRamp
 
             // Discretize by scaled values to match the same bins used in legend interpolations.
@@ -579,12 +585,11 @@ function computeClusterRampBin(val: number, clusterRamp: RampToDisplay & { type:
     return clamped
 }
 
-function computeRampToDisplay(value: CommonMap, label: HumanReadableName): RampToDisplay & { type: 'ramp' } {
+function computeRampToDisplay(value: CommonMap, label: HumanReadableName, unit: Unit | undefined): RampToDisplay & { type: 'ramp' } {
     const scale = instantiate(value.scale)
     const hasValuesClampedToStart = value.data.some(val => scale.forward(val) < 0)
     const hasValuesClampedToEnd = value.data.some(val => scale.forward(val) > 1)
     const interpolations = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1].map(scale.inverse)
-    const unit = value.unit === undefined ? undefined : unitTypeToUnit(value.unit)
     return { type: 'ramp', value: { ramp: value.ramp, interpolations, scale, label, unit, hasValuesClampedToStart, hasValuesClampedToEnd } }
 }
 

--- a/react/src/stat/types.ts
+++ b/react/src/stat/types.ts
@@ -3,7 +3,7 @@ import statnames from '../data/statistic_name_list'
 import { MapUSS } from '../mapper/settings/map-uss'
 import { Universe } from '../universe'
 import { HumanReadableName } from '../utils/human-readable-name'
-import { UnitType } from '../utils/unit'
+import { Unit } from '../utils/unit'
 
 export type Statistic = {
     universe: Universe
@@ -29,7 +29,7 @@ export interface StatSettings {
 
 export interface StatData {
     // One entry per column
-    table: { value: number[], populationPercentile: number[], ordinal: number[], name: HumanReadableName, unit?: UnitType }[]
+    table: { value: number[], populationPercentile: number[], ordinal: number[], name: HumanReadableName, unit?: Unit }[]
     articleNames: string[]
     renderedStatname: HumanReadableName
     statcol?: StatCol

--- a/react/src/stat/useStatGenerator.ts
+++ b/react/src/stat/useStatGenerator.ts
@@ -13,6 +13,7 @@ import { deriveTableColumnLabel, deriveTableLabel } from '../urban-stats-script/
 import { EditorError } from '../urban-stats-script/editor-utils'
 import { noLocation } from '../urban-stats-script/location'
 import { renderType, TypeEnvironment } from '../urban-stats-script/types-values'
+import { deriveTableColumnUnit } from '../urban-stats-script/unit-inference'
 import { AssignmentsResult, executeAsync } from '../urban-stats-script/workerManager'
 import { assert } from '../utils/defensive'
 import { HumanReadableName } from '../utils/human-readable-name'
@@ -129,7 +130,7 @@ async function makeStatGenerator({ stat, typeEnvironment, previousGenerator }: {
                 populationPercentile: col.populationPercentiles,
                 ordinal: computeOrdinals(col.values),
                 name,
-                unit: col.unit === undefined ? undefined : unitTypeToUnit(col.unit),
+                unit: col.unit !== undefined ? unitTypeToUnit(col.unit) : deriveTableColumnUnit(mapUSS, typeEnvironment, index),
             }
         })
 

--- a/react/src/stat/useStatGenerator.ts
+++ b/react/src/stat/useStatGenerator.ts
@@ -17,6 +17,7 @@ import { AssignmentsResult, executeAsync } from '../urban-stats-script/workerMan
 import { assert } from '../utils/defensive'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { pluralize } from '../utils/text'
+import { unitTypeToUnit } from '../utils/unit'
 import { useDebouncedResolve } from '../utils/useDebouncedResolve'
 
 import { StatData, Statistic } from './types'
@@ -128,7 +129,7 @@ async function makeStatGenerator({ stat, typeEnvironment, previousGenerator }: {
                 populationPercentile: col.populationPercentiles,
                 ordinal: computeOrdinals(col.values),
                 name,
-                unit: col.unit,
+                unit: col.unit === undefined ? undefined : unitTypeToUnit(col.unit),
             }
         })
 

--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -1,27 +1,42 @@
 import { MapUSS, mapUssParser } from '../mapper/settings/map-uss'
 import { assert } from '../utils/defensive'
 import { HumanReadableElement, HumanReadableName, joinHumanReadableNames } from '../utils/human-readable-name'
-import { formatToSignificantFigures, separateNumber } from '../utils/text'
+import { formatToSignificantFigures, separateNumber, trimTrailingZeros } from '../utils/text'
+import { displayQuantity, displayUnitFor, unitSuffix } from '../utils/unit'
 
 import { UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
 import * as l from './literal-parser'
 import { noLocation } from './location'
-import { expressionOperatorMap } from './operators'
+import { BinaryOperatorSymbol, expressionOperatorMap } from './operators'
 import { TypeEnvironment } from './types-values'
+import { inferUnit, InferredUnit } from './unit-inference'
 
-function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment): HumanReadableElement[] | undefined {
+/**
+ * Operators whose operands are quantities of the same kind, so a bare number written as one
+ * operand is in the unit of the other one.
+ */
+const operatorsSharingUnits = new Set<BinaryOperatorSymbol>(['+', '-', '==', '!=', '<', '>', '<=', '>='])
+
+/**
+ * `unit` is the unit a numeric constant in this position is measured in, which is used to
+ * render, e.g., `commute_bike < 0.1` as `Commute Bike % < 10%`.
+ */
+function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment, unit?: InferredUnit): HumanReadableElement[] | undefined {
     switch (ast.type) {
         case 'assignment':
-            return humanReadableElements(ast.value, typeEnvironment)
+            return humanReadableElements(ast.value, typeEnvironment, unit)
         case 'autoUXNode':
-            return humanReadableElements(ast.expr, typeEnvironment)
+            return humanReadableElements(ast.expr, typeEnvironment, unit)
         case 'binaryOperator': {
             const centerOp = expressionOperatorMap[ast.operator.node]
+            const sharesUnits = operatorsSharingUnits.has(ast.operator.node)
+            const leftUnit = sharesUnits ? inferUnit(ast.right, typeEnvironment) : undefined
+            const rightUnit = sharesUnits ? inferUnit(ast.left, typeEnvironment) : undefined
             /*
              * (A op1 B) op2 C => A op1 B op2 C iff prec(op1) > prec(op2) or op1 = op2
              * A op1 (B op2 C) => A op1 B op2 C iff prec(op2) > prec(op1) or (op1 = op2 and is_assoc(op1))
              */
-            let lhs = humanReadableElements(ast.left, typeEnvironment)
+            let lhs = humanReadableElements(ast.left, typeEnvironment, leftUnit)
             if (lhs === undefined) return
             if (ast.left.type === 'binaryOperator') {
                 const leftOp = expressionOperatorMap[ast.left.operator.node]
@@ -31,7 +46,7 @@ function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTState
                 }
             }
 
-            let rhs = humanReadableElements(ast.right, typeEnvironment)
+            let rhs = humanReadableElements(ast.right, typeEnvironment, rightUnit)
             if (rhs === undefined) return
             if (ast.right.type === 'binaryOperator') {
                 const rightOp = expressionOperatorMap[ast.right.operator.node]
@@ -94,12 +109,12 @@ function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTState
                 case 'humanReadableElements':
                     return ast.value.node.value
                 case 'number':
-                    return formatNumber(ast.value.node.value)
+                    return formatNumberWithUnit(ast.value.node.value, unit)
                 case 'string':
                     return [{ type: 'atom', value: ast.value.node.value }]
             }
         case 'unaryOperator': {
-            const operand = humanReadableElements(ast.expr, typeEnvironment)
+            const operand = humanReadableElements(ast.expr, typeEnvironment, unit)
             if (operand === undefined) return
             let operator: HumanReadableElement[]
             switch (ast.operator.node) {
@@ -116,9 +131,9 @@ function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTState
             return [...operator, ...operand]
         }
         case 'customNode':
-            return humanReadableElements(ast.expr, typeEnvironment)
+            return humanReadableElements(ast.expr, typeEnvironment, unit)
         case 'expression':
-            return humanReadableElements(ast.value, typeEnvironment)
+            return humanReadableElements(ast.value, typeEnvironment, unit)
         case 'call': {
             const fn = humanReadableElements(ast.fn, typeEnvironment)
             if (fn === undefined) return
@@ -252,9 +267,25 @@ export function deriveTableLabel(uss: MapUSS, typeEnvironment: TypeEnvironment, 
     }
 }
 
-function trimTrailingZeros(value: string): string {
-    if (!value.includes('.')) return value
-    return value.replace(/\.?0+$/g, '')
+/**
+ * Formats a constant written in the given unit, e.g., 0.1 as a percentage is 10%, and 600 as a
+ * number of minutes is 10 hours. The unit is only named when the number has to be rescaled to be
+ * read in it, so that, e.g., a population is still just a number of people.
+ */
+function formatNumberWithUnit(value: number, unit: InferredUnit): HumanReadableElement[] {
+    if (unit === undefined) {
+        return formatNumber(value)
+    }
+    // magnitude tiers are skipped because formatNumber abbreviates large numbers itself
+    const { scale, name, attached, custom } = displayUnitFor(value, unit, false, { includeTiers: false })
+    if (scale === 1) {
+        return formatNumber(value)
+    }
+    if (custom) {
+        const quantity = displayQuantity(value, unit, false, { includeTiers: false })
+        return [{ type: 'atom', value: `${quantity.value}${unitSuffix(quantity.unit, attached)}` }]
+    }
+    return [...formatNumber(value * scale), { type: 'atom', value: unitSuffix(name, attached) }]
 }
 
 function formatNumber(number: number): HumanReadableElement[] {

--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -1,0 +1,193 @@
+import { MapUSS, mapUssParser } from '../mapper/settings/map-uss'
+import { combineUnits, dimensionless, powerUnit, sameDimensions, Unit, unitTypeToUnit } from '../utils/unit'
+
+import { UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
+import * as l from './literal-parser'
+import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
+import { TypeEnvironment } from './types-values'
+
+/**
+ * The unit of an expression, computed by abstract interpretation over the AST. Undefined means
+ * the unit could not be inferred, e.g., for a numeric constant or the result of a function.
+ */
+export type InferredUnit = Unit | undefined
+
+function withoutPresentation(unit: Unit): Unit {
+    return { dimensions: unit.dimensions, multiplier: unit.multiplier }
+}
+
+/**
+ * Two quantities can only be added if they are the same unit. Their presentation survives only if
+ * they share it, so a percentage plus a percentage is a percentage, but a percentage plus an
+ * election margin is a plain fraction.
+ */
+function additionUnit(left: Unit, right: Unit): InferredUnit {
+    if (!sameDimensions(left.dimensions, right.dimensions) || left.multiplier !== right.multiplier) {
+        return undefined
+    }
+    if (left.presentation === right.presentation) {
+        return left
+    }
+    if (left.presentation !== undefined && right.presentation !== undefined) {
+        return { ...withoutPresentation(left), presentation: 'percentage' }
+    }
+    return withoutPresentation(left)
+}
+
+function exponentiationUnit(base: Unit, exponent: number | undefined): InferredUnit {
+    if (exponent !== undefined) {
+        return powerUnit(withoutPresentation(base), exponent)
+    }
+    // any power of a plain number is a plain number, whatever the exponent is
+    return sameDimensions(base.dimensions, {}) && base.multiplier === 1 ? dimensionless : undefined
+}
+
+/**
+ * The unit of `left operator right`. The exponent is the value of the right operand, which is
+ * needed to raise a unit to a power, and is undefined if it is not a known constant.
+ */
+export function binaryOperatorUnit(
+    operator: BinaryOperatorSymbol,
+    left: InferredUnit,
+    right: InferredUnit,
+    exponent?: number,
+): InferredUnit {
+    switch (operator) {
+        case '==':
+        case '!=':
+        case '<':
+        case '>':
+        case '<=':
+        case '>=':
+        case '&':
+        case '|':
+            return undefined
+        case '**':
+            return left === undefined ? undefined : exponentiationUnit(left, exponent)
+        case '+':
+        case '-':
+        case '*':
+        case '/':
+            break
+    }
+    if (left === undefined) {
+        return right
+    }
+    if (right === undefined) {
+        return left
+    }
+    switch (operator) {
+        case '+':
+        case '-':
+            return additionUnit(left, right)
+        case '*':
+            return combineUnits(withoutPresentation(left), withoutPresentation(right), 1)
+        case '/':
+            return combineUnits(withoutPresentation(left), withoutPresentation(right), -1)
+    }
+}
+
+export function unaryOperatorUnit(operator: UnaryOperatorSymbol, operand: InferredUnit): InferredUnit {
+    return operator === '!' ? undefined : operand
+}
+
+function constantNumber(ast: UrbanStatsASTExpression): number | undefined {
+    if (ast.type === 'constant') {
+        return ast.value.node.type === 'number' ? ast.value.node.value : undefined
+    }
+    if (ast.type === 'unaryOperator' && (ast.operator.node === '+' || ast.operator.node === '-')) {
+        const operand = constantNumber(ast.expr)
+        if (operand === undefined) return undefined
+        return ast.operator.node === '-' ? -operand : operand
+    }
+    return undefined
+}
+
+export function inferUnit(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment): InferredUnit {
+    switch (ast.type) {
+        case 'identifier':
+            const unitType = typeEnvironment.get(ast.name.node)?.documentation?.unit
+            return unitType === undefined ? undefined : unitTypeToUnit(unitType)
+        case 'binaryOperator':
+            return binaryOperatorUnit(
+                ast.operator.node,
+                inferUnit(ast.left, typeEnvironment),
+                inferUnit(ast.right, typeEnvironment),
+                constantNumber(ast.right),
+            )
+        case 'unaryOperator':
+            return unaryOperatorUnit(ast.operator.node, inferUnit(ast.expr, typeEnvironment))
+        case 'assignment':
+        case 'expression':
+            return inferUnit(ast.value, typeEnvironment)
+        case 'customNode':
+        case 'autoUXNode':
+            return inferUnit(ast.expr, typeEnvironment)
+        case 'do':
+            if (ast.statements.length === 0) return undefined
+            return inferUnit(ast.statements[ast.statements.length - 1], typeEnvironment)
+        case 'statements':
+            if (ast.result.length === 0) return undefined
+            return inferUnit(ast.result[ast.result.length - 1], typeEnvironment)
+        case 'condition':
+            if (ast.rest.length === 0) return undefined
+            return inferUnit(ast.rest[ast.rest.length - 1], typeEnvironment)
+        case 'constant':
+        case 'call':
+        case 'attribute':
+        case 'vectorLiteral':
+        case 'objectLiteral':
+        case 'if':
+        case 'parseError':
+            return undefined
+    }
+}
+
+function inferUnitOfArgument(
+    uss: MapUSS,
+    typeEnvironment: TypeEnvironment,
+    argument: (parsed: ReturnType<ReturnType<typeof valuesSchema>>) => UrbanStatsASTExpression | undefined,
+): InferredUnit {
+    try {
+        const expr = argument(valuesSchema()(uss, typeEnvironment))
+        if (expr === undefined) return undefined
+        return inferUnit(expr, typeEnvironment)
+    }
+    catch (error) {
+        if (error instanceof l.LiteralParseError) {
+            return undefined
+        }
+        throw error
+    }
+}
+
+function valuesSchema(): (uss: MapUSS, typeEnvironment: TypeEnvironment) => {
+    namedArgs: { data: UrbanStatsASTExpression | undefined, columns: { namedArgs: { values: UrbanStatsASTExpression | undefined } }[] | undefined }
+} {
+    return mapUssParser(l.call({
+        fn: l.ignore(),
+        namedArgs: {
+            data: l.passthrough(),
+            columns: l.optional(l.vector(l.call({
+                fn: l.ignore(),
+                namedArgs: { values: l.passthrough() },
+                unnamedArgs: [],
+            }))),
+        },
+        unnamedArgs: [],
+    }), 'dont-reparse')
+}
+
+/**
+ * The unit of the data displayed by a map, when it can be inferred from the map's data argument.
+ */
+export function deriveMapUnit(uss: MapUSS, typeEnvironment: TypeEnvironment): InferredUnit {
+    return inferUnitOfArgument(uss, typeEnvironment, parsed => parsed.namedArgs.data)
+}
+
+/**
+ * The unit of a table column, when it can be inferred from the column's values argument.
+ */
+export function deriveTableColumnUnit(uss: MapUSS, typeEnvironment: TypeEnvironment, columnIndex: number): InferredUnit {
+    return inferUnitOfArgument(uss, typeEnvironment, parsed => parsed.namedArgs.columns?.[columnIndex]?.namedArgs.values)
+}

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -33,6 +33,14 @@ export function separateNumber(number: string): string {
 }
 
 /**
+ * Removes trailing zeros after a decimal point, e.g., 10.00 -> 10 and 7.50 -> 7.5.
+ */
+export function trimTrailingZeros(value: string): string {
+    if (!value.includes('.')) return value
+    return value.replace(/\.?0+$/g, '')
+}
+
+/**
  * Formats a number to the specified number of significant figures (default 3) without scientific notation.
  */
 export function formatToSignificantFigures(value: number, sigFigs: number = 3): string {

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,4 +1,4 @@
-import { formatToSignificantFigures, separateNumber } from './text'
+import { formatToSignificantFigures, separateNumber, trimTrailingZeros } from './text'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
@@ -140,12 +140,46 @@ export function unitTypeToUnit(unitType: UnitType): Unit {
     return presentation === undefined ? { dimensions, multiplier } : { dimensions, multiplier, presentation }
 }
 
+export const dimensionless: Unit = { dimensions: {}, multiplier: 1 }
+
 export function renderDimensions(dimensions: Dimensions): string {
     return Object.entries(dimensions)
         .filter(([, exponent]) => exponent !== 0)
         .sort(([a], [b]) => a < b ? -1 : 1)
         .map(([base, exponent]) => `${base}^${exponent}`)
         .join(' ')
+}
+
+export function sameDimensions(left: Dimensions, right: Dimensions): boolean {
+    return renderDimensions(left) === renderDimensions(right)
+}
+
+/**
+ * The unit of `left * right` (or of `left / right` when rightExponent is -1).
+ */
+export function combineUnits(left: Unit, right: Unit, rightExponent: 1 | -1): Unit {
+    const dimensions = { ...left.dimensions }
+    for (const [base, exponent] of Object.entries(right.dimensions)) {
+        dimensions[base] = (dimensions[base] ?? 0) + exponent * rightExponent
+    }
+    return normalizeUnit({
+        dimensions,
+        multiplier: rightExponent === 1 ? left.multiplier * right.multiplier : left.multiplier / right.multiplier,
+    })
+}
+
+export function powerUnit(unit: Unit, exponent: number): Unit {
+    return normalizeUnit({
+        dimensions: Object.fromEntries(Object.entries(unit.dimensions).map(([base, e]) => [base, e * exponent])),
+        multiplier: Math.pow(unit.multiplier, exponent),
+    })
+}
+
+function normalizeUnit(unit: Unit): Unit {
+    return {
+        ...unit,
+        dimensions: Object.fromEntries(Object.entries(unit.dimensions).filter(([, exponent]) => exponent !== 0)),
+    }
 }
 
 /**
@@ -162,7 +196,8 @@ interface DisplayUnit {
     signed?: boolean
     /**
      * Whether this is a magnitude prefix on the unit below it, such as thousands, rather than a
-     * unit in its own right.
+     * unit in its own right. Tiers abbreviate large numbers, so they are skipped where the number
+     * is written out in full anyway.
      */
     tier?: boolean
     /** Whether groups of three digits are separated. Defaults to true. */
@@ -171,11 +206,11 @@ interface DisplayUnit {
     attached?: boolean
     /**
      * Decimal places: a fixed count, 'sigFigs' for 3 significant figures, 'precision' for 3
-     * significant figures of a number that is at least 1, 'hoursMinutes' for a duration written
-     * as h:mm, or a number of significant digits before the decimal point counts against the
-     * places shown.
+     * significant figures of a number that is at least 1, 'compact' for 3 significant figures
+     * without trailing zeros, 'hoursMinutes' for a duration written as h:mm, or a number of
+     * significant digits before the decimal point counts against the places shown.
      */
-    decimals: number | 'sigFigs' | 'precision' | 'hoursMinutes' | { significantDigits: number }
+    decimals: number | 'sigFigs' | 'precision' | 'compact' | 'hoursMinutes' | { significantDigits: number }
     /**
      * The smallest value (in base units) displayed in this unit. Defaults to just below the
      * multiplier, i.e., the unit is used once the displayed number reaches 1.
@@ -219,8 +254,12 @@ const displayUnits: Record<string, DisplayUnit[] | undefined> = {
         { multiplier: 1e-6, name: '/\u00a0km^2', decimals: { significantDigits: 2 }, system: 'metric' },
         { multiplier: 1 / squareMeterPerSquareMile, name: '/\u00a0mi^2', decimals: { significantDigits: 2 }, system: 'imperial' },
     ],
-    // durations are written as h:mm, dropping the hours when there are none
-    'time^1': [{ multiplier: 60 * 60, name: '', decimals: 'hoursMinutes' }],
+    // durations up to a day are written as h:mm, dropping the hours when there are none
+    'time^1': [
+        { multiplier: 60 * 60, name: '', decimals: 'hoursMinutes' },
+        { multiplier: 24 * 60 * 60, name: 'days', decimals: 'compact' },
+        { multiplier: secondsPerYear, name: 'years', decimals: 'compact' },
+    ],
     'length^1 time^-1': [
         { multiplier: 0.01 / secondsPerYear, name: 'cm/yr', decimals: 1, separators: false, system: 'metric' },
         { multiplier: 0.0254 / secondsPerYear, name: 'in/yr', decimals: 1, separators: false, system: 'imperial' },
@@ -318,6 +357,9 @@ function formatQuantity(value: number, displayUnit: { decimals: DisplayUnit['dec
     else if (decimals === 'precision') {
         formatted = value.toPrecision(3)
     }
+    else if (decimals === 'compact') {
+        formatted = trimTrailingZeros(formatToSignificantFigures(value, 3))
+    }
     else if (decimals === 'hoursMinutes') {
         const sign = value < 0 ? '-' : ''
         const totalMinutes = Math.round(Math.abs(value) * 60)
@@ -334,13 +376,16 @@ function formatQuantity(value: number, displayUnit: { decimals: DisplayUnit['dec
     return displayUnit.separators === false ? formatted : separateDigits(formatted)
 }
 
-function candidateDisplayUnits(unit: Unit, useImperial: boolean): DisplayUnit[] {
+function candidateDisplayUnits(unit: Unit, useImperial: boolean, includeTiers: boolean): DisplayUnit[] {
     const candidates = unit.presentation !== undefined
         ? presentationDisplayUnits[unit.presentation]
         : displayUnitsForStoredUnit[`${renderDimensions(unit.dimensions)}@${unit.multiplier}`]
         ?? displayUnits[renderDimensions(unit.dimensions)]
         ?? []
-    return candidates.filter(candidate => candidate.system !== (useImperial ? 'metric' : 'imperial'))
+    return candidates.filter(candidate =>
+        candidate.system !== (useImperial ? 'metric' : 'imperial')
+        && (includeTiers || candidate.tier !== true),
+    )
 }
 
 function prefixOf(displayUnit: DisplayUnit, value: number): string {
@@ -365,21 +410,33 @@ function selectDisplayUnit(valueInBaseUnits: number, candidates: DisplayUnit[]):
  * by to get the displayed number. Quantities with no display units are displayed in base units,
  * e.g., person·m^2.
  */
-export function displayUnitFor(value: number, unit: Unit, useImperial: boolean): { scale: number, name: string, prefix: string, attached: boolean } {
-    const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial))
+export function displayUnitFor(
+    value: number,
+    unit: Unit,
+    useImperial: boolean,
+    { includeTiers = true }: { includeTiers?: boolean } = {},
+): { scale: number, name: string, prefix: string, attached: boolean, custom: boolean } {
+    const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial, includeTiers))
     if (displayUnit === undefined) {
-        return { scale: unit.multiplier, name: nameOfDimensions(unit.dimensions), prefix: '', attached: false }
+        return { scale: unit.multiplier, name: nameOfDimensions(unit.dimensions), prefix: '', attached: false, custom: false }
     }
     return {
         scale: unit.multiplier / displayUnit.multiplier,
         name: displayUnit.name,
         prefix: prefixOf(displayUnit, value),
         attached: displayUnit.attached ?? /^[%/]/.test(displayUnit.name),
+        // the number cannot be written on its own, so callers must use displayQuantity
+        custom: displayUnit.decimals === 'hoursMinutes',
     }
 }
 
-export function displayQuantity(value: number, unit: Unit, useImperial: boolean): { value: string, unit: string } {
-    const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial))
+export function displayQuantity(
+    value: number,
+    unit: Unit,
+    useImperial: boolean,
+    { includeTiers = true }: { includeTiers?: boolean } = {},
+): { value: string, unit: string } {
+    const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial, includeTiers))
     if (displayUnit === undefined) {
         return {
             value: formatQuantity(value * unit.multiplier, { decimals: 'sigFigs' }),

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,3 +1,5 @@
+import { formatToSignificantFigures, separateNumber } from './text'
+
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
     | 'contaminantLevel' | 'number' | 'usd' | 'minutes'
@@ -42,6 +44,358 @@ export const allUnitTypes = [
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- just to check that all unit types are covered
 function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
+}
+
+/**
+ * The exponent of each base dimension, e.g., a density is { person: 1, length: -2 }.
+ * Dimensionless is {}.
+ */
+export type Dimensions = Record<string, number>
+
+/**
+ * The unit a quantity is measured in: its dimensions, and the multiplier that converts a
+ * stored value into base units (person, meter, second, dollar, gram, fatality, degree
+ * fahrenheit). E.g., a density is stored per square kilometer, so its multiplier is 1e-6.
+ */
+export interface Unit {
+    dimensions: Dimensions
+    multiplier: number
+    /**
+     * Set for quantities that are displayed as something other than a scaled number, such as
+     * percentages and election margins. Only preserved by operations that keep the quantity the
+     * same kind of thing, i.e., addition and subtraction.
+     */
+    presentation?: PresentationUnitType
+}
+
+const presentationUnitTypes = [
+    'percentage',
+    'percentageChange',
+    'democraticMargin',
+    'leftMargin',
+    'partyPctBlue',
+    'partyPctRed',
+    'partyPctOrange',
+    'partyPctTeal',
+    'partyPctGreen',
+    'partyPctPurple',
+    'partyChangeBlue',
+    'partyChangeRed',
+    'partyChangeOrange',
+    'partyChangeTeal',
+    'partyChangeGreen',
+    'partyChangePurple',
+    'temperature',
+] as const satisfies readonly UnitType[]
+
+export type PresentationUnitType = typeof presentationUnitTypes[number]
+
+function presentationOf(unitType: UnitType): PresentationUnitType | undefined {
+    return (presentationUnitTypes as readonly UnitType[]).includes(unitType) ? unitType as PresentationUnitType : undefined
+}
+
+const secondsPerYear = 365.25 * 24 * 60 * 60
+const meterPerMile = 1609.34
+const meterPerFoot = 1 / 3.28084
+const squareMeterPerSquareMile = meterPerMile * meterPerMile
+const squareMeterPerAcre = squareMeterPerSquareMile / 640
+
+const dimensionsAndMultiplier: Record<UnitType, { dimensions: Dimensions, multiplier: number }> = {
+    percentage: { dimensions: {}, multiplier: 1 },
+    percentageChange: { dimensions: {}, multiplier: 1 },
+    democraticMargin: { dimensions: {}, multiplier: 1 },
+    leftMargin: { dimensions: {}, multiplier: 1 },
+    partyPctBlue: { dimensions: {}, multiplier: 1 },
+    partyPctRed: { dimensions: {}, multiplier: 1 },
+    partyPctOrange: { dimensions: {}, multiplier: 1 },
+    partyPctTeal: { dimensions: {}, multiplier: 1 },
+    partyPctGreen: { dimensions: {}, multiplier: 1 },
+    partyPctPurple: { dimensions: {}, multiplier: 1 },
+    partyChangeBlue: { dimensions: {}, multiplier: 1 },
+    partyChangeRed: { dimensions: {}, multiplier: 1 },
+    partyChangeOrange: { dimensions: {}, multiplier: 1 },
+    partyChangeTeal: { dimensions: {}, multiplier: 1 },
+    partyChangeGreen: { dimensions: {}, multiplier: 1 },
+    partyChangePurple: { dimensions: {}, multiplier: 1 },
+    number: { dimensions: {}, multiplier: 1 },
+    population: { dimensions: { person: 1 }, multiplier: 1 },
+    fatalities: { dimensions: { fatality: 1 }, multiplier: 1 },
+    fatalitiesPerCapita: { dimensions: { fatality: 1, person: -1 }, multiplier: 1 },
+    density: { dimensions: { person: 1, length: -2 }, multiplier: 1e-6 },
+    area: { dimensions: { length: 2 }, multiplier: 1e6 },
+    distanceInKm: { dimensions: { length: 1 }, multiplier: 1e3 },
+    distanceInM: { dimensions: { length: 1 }, multiplier: 1 },
+    // temperature is affine rather than scalable, so it is only ever displayed via its presentation
+    temperature: { dimensions: { temperature: 1 }, multiplier: 1 },
+    time: { dimensions: { time: 1 }, multiplier: 60 * 60 },
+    minutes: { dimensions: { time: 1 }, multiplier: 60 },
+    distancePerYear: { dimensions: { length: 1, time: -1 }, multiplier: 1 / secondsPerYear },
+    contaminantLevel: { dimensions: { mass: 1, length: -3 }, multiplier: 1e-6 },
+    usd: { dimensions: { money: 1 }, multiplier: 1 },
+}
+
+export function unitTypeToUnit(unitType: UnitType): Unit {
+    const presentation = presentationOf(unitType)
+    const { dimensions, multiplier } = dimensionsAndMultiplier[unitType]
+    return presentation === undefined ? { dimensions, multiplier } : { dimensions, multiplier, presentation }
+}
+
+export function renderDimensions(dimensions: Dimensions): string {
+    return Object.entries(dimensions)
+        .filter(([, exponent]) => exponent !== 0)
+        .sort(([a], [b]) => a < b ? -1 : 1)
+        .map(([base, exponent]) => `${base}^${exponent}`)
+        .join(' ')
+}
+
+/**
+ * A unit a quantity can be displayed in. `multiplier` is its size in base units, so a value in
+ * base units is divided by it to get the displayed number. `name` may contain `^n`, which is
+ * displayed as a superscript.
+ */
+interface DisplayUnit {
+    multiplier: number
+    name: string
+    /** Rendered immediately before the number, e.g., a dollar sign */
+    prefix?: string
+    /** Whether non-negative values are rendered with a leading plus sign */
+    signed?: boolean
+    /**
+     * Whether this is a magnitude prefix on the unit below it, such as thousands, rather than a
+     * unit in its own right.
+     */
+    tier?: boolean
+    /** Whether groups of three digits are separated. Defaults to true. */
+    separators?: boolean
+    /** Whether the name is written directly after the number, rather than after a space */
+    attached?: boolean
+    /**
+     * Decimal places: a fixed count, 'sigFigs' for 3 significant figures, 'precision' for 3
+     * significant figures of a number that is at least 1, 'hoursMinutes' for a duration written
+     * as h:mm, or a number of significant digits before the decimal point counts against the
+     * places shown.
+     */
+    decimals: number | 'sigFigs' | 'precision' | 'hoursMinutes' | { significantDigits: number }
+    /**
+     * The smallest value (in base units) displayed in this unit. Defaults to just below the
+     * multiplier, i.e., the unit is used once the displayed number reaches 1.
+     */
+    threshold?: number
+    system?: 'metric' | 'imperial'
+}
+
+/**
+ * Abbreviations for large numbers, which each unit below either uses or writes out in full.
+ */
+function magnitudeTiers(prefix: string | undefined, thousandsThreshold: number): DisplayUnit[] {
+    return [
+        { multiplier: 1e3, name: 'k', prefix, decimals: 'precision', threshold: thousandsThreshold, tier: true, attached: true },
+        { multiplier: 1e6, name: 'm', prefix, decimals: 'precision', threshold: 999.5e3, tier: true, attached: true },
+        { multiplier: 1e9, name: 'B', prefix, decimals: 'precision', threshold: 999.5e6, tier: true, attached: true },
+    ]
+}
+
+/**
+ * The units each kind of quantity can be displayed in, smallest first. The largest one the value
+ * reaches is the one used, so 600 minutes is displayed as 10 hours.
+ */
+const displayUnits: Record<string, DisplayUnit[] | undefined> = {
+    '': [{ multiplier: 1, name: '', decimals: 'sigFigs', separators: false }],
+    'person^1': [{ multiplier: 1, name: '', decimals: 0 }, ...magnitudeTiers(undefined, 1e4)],
+    'money^1': [{ multiplier: 1, name: '', prefix: '$', decimals: 0 }, ...magnitudeTiers('$', 1e3)],
+    'length^1': [
+        { multiplier: 1, name: 'm', decimals: 0, system: 'metric' },
+        { multiplier: 1e3, name: 'km', decimals: 2, system: 'metric' },
+        { multiplier: meterPerFoot, name: 'ft', decimals: 0, system: 'imperial' },
+        { multiplier: meterPerMile, name: 'mi', decimals: 2, system: 'imperial' },
+    ],
+    'length^2': [
+        { multiplier: 1, name: 'm^2', decimals: { significantDigits: 3 }, system: 'metric' },
+        { multiplier: 1e6, name: 'km^2', decimals: { significantDigits: 3 }, threshold: 1e4, system: 'metric' },
+        { multiplier: squareMeterPerAcre, name: 'acres', decimals: { significantDigits: 3 }, system: 'imperial' },
+        { multiplier: squareMeterPerSquareMile, name: 'mi^2', decimals: { significantDigits: 3 }, system: 'imperial' },
+    ],
+    'length^-2 person^1': [
+        { multiplier: 1e-6, name: '/\u00a0km^2', decimals: { significantDigits: 2 }, system: 'metric' },
+        { multiplier: 1 / squareMeterPerSquareMile, name: '/\u00a0mi^2', decimals: { significantDigits: 2 }, system: 'imperial' },
+    ],
+    // durations are written as h:mm, dropping the hours when there are none
+    'time^1': [{ multiplier: 60 * 60, name: '', decimals: 'hoursMinutes' }],
+    'length^1 time^-1': [
+        { multiplier: 0.01 / secondsPerYear, name: 'cm/yr', decimals: 1, separators: false, system: 'metric' },
+        { multiplier: 0.0254 / secondsPerYear, name: 'in/yr', decimals: 1, separators: false, system: 'imperial' },
+    ],
+    'length^-3 mass^1': [{ multiplier: 1e-6, name: '\u03bcg/m^3', decimals: 2, separators: false }],
+    'fatality^1': [{ multiplier: 1, name: '', decimals: 0 }],
+    'fatality^1 person^-1': [{ multiplier: 1e-5, name: '/100k', decimals: 2, separators: false }],
+}
+
+/**
+ * Quantities that are displayed in the unit they are stored in, rather than in whichever unit
+ * fits their magnitude: an elevation stays in meters, and a distance stays in kilometers, however
+ * large or small it is. Keyed by dimensions and stored multiplier.
+ */
+const displayUnitsForStoredUnit: Record<string, DisplayUnit[] | undefined> = {
+    'length^1@1': [
+        { multiplier: 1, name: 'm', decimals: 0, system: 'metric' },
+        { multiplier: meterPerFoot, name: 'ft', decimals: 0, system: 'imperial' },
+    ],
+    'length^1@1000': [
+        { multiplier: 1e3, name: 'km', decimals: 2, separators: false, system: 'metric' },
+        { multiplier: meterPerMile, name: 'mi', decimals: 2, separators: false, system: 'imperial' },
+    ],
+}
+
+const percentDisplay: DisplayUnit[] = [{ multiplier: 0.01, name: '%', decimals: 2, separators: false }]
+const percentChangeDisplay: DisplayUnit[] = [{ multiplier: 0.01, name: '%', decimals: 2, separators: false, signed: true }]
+
+/**
+ * How each specially displayed quantity is rendered as a number. The ones that are rendered with
+ * party colors are overridden by the components that can render them.
+ */
+const presentationDisplayUnits: Record<PresentationUnitType, DisplayUnit[]> = {
+    percentage: percentDisplay,
+    democraticMargin: percentDisplay,
+    leftMargin: percentDisplay,
+    partyPctBlue: percentDisplay,
+    partyPctRed: percentDisplay,
+    partyPctOrange: percentDisplay,
+    partyPctTeal: percentDisplay,
+    partyPctGreen: percentDisplay,
+    partyPctPurple: percentDisplay,
+    percentageChange: percentChangeDisplay,
+    partyChangeBlue: percentChangeDisplay,
+    partyChangeRed: percentChangeDisplay,
+    partyChangeOrange: percentChangeDisplay,
+    partyChangeTeal: percentChangeDisplay,
+    partyChangeGreen: percentChangeDisplay,
+    partyChangePurple: percentChangeDisplay,
+    temperature: [{ multiplier: 1, name: '°F', decimals: 1 }],
+}
+
+/**
+ * The base units themselves, used to name a quantity whose dimensions have no display units.
+ */
+const baseUnitNames: Record<string, string> = {
+    person: 'person',
+    length: 'm',
+    time: 's',
+    money: '$',
+    mass: 'g',
+    fatality: 'fatalities',
+    temperature: '°F',
+}
+
+function nameOfDimensions(dimensions: Dimensions): string {
+    return Object.entries(dimensions)
+        .sort(([a, aExponent], [b, bExponent]) => aExponent !== bExponent ? bExponent - aExponent : (a < b ? -1 : 1))
+        .map(([base, exponent]) => `${baseUnitNames[base] ?? base}${exponent === 1 ? '' : `^${exponent}`}`)
+        .join('·')
+}
+
+// separateNumber groups digits from the left, so it needs the integer part on its own
+function separateDigits(value: string): string {
+    const sign = value.startsWith('-') ? '-' : ''
+    const [integerPart, ...rest] = value.slice(sign.length).split('.')
+    return sign + [separateNumber(integerPart), ...rest].join('.')
+}
+
+// e.g., with 3 significant digits, 123.4 has no decimal places and 1.234 has two
+function decimalPlacesFor(value: number, significantDigits: number): number {
+    const digitsBeforePoint = Math.max(0, Math.ceil(Math.log10(Math.abs(value))))
+    return Math.max(0, significantDigits - digitsBeforePoint)
+}
+
+function formatQuantity(value: number, displayUnit: { decimals: DisplayUnit['decimals'], separators?: boolean }): string {
+    if (!isFinite(value)) {
+        return value.toString()
+    }
+    const decimals = displayUnit.decimals
+    let formatted: string
+    if (decimals === 'sigFigs') {
+        formatted = formatToSignificantFigures(value, 3)
+    }
+    else if (decimals === 'precision') {
+        formatted = value.toPrecision(3)
+    }
+    else if (decimals === 'hoursMinutes') {
+        const sign = value < 0 ? '-' : ''
+        const totalMinutes = Math.round(Math.abs(value) * 60)
+        const hours = Math.floor(totalMinutes / 60)
+        const minutes = totalMinutes % 60
+        return hours > 0 ? `${sign}${hours}:${minutes.toString().padStart(2, '0')}` : `${sign}${minutes}`
+    }
+    else if (typeof decimals === 'object') {
+        formatted = value.toFixed(decimalPlacesFor(value, decimals.significantDigits))
+    }
+    else {
+        formatted = value.toFixed(decimals)
+    }
+    return displayUnit.separators === false ? formatted : separateDigits(formatted)
+}
+
+function candidateDisplayUnits(unit: Unit, useImperial: boolean): DisplayUnit[] {
+    const candidates = unit.presentation !== undefined
+        ? presentationDisplayUnits[unit.presentation]
+        : displayUnitsForStoredUnit[`${renderDimensions(unit.dimensions)}@${unit.multiplier}`]
+        ?? displayUnits[renderDimensions(unit.dimensions)]
+        ?? []
+    return candidates.filter(candidate => candidate.system !== (useImperial ? 'metric' : 'imperial'))
+}
+
+function prefixOf(displayUnit: DisplayUnit, value: number): string {
+    const prefix = displayUnit.prefix ?? ''
+    return displayUnit.signed === true && value >= 0 ? `+${prefix}` : prefix
+}
+
+function selectDisplayUnit(valueInBaseUnits: number, candidates: DisplayUnit[]): DisplayUnit | undefined {
+    let selected: DisplayUnit | undefined = candidates[0]
+    for (const candidate of candidates) {
+        // 0.9995 rather than 1 so that a value that rounds up to the next unit is displayed in it
+        if (Math.abs(valueInBaseUnits) >= (candidate.threshold ?? candidate.multiplier * 0.9995)) {
+            selected = candidate
+        }
+    }
+    return selected
+}
+
+/**
+ * The unit a value is displayed in: the largest of its unit's display units that it reaches, so
+ * a value of 600 in minutes is displayed in hours. `scale` is what the stored value is multiplied
+ * by to get the displayed number. Quantities with no display units are displayed in base units,
+ * e.g., person·m^2.
+ */
+export function displayUnitFor(value: number, unit: Unit, useImperial: boolean): { scale: number, name: string, prefix: string, attached: boolean } {
+    const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial))
+    if (displayUnit === undefined) {
+        return { scale: unit.multiplier, name: nameOfDimensions(unit.dimensions), prefix: '', attached: false }
+    }
+    return {
+        scale: unit.multiplier / displayUnit.multiplier,
+        name: displayUnit.name,
+        prefix: prefixOf(displayUnit, value),
+        attached: displayUnit.attached ?? /^[%/]/.test(displayUnit.name),
+    }
+}
+
+export function displayQuantity(value: number, unit: Unit, useImperial: boolean): { value: string, unit: string } {
+    const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial))
+    if (displayUnit === undefined) {
+        return {
+            value: formatQuantity(value * unit.multiplier, { decimals: 'sigFigs' }),
+            unit: nameOfDimensions(unit.dimensions),
+        }
+    }
+    // divided rather than scaled by the reciprocal, which rounds differently at tier boundaries
+    const displayed = value * unit.multiplier / displayUnit.multiplier
+    return { value: `${prefixOf(displayUnit, value)}${formatQuantity(displayed, displayUnit)}`, unit: displayUnit.name }
+}
+
+/**
+ * A unit name as it is written after a number, e.g., " hours" but "%".
+ */
+export function unitSuffix(name: string, attached: boolean): string {
+    return name === '' || attached ? name : ` ${name}`
 }
 
 function fahrenheitToCelsius(value: number): number {

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,3 +1,5 @@
+import { HumanReadableElement, HumanReadableName } from './human-readable-name'
+import { hre } from './human-readable-template'
 import { formatToSignificantFigures, separateNumber } from './text'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
@@ -150,12 +152,11 @@ export function renderDimensions(dimensions: Dimensions): string {
 
 /**
  * A unit a quantity can be displayed in. `multiplier` is its size in base units, so a value in
- * base units is divided by it to get the displayed number. `name` may contain `^n`, which is
- * displayed as a superscript.
+ * base units is divided by it to get the displayed number.
  */
 interface DisplayUnit {
     multiplier: number
-    name: string
+    name: HumanReadableName
     /** Rendered immediately before the number, e.g., a dollar sign */
     prefix?: string
     /** Whether non-negative values are rendered with a leading plus sign */
@@ -210,14 +211,14 @@ const displayUnits: Record<string, DisplayUnit[] | undefined> = {
         { multiplier: meterPerMile, name: 'mi', decimals: 2, system: 'imperial' },
     ],
     'length^2': [
-        { multiplier: 1, name: 'm^2', decimals: { significantDigits: 3 }, system: 'metric' },
-        { multiplier: 1e6, name: 'km^2', decimals: { significantDigits: 3 }, threshold: 1e4, system: 'metric' },
+        { multiplier: 1, name: hre`m^{2}`, decimals: { significantDigits: 3 }, system: 'metric' },
+        { multiplier: 1e6, name: hre`km^{2}`, decimals: { significantDigits: 3 }, threshold: 1e4, system: 'metric' },
         { multiplier: squareMeterPerAcre, name: 'acres', decimals: { significantDigits: 3 }, system: 'imperial' },
-        { multiplier: squareMeterPerSquareMile, name: 'mi^2', decimals: { significantDigits: 3 }, system: 'imperial' },
+        { multiplier: squareMeterPerSquareMile, name: hre`mi^{2}`, decimals: { significantDigits: 3 }, system: 'imperial' },
     ],
     'length^-2 person^1': [
-        { multiplier: 1e-6, name: '/\u00a0km^2', decimals: { significantDigits: 2 }, system: 'metric' },
-        { multiplier: 1 / squareMeterPerSquareMile, name: '/\u00a0mi^2', decimals: { significantDigits: 2 }, system: 'imperial' },
+        { multiplier: 1e-6, name: hre`/\u00a0km^{2}`, decimals: { significantDigits: 2 }, attached: true, system: 'metric' },
+        { multiplier: 1 / squareMeterPerSquareMile, name: hre`/\u00a0mi^{2}`, decimals: { significantDigits: 2 }, attached: true, system: 'imperial' },
     ],
     // durations are written as h:mm, dropping the hours when there are none
     'time^1': [{ multiplier: 60 * 60, name: '', decimals: 'hoursMinutes' }],
@@ -225,9 +226,9 @@ const displayUnits: Record<string, DisplayUnit[] | undefined> = {
         { multiplier: 0.01 / secondsPerYear, name: 'cm/yr', decimals: 1, separators: false, system: 'metric' },
         { multiplier: 0.0254 / secondsPerYear, name: 'in/yr', decimals: 1, separators: false, system: 'imperial' },
     ],
-    'length^-3 mass^1': [{ multiplier: 1e-6, name: '\u03bcg/m^3', decimals: 2, separators: false }],
+    'length^-3 mass^1': [{ multiplier: 1e-6, name: hre`\u03bcg/m^{3}`, decimals: 2, separators: false }],
     'fatality^1': [{ multiplier: 1, name: '', decimals: 0 }],
-    'fatality^1 person^-1': [{ multiplier: 1e-5, name: '/100k', decimals: 2, separators: false }],
+    'fatality^1 person^-1': [{ multiplier: 1e-5, name: '/100k', decimals: 2, separators: false, attached: true }],
 }
 
 /**
@@ -246,8 +247,8 @@ const displayUnitsForStoredUnit: Record<string, DisplayUnit[] | undefined> = {
     ],
 }
 
-const percentDisplay: DisplayUnit[] = [{ multiplier: 0.01, name: '%', decimals: 2, separators: false }]
-const percentChangeDisplay: DisplayUnit[] = [{ multiplier: 0.01, name: '%', decimals: 2, separators: false, signed: true }]
+const percentDisplay: DisplayUnit[] = [{ multiplier: 0.01, name: '%', decimals: 2, separators: false, attached: true }]
+const percentChangeDisplay: DisplayUnit[] = [{ multiplier: 0.01, name: '%', decimals: 2, separators: false, signed: true, attached: true }]
 
 /**
  * How each specially displayed quantity is rendered as a number. The ones that are rendered with
@@ -286,11 +287,14 @@ const baseUnitNames: Record<string, string> = {
     temperature: '°F',
 }
 
-function nameOfDimensions(dimensions: Dimensions): string {
+function nameOfDimensions(dimensions: Dimensions): HumanReadableName {
     return Object.entries(dimensions)
         .sort(([a, aExponent], [b, bExponent]) => aExponent !== bExponent ? bExponent - aExponent : (a < b ? -1 : 1))
-        .map(([base, exponent]) => `${baseUnitNames[base] ?? base}${exponent === 1 ? '' : `^${exponent}`}`)
-        .join('·')
+        .flatMap(([base, exponent], index): HumanReadableElement[] => [
+            ...index === 0 ? [] : [{ type: 'atom', value: '·' } satisfies HumanReadableElement],
+            { type: 'atom', value: baseUnitNames[base] ?? base },
+            ...exponent === 1 ? [] : [{ type: 'superscript', value: [{ type: 'atom', value: exponent.toString() }] } satisfies HumanReadableElement],
+        ])
 }
 
 // separateNumber groups digits from the left, so it needs the integer part on its own
@@ -365,7 +369,7 @@ function selectDisplayUnit(valueInBaseUnits: number, candidates: DisplayUnit[]):
  * by to get the displayed number. Quantities with no display units are displayed in base units,
  * e.g., person·m^2.
  */
-export function displayUnitFor(value: number, unit: Unit, useImperial: boolean): { scale: number, name: string, prefix: string, attached: boolean } {
+export function displayUnitFor(value: number, unit: Unit, useImperial: boolean): { scale: number, name: HumanReadableName, prefix: string, attached: boolean } {
     const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial))
     if (displayUnit === undefined) {
         return { scale: unit.multiplier, name: nameOfDimensions(unit.dimensions), prefix: '', attached: false }
@@ -374,11 +378,11 @@ export function displayUnitFor(value: number, unit: Unit, useImperial: boolean):
         scale: unit.multiplier / displayUnit.multiplier,
         name: displayUnit.name,
         prefix: prefixOf(displayUnit, value),
-        attached: displayUnit.attached ?? /^[%/]/.test(displayUnit.name),
+        attached: displayUnit.attached ?? false,
     }
 }
 
-export function displayQuantity(value: number, unit: Unit, useImperial: boolean): { value: string, unit: string } {
+export function displayQuantity(value: number, unit: Unit, useImperial: boolean): { value: string, unit: HumanReadableName } {
     const displayUnit = selectDisplayUnit(value * unit.multiplier, candidateDisplayUnits(unit, useImperial))
     if (displayUnit === undefined) {
         return {

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -239,6 +239,13 @@ const displayUnits: Record<string, DisplayUnit[] | undefined> = {
     '': [{ multiplier: 1, name: '', decimals: 'sigFigs', separators: false }],
     'person^1': [{ multiplier: 1, name: '', decimals: 0 }, ...magnitudeTiers(undefined, 1e4)],
     'money^1': [{ multiplier: 1, name: '', prefix: '$', decimals: 0 }, ...magnitudeTiers('$', 1e3)],
+    // a computed length is not stored in any particular unit, so it is displayed in whichever fits
+    'length^1': [
+        { multiplier: 1, name: 'm', decimals: { significantDigits: 3 }, system: 'metric' },
+        { multiplier: 1e3, name: 'km', decimals: { significantDigits: 3 }, system: 'metric' },
+        { multiplier: meterPerFoot, name: 'ft', decimals: { significantDigits: 3 }, system: 'imperial' },
+        { multiplier: meterPerMile, name: 'mi', decimals: { significantDigits: 3 }, system: 'imperial' },
+    ],
     'length^2': [
         { multiplier: 1, name: hre`m^{2}`, decimals: { significantDigits: 3 }, system: 'metric' },
         { multiplier: 1e6, name: hre`km^{2}`, decimals: { significantDigits: 3 }, threshold: 1e4, system: 'metric' },

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -204,12 +204,6 @@ const displayUnits: Record<string, DisplayUnit[] | undefined> = {
     '': [{ multiplier: 1, name: '', decimals: 'sigFigs', separators: false }],
     'person^1': [{ multiplier: 1, name: '', decimals: 0 }, ...magnitudeTiers(undefined, 1e4)],
     'money^1': [{ multiplier: 1, name: '', prefix: '$', decimals: 0 }, ...magnitudeTiers('$', 1e3)],
-    'length^1': [
-        { multiplier: 1, name: 'm', decimals: 0, system: 'metric' },
-        { multiplier: 1e3, name: 'km', decimals: 2, system: 'metric' },
-        { multiplier: meterPerFoot, name: 'ft', decimals: 0, system: 'imperial' },
-        { multiplier: meterPerMile, name: 'mi', decimals: 2, system: 'imperial' },
-    ],
     'length^2': [
         { multiplier: 1, name: hre`m^{2}`, decimals: { significantDigits: 3 }, system: 'metric' },
         { multiplier: 1e6, name: hre`km^{2}`, decimals: { significantDigits: 3 }, threshold: 1e4, system: 'metric' },

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -52,13 +52,15 @@ for (const [value, expected] of [
     })
 }
 
-// Every quantity is displayed in the unit it is stored in, and durations as h:mm
+// Durations are written as h:mm until they outgrow it; everything else is displayed in the unit
+// it is stored in
 for (const [unitType, value, expected] of [
     ['minutes', 34, '34'],
     ['minutes', 90, '1:30'],
     ['minutes', 600, '10:00'],
     ['minutes', 1234, '20:34'],
-    ['minutes', 5000, '83:20'],
+    ['minutes', 5000, '3.47 days'],
+    ['minutes', 1e6, '1.9 years'],
     ['time', 7.5, '7:30'],
     ['time', 0.5, '30'],
     ['distanceInM', 543, '543 m'],

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -4,7 +4,8 @@ import assert from 'assert/strict'
 import test from 'node:test'
 
 import { getUnit, getUnitDisplay } from '../src/components/unit-display'
-import { allUnitTypes, displayQuantity, displayUnitFor, unitSuffix, unitTypeToUnit, UnitType } from '../src/utils/unit'
+import { reifyString } from '../src/utils/human-readable-name'
+import { allUnitTypes, displayQuantity, displayUnitFor, unitTypeToUnit, UnitType } from '../src/utils/unit'
 
 // Flatten a React element tree into its text content.
 function textOf(node: unknown): string {
@@ -18,7 +19,8 @@ function textOf(node: unknown): string {
 function renderValue(unitType: UnitType, value: number, useImperial = false): string {
     const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value, useImperial)
     const { attached } = displayUnitFor(value, unitTypeToUnit(unitType), useImperial)
-    return `${textOf(valueEl)}${unitSuffix(textOf(unitEl), attached)}`.trim()
+    const unit = textOf(unitEl)
+    return `${textOf(valueEl)}${attached ? '' : ' '}${unit}`.trim()
 }
 
 // Regression tests for toPrecision(3) emitting scientific notation at tier boundaries.
@@ -127,10 +129,9 @@ void test('temperature is rendered in the reader\'s temperature unit', () => {
 // Anything without a unit type of its own is displayed in base units
 void test('a quantity with no display units is displayed in base units', () => {
     const personSquareMeters = { dimensions: { person: 1, length: 2 }, multiplier: 1e6 }
-    assert.deepEqual(displayQuantity(1234, personSquareMeters, false), {
-        value: '1\u202f230\u202f000\u202f000',
-        unit: 'm^2·person',
-    })
+    const { value, unit } = displayQuantity(1234, personSquareMeters, false)
+    assert.equal(value, '1\u202f230\u202f000\u202f000')
+    assert.equal(reifyString(unit), 'm^{2}·person')
 })
 
 // Every unit type has to be renderable, or a statistic displays as undefined

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -3,8 +3,8 @@ import './util/localStorage'
 import assert from 'assert/strict'
 import test from 'node:test'
 
-import { getUnitDisplay } from '../src/components/unit-display'
-import { UnitType } from '../src/utils/unit'
+import { getUnit, getUnitDisplay } from '../src/components/unit-display'
+import { allUnitTypes, displayQuantity, displayUnitFor, unitSuffix, unitTypeToUnit, UnitType } from '../src/utils/unit'
 
 // Flatten a React element tree into its text content.
 function textOf(node: unknown): string {
@@ -15,9 +15,10 @@ function textOf(node: unknown): string {
     return textOf((node as { props?: { children?: unknown } }).props?.children)
 }
 
-function renderValue(unitType: UnitType, value: number): string {
-    const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value)
-    return `${textOf(valueEl)}${textOf(unitEl)}`.trim()
+function renderValue(unitType: UnitType, value: number, useImperial = false): string {
+    const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value, useImperial)
+    const { attached } = displayUnitFor(value, unitTypeToUnit(unitType), useImperial)
+    return `${textOf(valueEl)}${unitSuffix(textOf(unitEl), attached)}`.trim()
 }
 
 // Regression tests for toPrecision(3) emitting scientific notation at tier boundaries.
@@ -48,5 +49,112 @@ for (const [value, expected] of [
 ] as const) {
     void test(`usd renders ${value} as ${expected}`, () => {
         assert.equal(renderValue('usd', value), expected)
+    })
+}
+
+// Every quantity is displayed in the unit it is stored in, and durations as h:mm
+for (const [unitType, value, expected] of [
+    ['minutes', 34, '34'],
+    ['minutes', 90, '1:30'],
+    ['minutes', 600, '10:00'],
+    ['minutes', 1234, '20:34'],
+    ['minutes', 5000, '83:20'],
+    ['time', 7.5, '7:30'],
+    ['time', 0.5, '30'],
+    ['distanceInM', 543, '543 m'],
+    ['distanceInM', 1234, '1\u202f234 m'],
+    ['distanceInKm', 3.42, '3.42 km'],
+    ['density', 1234, '1\u202f234/\u00a0km2'],
+    ['area', 0.005, '5\u202f000 m2'],
+    ['area', 12.5, '12.5 km2'],
+    ['usd', 75000, '$75.0k'],
+    ['percentage', 0.125, '12.50%'],
+    ['percentageChange', 0.125, '+12.50%'],
+    ['population', 1234, '1\u202f234'],
+    ['density', 5.67, '5.7/\u00a0km2'],
+    ['area', 0.5, '0.500 km2'],
+    ['fatalities', 1234, '1\u202f234'],
+    ['fatalitiesPerCapita', 1.2e-5, '1.20/100k'],
+    ['contaminantLevel', 8.2, '8.20 \u03bcg/m3'],
+    ['distancePerYear', 1.2, '120.0 cm/yr'],
+    ['number', 1234, '1230'],
+] as const) {
+    void test(`${unitType} renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue(unitType, value), expected)
+    })
+}
+
+for (const [unitType, value, expected] of [
+    ['distanceInKm', 3.42, '2.13 mi'],
+    ['distanceInM', 543, '1\u202f781 ft'],
+    ['area', 12.5, '4.83 mi2'],
+    ['density', 1234, '3\u202f196/\u00a0mi2'],
+    ['area', 0.5, '124 acres'],
+    ['distancePerYear', 1.2, '47.2 in/yr'],
+] as const) {
+    void test(`${unitType} renders ${value} in imperial as ${expected}`, () => {
+        assert.equal(renderValue(unitType, value, true), expected)
+    })
+}
+
+// Values that have to survive being formatted, whatever the unit
+for (const [unitType, value, expected] of [
+    ['population', 0, '0'],
+    ['population', -1234, '-1\u202f234'],
+    ['population', -12345, '-12.3k'],
+    ['population', NaN, 'NaN'],
+    ['density', 0, '0.00/\u00a0km2'],
+    ['density', -5.67, '-5.7/\u00a0km2'],
+    ['percentage', -0.125, '-12.50%'],
+    ['percentageChange', -0.125, '-12.50%'],
+    ['usd', -12345, '$-12.3k'],
+    ['minutes', 0, '0'],
+    ['number', 0, '0'],
+    ['number', Infinity, 'Infinity'],
+] as const) {
+    void test(`${unitType} renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue(unitType, value), expected)
+    })
+}
+
+void test('temperature is rendered in the reader\'s temperature unit', () => {
+    const { value, unit } = getUnitDisplay('temperature').renderValue(50, false, 'celsius')
+    assert.equal(`${textOf(value)} ${textOf(unit)}`, '10.0 °C')
+    const fahrenheit = getUnitDisplay('temperature').renderValue(50, false, 'fahrenheit')
+    assert.equal(`${textOf(fahrenheit.value)} ${textOf(fahrenheit.unit)}`, '50.0 °F')
+})
+
+// Anything without a unit type of its own is displayed in base units
+void test('a quantity with no display units is displayed in base units', () => {
+    const personSquareMeters = { dimensions: { person: 1, length: 2 }, multiplier: 1e6 }
+    assert.deepEqual(displayQuantity(1234, personSquareMeters, false), {
+        value: '1\u202f230\u202f000\u202f000',
+        unit: 'm^2·person',
+    })
+})
+
+// Every unit type has to be renderable, or a statistic displays as undefined
+void test('every unit type renders', () => {
+    for (const unitType of allUnitTypes) {
+        for (const value of [0, 0.005, 1, 1234, 1e9]) {
+            const rendered = renderValue(unitType, value)
+            assert.ok(!rendered.includes('undefined'), `${unitType} rendered ${value} as ${rendered}`)
+            assert.ok(!rendered.includes('NaN'), `${unitType} rendered ${value} as ${rendered}`)
+        }
+        assert.notEqual(textOf(getUnit(unitType)), '', `${unitType} has no documented unit name`)
+    }
+})
+
+// The inequalities on a colorbar point the other way for margins, which display as absolute values
+for (const [unitType, value, inequality, expected] of [
+    ['percentage', 0.5, 'leq', '\u2264'],
+    ['percentage', 0.5, 'geq', '\u2265'],
+    ['democraticMargin', 0.5, 'leq', '\u2264'],
+    ['democraticMargin', -0.5, 'leq', '\u2265'],
+    ['democraticMargin', -0.5, 'geq', '\u2264'],
+    ['leftMargin', -0.5, 'geq', '\u2264'],
+] as const) {
+    void test(`${unitType} renders a ${inequality} at ${value} as ${expected}`, () => {
+        assert.equal(getUnitDisplay(unitType).renderInequality(value, inequality), expected)
     })
 }

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -41,7 +41,7 @@ cMap(data=density_pw_1km_2000 / (density_pw_1km * density_pw_2km), scale=linearS
 testMapLabel(test,
     `condition(ped_cyclist_fatalities_per_capita > 1e-5)
 cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)`,
-    'PW Density (r=1km) where Pedestrian/Cyclist Fatalities Per Capita Per Year > 1x10^{-5}',
+    'PW Density (r=1km) where Pedestrian/Cyclist Fatalities Per Capita Per Year > 1/100k',
 )
 
 // Number formatting, in particular the boundaries where rounding to 3 significant
@@ -90,6 +90,44 @@ testMapLabel(test,
 testMapLabel(test,
     'cMap(data=population + 1234, scale=linearScale(), ramp=rampUridis)',
     'Population + 1 234',
+)
+
+// A bare number compared against a percentage is itself a percentage
+testMapLabel(test,
+    `condition (commute_bike < 0.1)
+cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)`,
+    'PW Density (r=1km) where Commute Bike % < 10%',
+)
+testMapLabel(test,
+    `condition (0.125 <= commute_bike)
+cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)`,
+    'PW Density (r=1km) where 12.5% ≤ Commute Bike %',
+)
+testMapLabel(test,
+    'cMap(data=commute_bike - 0.01, scale=linearScale(), ramp=rampUridis)',
+    'Commute Bike % − 1%',
+)
+// Only operators whose operands are the same kind of quantity get this treatment
+testMapLabel(test,
+    'cMap(data=commute_bike * 0.5, scale=linearScale(), ramp=rampUridis)',
+    'Commute Bike % × 0.5',
+)
+testMapLabel(test,
+    `condition (population > 0.1)
+cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)`,
+    'PW Density (r=1km) where Population > 0.1',
+)
+// A constant is written in whichever unit it is best read in
+testMapLabel(test,
+    `condition (commute_time_median > 600)
+cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)`,
+    'PW Density (r=1km) where Median Commute Time (min) > 10:00',
+)
+// Quantities displayed in the unit they are stored in are written as plain numbers
+testMapLabel(test,
+    `condition (elevation > 1234)
+cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)`,
+    'PW Density (r=1km) where PW Mean Elevation > 1\u202f234',
 )
 
 void test('map label cannot be derived for a raw vector literal', () => {

--- a/react/unit/urban-stats-script-unit-inference.test.ts
+++ b/react/unit/urban-stats-script-unit-inference.test.ts
@@ -1,0 +1,160 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { defaultTypeEnvironment } from '../src/mapper/context'
+import { mapUSSFromString } from '../src/mapper/settings/map-uss'
+import { parse } from '../src/urban-stats-script/parser'
+import { deriveMapUnit, deriveTableColumnUnit, inferUnit, InferredUnit } from '../src/urban-stats-script/unit-inference'
+import { combineUnits, displayQuantity, displayUnitFor, powerUnit, Unit, unitSuffix, unitTypeToUnit } from '../src/utils/unit'
+
+function getTypeEnvironment(): ReturnType<typeof defaultTypeEnvironment> {
+    return defaultTypeEnvironment('USA')
+}
+
+function unitOf(code: string): InferredUnit {
+    const stmts = parse(code)
+    assert.notEqual(stmts.type, 'error', `could not parse ${code}`)
+    return inferUnit(stmts as Exclude<typeof stmts, { type: 'error' }>, getTypeEnvironment())
+}
+
+function testUnit(code: string, expected: InferredUnit): void {
+    void test(`unit of ${code}`, () => {
+        assert.deepEqual(unitOf(code), expected)
+    })
+}
+
+function unit(dimensions: Record<string, number>, multiplier: number, presentation?: Unit['presentation']): Unit {
+    return presentation === undefined ? { dimensions, multiplier } : { dimensions, multiplier, presentation }
+}
+
+const percentage = unit({}, 1, 'percentage')
+const dimensionless = unit({}, 1)
+const density = unit({ person: 1, length: -2 }, 1e-6)
+
+// Leaves: statistic columns carry a unit, everything else is unknown
+testUnit('population', unit({ person: 1 }, 1))
+testUnit('density_pw_1km', density)
+testUnit('commute_bike', percentage)
+testUnit('elevation', unit({ length: 1 }, 1))
+testUnit('commute_time_median', unit({ time: 1 }, 60))
+testUnit('2', undefined)
+testUnit('notAVariable', undefined)
+
+// Dimension arithmetic, including the multipliers: people per square kilometer either way
+testUnit('population / area', density)
+testUnit('density_pw_1km * area', unit({ person: 1 }, 1))
+testUnit('density_pw_1km / density_pw_2km', dimensionless)
+testUnit('population + population_2000', unit({ person: 1 }, 1))
+testUnit('population - area', undefined)
+testUnit('area ** 0.5', unit({ length: 1 }, 1e3))
+testUnit('area ** population', undefined)
+testUnit('-population', unit({ person: 1 }, 1))
+
+// Quantities of the same dimensions but different multipliers cannot be added
+testUnit('hospital_mean_dist + elevation', undefined)
+testUnit('hospital_mean_dist * elevation', unit({ length: 2 }, 1e3))
+
+// A presentation only survives an operation that keeps the quantity the same kind of thing
+testUnit('commute_bike + commute_car', percentage)
+testUnit('commute_bike / commute_car', dimensionless)
+testUnit('commute_bike + pres_2020_margin', percentage)
+testUnit('commute_bike * population', unit({ person: 1 }, 1))
+testUnit('population / commute_bike', unit({ person: 1 }, 1))
+
+// Unknown op anything is that thing
+testUnit('population * 2', unit({ person: 1 }, 1))
+testUnit('2 - population', unit({ person: 1 }, 1))
+testUnit('sqrt(population) * area', unit({ length: 2 }, 1e6))
+
+// Comparisons and logical operations produce booleans, which have no unit
+testUnit('population > 100', undefined)
+testUnit('commute_bike > 0.1 & population > 100', undefined)
+
+// The unit of a script is the unit of the value it evaluates to
+testUnit(`condition (commute_bike < 0.1)
+population / area`, density)
+// Variables assigned in the script are not in the type environment, so their unit is not known
+testUnit(`x = population / area
+x * 2`, undefined)
+
+// Operators that produce booleans, and operands that are not quantities at all
+testUnit('population == population_2000', undefined)
+testUnit('!(population > 100)', undefined)
+testUnit('geoName', undefined)
+testUnit('[1, 2, 3]', undefined)
+testUnit('{ a: population }', undefined)
+testUnit('"a string"', undefined)
+
+// Chains of operators, where an unknown operand does not lose the units of the rest
+testUnit('population / area * 2', density)
+testUnit('(population + 1000) / area', density)
+testUnit('population / (area * 2)', density)
+testUnit('density_pw_1km * area / population', dimensionless)
+testUnit('area ** 2 ** 0.5', unit({ length: 2 }, 1e6))
+
+void test('unit arithmetic keeps the multipliers in step', () => {
+    const area = unitTypeToUnit('area')
+    const population = unitTypeToUnit('population')
+    assert.deepEqual(combineUnits(population, area, -1), unitTypeToUnit('density'))
+    assert.deepEqual(combineUnits(unitTypeToUnit('density'), area, 1), population)
+    assert.deepEqual(powerUnit(area, 0.5), unitTypeToUnit('distanceInKm'))
+    assert.deepEqual(powerUnit(unitTypeToUnit('distanceInKm'), 2), area)
+    assert.deepEqual(combineUnits(area, area, -1), unit({}, 1))
+})
+
+void test('a unit that is not stored in base units is displayed correctly either way', () => {
+    // an area is stored in square kilometers, so a computed one must be too
+    const computed = combineUnits(unitTypeToUnit('distanceInKm'), unitTypeToUnit('distanceInKm'), 1)
+    assert.deepEqual(displayQuantity(12.5, computed, false), displayQuantity(12.5, unitTypeToUnit('area'), false))
+})
+
+let mapUnitIdx = 0
+
+function testMapUnit(code: string, expected: string | undefined): void {
+    void test(`map unit ${++mapUnitIdx}`, () => {
+        const mapUnit = deriveMapUnit(mapUSSFromString(code), getTypeEnvironment())
+        if (expected === undefined) {
+            assert.equal(mapUnit, undefined)
+            return
+        }
+        assert.ok(mapUnit)
+        const rendered = displayQuantity(1234, mapUnit, false)
+        const { attached } = displayUnitFor(1234, mapUnit, false)
+        assert.equal(`${rendered.value}${unitSuffix(rendered.unit, attached)}`, expected)
+    })
+}
+
+testMapUnit('cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)', '1\u202f234/\u00a0km^2')
+testMapUnit('cMap(data=population / area, scale=linearScale(), ramp=rampUridis)', '1\u202f234/\u00a0km^2')
+testMapUnit('cMap(data=density_pw_1km / density_pw_2km, scale=linearScale(), ramp=rampUridis)', '1230')
+testMapUnit('cMap(data=pres_2020_margin, scale=linearScale(), ramp=rampUridis)', '123400.00%')
+testMapUnit('cMap(data=commute_time_median, scale=linearScale(), ramp=rampUridis)', '20:34')
+testMapUnit('cMap(data=elevation, scale=linearScale(), ramp=rampUridis)', '1\u202f234 m')
+// A quantity with no display units of its own is displayed in base units
+testMapUnit('cMap(data=population * area, scale=linearScale(), ramp=rampUridis)', '1\u202f230\u202f000\u202f000 m^2·person')
+testMapUnit('cMap(data=[1, 2, 3], scale=linearScale(), ramp=rampUridis)', undefined)
+testMapUnit('cMapRGB(dataR=population, dataG=population, dataB=population)', undefined)
+testMapUnit('pMap(data=population / area, scale=linearScale(), ramp=rampUridis)', '1\u202f234/\u00a0km^2')
+testMapUnit(`condition (population > 1000)
+cMap(data=commute_bike, scale=linearScale(), ramp=rampUridis)`, '123400.00%')
+
+let columnUnitIdx = 0
+
+function testColumnUnit(code: string, columnIndex: number, expected: string | undefined): void {
+    void test(`table column unit ${++columnUnitIdx}`, () => {
+        const columnUnit = deriveTableColumnUnit(mapUSSFromString(code), getTypeEnvironment(), columnIndex)
+        if (expected === undefined) {
+            assert.equal(columnUnit, undefined)
+            return
+        }
+        assert.ok(columnUnit)
+        const rendered = displayQuantity(1234, columnUnit, false)
+        const { attached } = displayUnitFor(1234, columnUnit, false)
+        assert.equal(`${rendered.value}${unitSuffix(rendered.unit, attached)}`, expected)
+    })
+}
+
+testColumnUnit('table(columns=[column(values=population), column(values=population / area)])', 0, '1\u202f234')
+testColumnUnit('table(columns=[column(values=population), column(values=population / area)])', 1, '1\u202f234/\u00a0km^2')
+testColumnUnit('table(columns=[column(values=population)])', 1, undefined)
+testColumnUnit('table(columns=[column(values=[1, 2, 3])])', 0, undefined)

--- a/react/unit/urban-stats-script-unit-inference.test.ts
+++ b/react/unit/urban-stats-script-unit-inference.test.ts
@@ -12,9 +12,9 @@ function getTypeEnvironment(): ReturnType<typeof defaultTypeEnvironment> {
     return defaultTypeEnvironment('USA')
 }
 
-function renderQuantity(value: number, unit: Unit): string {
-    const { value: rendered, unit: name } = displayQuantity(value, unit, false)
-    const { attached } = displayUnitFor(value, unit, false)
+function renderQuantity(value: number, quantityUnit: Unit): string {
+    const { value: rendered, unit: name } = displayQuantity(value, quantityUnit, false)
+    const { attached } = displayUnitFor(value, quantityUnit, false)
     return `${rendered}${reifyString(unitSuffix(name, attached))}`
 }
 

--- a/react/unit/urban-stats-script-unit-inference.test.ts
+++ b/react/unit/urban-stats-script-unit-inference.test.ts
@@ -135,6 +135,10 @@ testMapUnit('cMap(data=density_pw_1km / density_pw_2km, scale=linearScale(), ram
 testMapUnit('cMap(data=pres_2020_margin, scale=linearScale(), ramp=rampUridis)', '123400.00%')
 testMapUnit('cMap(data=commute_time_median, scale=linearScale(), ramp=rampUridis)', '20:34')
 testMapUnit('cMap(data=elevation, scale=linearScale(), ramp=rampUridis)', '1\u202f234 m')
+// a length that comes out in kilometers is displayed like a distance that is stored in them
+testMapUnit('cMap(data=area ** 0.5, scale=linearScale(), ramp=rampUridis)', '1234.00 km')
+// one that is in no particular unit is displayed in whichever unit fits
+testMapUnit('cMap(data=area / elevation, scale=linearScale(), ramp=rampUridis)', '1\u202f234\u202f000 km')
 // A quantity with no display units of its own is displayed in base units
 testMapUnit('cMap(data=population * area, scale=linearScale(), ramp=rampUridis)', '1\u202f230\u202f000\u202f000 m^{2}·person')
 testMapUnit('cMap(data=[1, 2, 3], scale=linearScale(), ramp=rampUridis)', undefined)


### PR DESCRIPTION
Closes #2204. **Stacked on #2215**, which introduces the unit framework this builds on and changes no behavior; review that one first, and this diff shrinks to the feature once it merges.

A map or a caption could only say what unit its data was in when the data was a statistic column. Anything computed fell back to `classifyStatistic` on the words of the label, so `density_pw_1km / density_pw_2km` was labelled a density, and the condition in

```
condition (commute_bike < 0.1)
cMap(data=density_pw_1km, scale=linearScale(), ramp=rampUridis)
```

was written as `PW Density (r=1km) where Commute Bike % < 0.1`.

## Inference

`urban-stats-script/unit-inference.ts` infers the unit of an expression by abstract interpretation over the AST, over the `Unit` from #2215 (dimensions + the multiplier into base units), with `undefined` for what cannot be inferred:

- dimensions and multipliers follow the arithmetic, so `population / area` is exactly the unit a density is stored in, and `area ** 0.5` is kilometers
- adding quantities of different dimensions, or of the same dimensions stored differently (`hospital_mean_dist + elevation`), gives no unit
- a presentation survives an operation that keeps the quantity the same kind of thing: percentage ± percentage is a percentage, percentage × percentage is a plain fraction, percentage × population is a number of people
- an unknown operand leaves the other one's unit alone, so `population * 2` is still a population
- comparisons and logical operators produce booleans, which have no unit

`deriveMapUnit` and `deriveTableColumnUnit` read the unit off the map's `data` or a column's `values` the same way the label is derived, and are used when nothing was passed explicitly. Where inference gives nothing, the old label-text heuristic still applies.

## Captions

A constant is written in the unit of what it is compared against, in whichever display unit reads best:

| | before | after |
|---|---|---|
| `commute_bike < 0.1` | `Commute Bike % < 0.1` | `Commute Bike % < 10%` |
| `ped_cyclist_fatalities_per_capita > 1e-5` | `... > 1x10^-5` | `... > 1/100k` |
| `commute_time_median > 600` | `... > 600` | `... > 10:00` |
| `population > 1000000` | `Population > 1m` | unchanged |
| `elevation > 1234` | `PW Mean Elevation > 1 234` | unchanged |

The unit is only named when the number has to be rescaled to be read in it, so quantities already stored in the unit they are displayed in keep their bare number.

## Durations past a day

The one display change: `time^1` gains days and years above a day, so a duration that outgrows h:mm is readable. No statistic reaches it — commute times are minutes and sunny hours are under 24 — but a computed one can.

## Test plan

- `unit/urban-stats-script-unit-inference.test.ts`: 50 cases over the inference rules, the unit arithmetic, and `deriveMapUnit` / `deriveTableColumnUnit` rendered end to end.
- `unit/urban-stats-script-derive-human-readable-name.test.ts`: the caption cases above, including the ones that must not change.
- `npm run test:unit`, `tsc` and eslint pass.
- Screenshots should only move for a mapper colorbar whose data is a computed expression: every condition in the e2e mapper scripts is on `population`, and the one on `white` belongs to a map that passes its own label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)