### PR TITLE
Extract a borderless button class and split Flag by call site

### DIFF
--- a/react/src/common.css
+++ b/react/src/common.css
@@ -71,6 +71,11 @@ button, select {
     cursor: pointer;
 }
 
+button.borderless {
+    border: none;
+    background-color: transparent;
+}
+
 button:hover:not(:disabled) {
     background-color: var(--slightly-different-background-focused);
 }

--- a/react/src/common.css
+++ b/react/src/common.css
@@ -73,7 +73,6 @@ button, select {
 
 button.borderless {
     border: none;
-    background-color: transparent;
 }
 
 button:hover:not(:disabled) {

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -56,6 +56,7 @@ export function CSVButton(props: { onClick: () => void }): ReactNode {
             style={{
                 height: '100%',
                 cursor: 'pointer',
+                background: 'none',
                 padding: 0,
             }}
         >

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -50,13 +50,12 @@ export function CSVButton(props: { onClick: () => void }): ReactNode {
     return (
         <button
             type="button"
+            className="borderless"
             aria-label="Export as CSV"
             onClick={props.onClick}
             style={{
                 height: '100%',
                 cursor: 'pointer',
-                background: 'none',
-                border: 'none',
                 padding: 0,
             }}
         >

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -260,11 +260,10 @@ function UniverseSelector(): ReactNode {
                 }
             }
             >
-                <Flag
+                <SelectorFlag
                     height={headerBarSize}
                     onClick={() => { setDropdownOpen(!dropdownOpen) }}
                     universe={universeCtx.universe}
-                    classNameToUse="universe-selector"
                 />
             </div>
             {dropdown}
@@ -272,7 +271,7 @@ function UniverseSelector(): ReactNode {
     )
 }
 
-function Flag(props: { height: number, onClick?: () => void, universe: string, classNameToUse: string }): ReactNode {
+function SelectorFlag(props: { height: number, onClick: () => void, universe: string }): ReactNode {
     const imageAR = flag_dimensions[props.universe]
     const usableHeight = props.height * flagIconMaxHeightPercent
     const usableWidth = Math.min(usableHeight * imageAR, props.height * flagIconWidthRatio)
@@ -286,16 +285,36 @@ function Flag(props: { height: number, onClick?: () => void, universe: string, c
                 src={universePath(props.universe)}
                 alt={props.universe}
                 width={`${usableWidth}px`}
-                className={props.classNameToUse}
+                className="universe-selector"
                 onClick={props.onClick}
-                role={props.onClick && 'button'}
-                tabIndex={props.onClick && 0}
-                onKeyDown={props.onClick && ((e) => {
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
                     if (e.key === ' ' || e.key === 'Enter') {
                         e.preventDefault()
-                        props.onClick!()
+                        props.onClick()
                     }
-                })}
+                }}
+            />
+        </div>
+    )
+}
+
+function DropdownFlag(props: { height: number, universe: string }): ReactNode {
+    const imageAR = flag_dimensions[props.universe]
+    const usableHeight = props.height * flagIconMaxHeightPercent
+    const usableWidth = Math.min(usableHeight * imageAR, props.height * flagIconWidthRatio)
+
+    return (
+        <div style={{ width: props.height * flagIconWidthRatio, height: props.height, display: 'flex' }}>
+            <img
+                style={{
+                    margin: 'auto',
+                }}
+                src={universePath(props.universe)}
+                alt={props.universe}
+                width={`${usableWidth}px`}
+                className="universe-selector-option"
             />
         </div>
     )
@@ -375,10 +394,9 @@ function UniverseDropdown(
                             }}
                             className="hoverable_elements"
                         >
-                            <Flag
+                            <DropdownFlag
                                 height={flagSize}
                                 universe={altUniverse}
-                                classNameToUse="universe-selector-option"
                             />
                             <div className="serif">
                                 {humanReadableUniverse(altUniverse)}

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -24,6 +24,7 @@ export function ScreenshotButton(props: { onClick: () => void }): ReactNode {
             style={{
                 height: '100%',
                 cursor: 'pointer',
+                background: 'none',
                 padding: 0,
             }}
         >

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -18,13 +18,12 @@ export function ScreenshotButton(props: { onClick: () => void }): ReactNode {
     const screencapButton = (
         <button
             type="button"
+            className="borderless"
             aria-label="Take screenshot"
             onClick={props.onClick}
             style={{
                 height: '100%',
                 cursor: 'pointer',
-                background: 'none',
-                border: 'none',
                 padding: 0,
             }}
         >


### PR DESCRIPTION
Nothing renders differently after this PR. It is groundwork for a chain that reworks the universe selector, split out so the later diffs are readable.

`Flag` took an optional `onClick` and a `classNameToUse`, because the header selector and the dropdown rows happened to share a layout. They are about to stop having anything in common, so each call site gets its own component now, while they are still identical, rather than inside a diff that also changes how they look.

The `borderless` class covers only `border: none`, and the CSV and screenshot buttons keep their inline `background: none`. That inline value also suppresses the shared `button:hover` rule, so folding it into the class would quietly give those buttons a hover background — a visual change that belongs with the restyle at the top of the stack, along with the border radius.

First of six:
1. **this PR** — refactor
2. #2219 — dropdown options become real buttons
3. #2220 — keyboard navigation
4. #2221 — selector moves to the right panel on mobile
5. #2222 — dropdown stays inside the viewport
6. #2223 — the restyle

🤖 Generated with [Claude Code](https://claude.com/claude-code)