### PR TITLE
Show the screenshot button's spinner during map exports

### DIFF
--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -27,6 +27,7 @@ export function Header(props: {
     hamburgerOpen: boolean
     setHamburgerOpen: (newValue: boolean) => void
     hasScreenshot: boolean
+    screenshotInProgress: boolean
     hasCSV: boolean
     initiateScreenshot: (currentUniverse: string | undefined) => void
     exportCSV: () => void
@@ -56,6 +57,7 @@ export function Header(props: {
                             ? (
                                     <ScreenshotButton
                                         onClick={() => { props.initiateScreenshot(currentUniverse) }}
+                                        loading={props.screenshotInProgress}
                                     />
                                 )
                             : undefined

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -13,7 +13,7 @@ import { zIndex } from '../utils/zIndex'
 
 const debugLog = makeDebugLogger('mapExport')
 
-export function ScreenshotButton(props: { onClick: () => void }): ReactNode {
+export function ScreenshotButton(props: { onClick: () => void, loading: boolean }): ReactNode {
     const colors = useColors()
     const screencapButton = (
         <button
@@ -31,8 +31,8 @@ export function ScreenshotButton(props: { onClick: () => void }): ReactNode {
             <img src="/screenshot.png" alt="" style={{ height: '100%' }} />
         </button>
     )
-    // if screenshot mode is on, put a loading circle over the image
-    if (useScreenshotMode()) {
+    // while a capture is running, put a loading circle over the image
+    if (props.loading) {
         const pad = 10 // pct
         const loadingCircle = (
             <div style={{

--- a/react/src/page_template/template.tsx
+++ b/react/src/page_template/template.tsx
@@ -36,6 +36,7 @@ export function PageTemplate({
     hideSidebar?: boolean
 }): ReactNode {
     const [hamburgerOpen, setHamburgerOpen] = useState(false)
+    const [screenshotInProgress, setScreenshotInProgress] = useState(false)
     const ownScreenshotContext = useRef<ScreenshotContextType>({ render: new Set(), wait: new Set() })
     const screenshotContext = inheritedScreenshotContext ?? ownScreenshotContext.current
     const colors = useColors()
@@ -78,11 +79,15 @@ export function PageTemplate({
         if (screencap === undefined) {
             return
         }
+        setScreenshotInProgress(true)
         try {
             await screencap(currentUniverse, colors, screenshotContext)
         }
         catch (e) {
             console.error(e)
+        }
+        finally {
+            setScreenshotInProgress(false)
         }
     }
 
@@ -115,6 +120,7 @@ export function PageTemplate({
                             hamburgerOpen={hamburgerOpen}
                             setHamburgerOpen={setHamburgerOpen}
                             hasScreenshot={hasScreenshotButton}
+                            screenshotInProgress={screenshotInProgress}
                             hasCSV={hasCSVButton}
                             initiateScreenshot={(currentUniverse) => { void doScreencap(currentUniverse) }}
                             exportCSV={exportCSV}


### PR DESCRIPTION
The screenshot button in the header never showed a loading indicator on the mapper page, because its spinner was driven by `useScreenshotMode()` — a subscription to whichever `ScreenshotContext` sits above the button. The mapper runs `withScreenshotMode` on a context created inside the map generator, and that provider wraps only the map, not the header. The button therefore subscribed to `PageTemplate`'s context, which nothing ever notifies during a map export, and sat inert for the whole capture.

Rather than reconciling the two contexts, the spinner is now driven by the capture itself: `PageTemplate` tracks a flag around its `await screencap(...)` and passes it to `ScreenshotButton` as a `loading` prop. Sharing one context between the header and the map would have dragged every other subscriber on the page into screenshot mode during an export, which is wrong for the mapper — only the map is being captured, not the settings panel.

The spinner also stays up longer on every page now. Screenshot mode is cleared before the canvas compositing and PNG encoding, so that work previously ran with no indicator; for the mapper's 4x-pixel-ratio export it is a noticeable wait.

Typecheck and lint pass. Not clicked through in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)