### PR TITLE
Put the universe selector in the header's right panel on mobile

### DIFF
--- a/react/src/common.css
+++ b/react/src/common.css
@@ -71,6 +71,11 @@ button, select {
     cursor: pointer;
 }
 
+button.borderless {
+    border: none;
+    background-color: transparent;
+}
+
 button:hover:not(:disabled) {
     background-color: var(--slightly-different-background-focused);
 }

--- a/react/src/common.css
+++ b/react/src/common.css
@@ -73,7 +73,6 @@ button, select {
 
 button.borderless {
     border: none;
-    background-color: transparent;
 }
 
 button:hover:not(:disabled) {

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -56,6 +56,7 @@ export function CSVButton(props: { onClick: () => void }): ReactNode {
             style={{
                 height: '100%',
                 cursor: 'pointer',
+                background: 'none',
                 padding: 0,
             }}
         >

--- a/react/src/components/csv-export.tsx
+++ b/react/src/components/csv-export.tsx
@@ -50,13 +50,12 @@ export function CSVButton(props: { onClick: () => void }): ReactNode {
     return (
         <button
             type="button"
+            className="borderless"
             aria-label="Export as CSV"
             onClick={props.onClick}
             style={{
                 height: '100%',
                 cursor: 'pointer',
-                background: 'none',
-                border: 'none',
                 padding: 0,
             }}
         >

--- a/react/src/components/header.css
+++ b/react/src/components/header.css
@@ -1,7 +1,0 @@
-.hoverable_elements {
-    background-color: var(--slightly-different-background);
-}
-
-.hoverable_elements:hover {
-    background-color: var(--slightly-different-background-focused);
-}

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -329,6 +329,52 @@ function UniverseDropdown(
     const { universes, setUniverse } = universeCtx
     const filteredUniverses = universes.filter(universe => universe.toLowerCase().includes(searchTerm.toLowerCase()))
 
+    const searchInputRef = useRef<HTMLInputElement>(null)
+
+    useEffect(() => {
+        searchInputRef.current?.focus()
+    }, [])
+
+    const [highlighted, setHighlighted] = useState(0)
+    const highlightedRef = useRef<HTMLButtonElement>(null)
+    const optionsRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (optionsRef.current?.contains(document.activeElement) ?? false) {
+            highlightedRef.current?.focus()
+        }
+        else {
+            highlightedRef.current?.scrollIntoView({ block: 'nearest' })
+        }
+    }, [highlighted])
+
+    useEffect(() => {
+        const listener = (e: KeyboardEvent): void => {
+            switch (e.key) {
+                case 'ArrowDown':
+                    setHighlighted(h => Math.max(0, Math.min(h + 1, filteredUniverses.length - 1)))
+                    break
+                case 'ArrowUp':
+                    setHighlighted(h => Math.max(h - 1, 0))
+                    break
+                case 'Enter':
+                    if (optionsRef.current?.contains(document.activeElement) ?? false) {
+                        return // the focused option will be clicked
+                    }
+                    if (filteredUniverses.length > 0) {
+                        setUniverse(filteredUniverses[highlighted])
+                        closeDropdown()
+                    }
+                    break
+                default:
+                    return
+            }
+            e.preventDefault()
+        }
+        document.addEventListener('keydown', listener)
+        return () => { document.removeEventListener('keydown', listener) }
+    }, [filteredUniverses, highlighted, setUniverse, closeDropdown])
+
     return (
         <div>
             <div
@@ -351,6 +397,7 @@ function UniverseDropdown(
                             }}
                             >
                                 <input
+                                    ref={searchInputRef}
                                     type="text"
                                     placeholder="Search Universes"
                                     className="serif"
@@ -363,7 +410,10 @@ function UniverseDropdown(
                                         e.target.select()
                                     }, 0)}
                                     value={searchTerm}
-                                    onChange={(e) => { setSearchTerm(e.target.value) }}
+                                    onChange={(e) => {
+                                        setSearchTerm(e.target.value)
+                                        setHighlighted(0)
+                                    }}
                                     data-test-id="universe-search"
                                 >
 
@@ -372,38 +422,45 @@ function UniverseDropdown(
                         )
                     : null
             }
-            {filteredUniverses.map((altUniverse) => {
-                return (
-                    <button
-                        key={altUniverse}
-                        type="button"
-                        className="borderless"
-                        onClick={() => {
-                            setUniverse(altUniverse)
-                            closeDropdown()
-                        }}
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            gap: '1em',
-                            alignItems: 'center',
-                            cursor: 'pointer',
-                            padding: '0.5em',
-                            width: '100%',
-                            fontSize: 'inherit',
-                            borderRadius: 0,
-                        }}
-                    >
-                        <DropdownFlag
-                            height={flagSize}
-                            universe={altUniverse}
-                        />
-                        <div className="serif">
-                            {humanReadableUniverse(altUniverse)}
-                        </div>
-                    </button>
-                )
-            })}
+            <div ref={optionsRef}>
+                {filteredUniverses.map((altUniverse, index) => {
+                    return (
+                        <button
+                            key={altUniverse}
+                            ref={index === highlighted ? highlightedRef : null}
+                            type="button"
+                            className="borderless"
+                            onClick={() => {
+                                setUniverse(altUniverse)
+                                closeDropdown()
+                            }}
+                            onFocus={() => { setHighlighted(index) }}
+                            onMouseEnter={() => { setHighlighted(index) }}
+                            style={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                gap: '1em',
+                                alignItems: 'center',
+                                cursor: 'pointer',
+                                padding: '0.5em',
+                                width: '100%',
+                                fontSize: 'inherit',
+                                borderRadius: 0,
+                                // overrides the :hover rule, so hovering moves the highlight instead of adding a second one
+                                backgroundColor: index === highlighted ? colors.slightlyDifferentBackgroundFocused : 'transparent',
+                            }}
+                        >
+                            <DropdownFlag
+                                height={flagSize}
+                                universe={altUniverse}
+                            />
+                            <div className="serif">
+                                {humanReadableUniverse(altUniverse)}
+                            </div>
+                        </button>
+                    )
+                })}
+            </div>
         </div>
     )
 }

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useContext, useEffect, useRef, useState } from 'react'
 
 import '../common.css'
-import './header.css'
 import flag_dimensions from '../data/flag_dimensions'
 import statistic_name_list from '../data/statistic_name_list'
 import { Navigator } from '../navigation/Navigator'
@@ -375,34 +374,34 @@ function UniverseDropdown(
             }
             {filteredUniverses.map((altUniverse) => {
                 return (
-                    <div
+                    <button
                         key={altUniverse}
+                        type="button"
+                        className="borderless"
                         onClick={() => {
                             setUniverse(altUniverse)
                             closeDropdown()
                         }}
+                        style={{
+                            display: 'flex',
+                            flexDirection: 'row',
+                            gap: '1em',
+                            alignItems: 'center',
+                            cursor: 'pointer',
+                            padding: '0.5em',
+                            width: '100%',
+                            fontSize: 'inherit',
+                            borderRadius: 0,
+                        }}
                     >
-                        <div
-                            style={{
-                                display: 'flex',
-                                flexDirection: 'row',
-                                gap: '1em',
-                                // center vertically
-                                alignItems: 'center',
-                                cursor: 'pointer',
-                                padding: '0.5em',
-                            }}
-                            className="hoverable_elements"
-                        >
-                            <DropdownFlag
-                                height={flagSize}
-                                universe={altUniverse}
-                            />
-                            <div className="serif">
-                                {humanReadableUniverse(altUniverse)}
-                            </div>
+                        <DropdownFlag
+                            height={flagSize}
+                            universe={altUniverse}
+                        />
+                        <div className="serif">
+                            {humanReadableUniverse(altUniverse)}
                         </div>
-                    </div>
+                    </button>
                 )
             })}
         </div>

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -43,19 +43,16 @@ export function Header(props: {
             <div className="right_panel_top" style={{ height: `${headerBarSize}px` }}>
                 {/* flex but stretch to fill */}
                 <div style={{ display: 'flex', flexDirection: 'row', height: '100%' }}>
-                    {!isMobile && currentUniverse
-                        ? (
-                                <div style={{ paddingRight: '0.5em' }}>
-                                    <UniverseSelector />
-                                </div>
-                            )
-                        : undefined}
+                    {currentUniverse ? <UniverseSelector /> : undefined}
                     {
                         props.hasScreenshot
                             ? (
-                                    <ScreenshotButton
-                                        onClick={() => { props.initiateScreenshot(currentUniverse) }}
-                                    />
+                                    <>
+                                        <div className="hgap"></div>
+                                        <ScreenshotButton
+                                            onClick={() => { props.initiateScreenshot(currentUniverse) }}
+                                        />
+                                    </>
                                 )
                             : undefined
                     }
@@ -142,16 +139,10 @@ function TopLeft(props: {
     const universeCtx = useUniverseContext()
     if (useMobileLayout()) {
         return (
-            <div className="left_panel_top" style={{ minWidth: '28%' }}>
+            <div className="left_panel_top">
                 <Nav hamburgerOpen={props.hamburgerOpen} setHamburgerOpen={props.setHamburgerOpen} />
                 <div className="hgap"></div>
-                {
-                    universeCtx
-                        ? (
-                                <UniverseSelector />
-                            )
-                        : <HeaderImage />
-                }
+                {universeCtx === undefined ? <HeaderImage /> : undefined}
             </div>
         )
     }

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -435,7 +435,9 @@ function UniverseDropdown(
                                 closeDropdown()
                             }}
                             onFocus={() => { setHighlighted(index) }}
-                            onMouseEnter={() => { setHighlighted(index) }}
+                            // mousemove rather than mouseenter: scrolling the list under a stationary
+                            // cursor fires mouseenter, which would undo the arrow key that scrolled it
+                            onMouseMove={() => { setHighlighted(index) }}
                             style={{
                                 display: 'flex',
                                 flexDirection: 'row',

--- a/react/src/components/header.tsx
+++ b/react/src/components/header.tsx
@@ -260,11 +260,10 @@ function UniverseSelector(): ReactNode {
                 }
             }
             >
-                <Flag
+                <SelectorFlag
                     height={headerBarSize}
                     onClick={() => { setDropdownOpen(!dropdownOpen) }}
                     universe={universeCtx.universe}
-                    classNameToUse="universe-selector"
                 />
             </div>
             {dropdown}
@@ -272,7 +271,7 @@ function UniverseSelector(): ReactNode {
     )
 }
 
-function Flag(props: { height: number, onClick?: () => void, universe: string, classNameToUse: string }): ReactNode {
+function SelectorFlag(props: { height: number, onClick: () => void, universe: string }): ReactNode {
     const imageAR = flag_dimensions[props.universe]
     const usableHeight = props.height * flagIconMaxHeightPercent
     const usableWidth = Math.min(usableHeight * imageAR, props.height * flagIconWidthRatio)
@@ -286,16 +285,36 @@ function Flag(props: { height: number, onClick?: () => void, universe: string, c
                 src={universePath(props.universe)}
                 alt={props.universe}
                 width={`${usableWidth}px`}
-                className={props.classNameToUse}
+                className="universe-selector"
                 onClick={props.onClick}
-                role={props.onClick && 'button'}
-                tabIndex={props.onClick && 0}
-                onKeyDown={props.onClick && ((e) => {
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
                     if (e.key === ' ' || e.key === 'Enter') {
                         e.preventDefault()
-                        props.onClick!()
+                        props.onClick()
                     }
-                })}
+                }}
+            />
+        </div>
+    )
+}
+
+function DropdownFlag(props: { height: number, universe: string }): ReactNode {
+    const imageAR = flag_dimensions[props.universe]
+    const usableHeight = props.height * flagIconMaxHeightPercent
+    const usableWidth = Math.min(usableHeight * imageAR, props.height * flagIconWidthRatio)
+
+    return (
+        <div style={{ width: props.height * flagIconWidthRatio, height: props.height, display: 'flex' }}>
+            <img
+                style={{
+                    margin: 'auto',
+                }}
+                src={universePath(props.universe)}
+                alt={props.universe}
+                width={`${usableWidth}px`}
+                className="universe-selector-option"
             />
         </div>
     )
@@ -375,10 +394,9 @@ function UniverseDropdown(
                             }}
                             className="hoverable_elements"
                         >
-                            <Flag
+                            <DropdownFlag
                                 height={flagSize}
                                 universe={altUniverse}
-                                classNameToUse="universe-selector-option"
                             />
                             <div className="serif">
                                 {humanReadableUniverse(altUniverse)}

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -24,6 +24,7 @@ export function ScreenshotButton(props: { onClick: () => void }): ReactNode {
             style={{
                 height: '100%',
                 cursor: 'pointer',
+                background: 'none',
                 padding: 0,
             }}
         >

--- a/react/src/components/screenshot.tsx
+++ b/react/src/components/screenshot.tsx
@@ -18,13 +18,12 @@ export function ScreenshotButton(props: { onClick: () => void }): ReactNode {
     const screencapButton = (
         <button
             type="button"
+            className="borderless"
             aria-label="Take screenshot"
             onClick={props.onClick}
             style={{
                 height: '100%',
                 cursor: 'pointer',
-                background: 'none',
-                border: 'none',
                 padding: 0,
             }}
         >


### PR DESCRIPTION
The universe selector now sits next to the screenshot and CSV buttons at every screen size. Mobile previously swapped it into the left panel in place of the logo, so it had a different position and different neighbours depending on the viewport, which made it hard to style once.

The consequence is that mobile shows no logo while a universe is active — the left panel is just the hamburger. That is intentional; the selector is the more useful thing to have in that space.

Stacked on #2220.