### PR TITLE
Follow the TOTP endpoint's redirect by hand and retry the second hop

### DIFF
--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -26,6 +26,13 @@ const nextButton = Selector('button').withExactText('Next')
 const emailInput = Selector('input[type=text][aria-label*=email i]:not([aria-hidden="true"])')
 const passwordInput = Selector('input[type=password]')
 
+// Headers is not iterable under our tsconfig's lib (DOM without DOM.Iterable)
+function headersJSON(headers: Headers): string {
+    const entries: Record<string, string> = {}
+    headers.forEach((value, key) => { entries[key] = value })
+    return JSON.stringify(entries)
+}
+
 async function popTOTP(t: TestController): Promise<string> {
     // https://script.google.com/u/2/home/projects/1CWDP4eezFo8fMhQb327VfSm3DnThl-8xg1fmg4cl9gHnK0NGB8XSz094/edit
     // Apps Script runs the script at /exec, then 302s to a script.googleusercontent.com URL that
@@ -34,7 +41,7 @@ async function popTOTP(t: TestController): Promise<string> {
     const location = exec.headers.get('location')
     if (location === null) {
         console.warn(`TOTP exec hop did not redirect: ${exec.status} ${exec.statusText}`)
-        console.warn(`headers: ${JSON.stringify(Object.fromEntries(exec.headers))}`)
+        console.warn(`headers: ${headersJSON(exec.headers)}`)
         console.warn(`body: ${await exec.text()}`)
         throw new Error('TOTP exec hop did not redirect')
     }
@@ -52,7 +59,7 @@ async function popTOTP(t: TestController): Promise<string> {
     }
     catch (error) {
         console.warn(`TOTP echo hop failed: ${echo.status} ${echo.statusText} for ${location}`)
-        console.warn(`headers: ${JSON.stringify(Object.fromEntries(echo.headers))}`)
+        console.warn(`headers: ${headersJSON(echo.headers)}`)
         console.warn(`body: ${body}`)
         throw error
     }

--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -28,15 +28,31 @@ const passwordInput = Selector('input[type=password]')
 
 async function popTOTP(t: TestController): Promise<string> {
     // https://script.google.com/u/2/home/projects/1CWDP4eezFo8fMhQb327VfSm3DnThl-8xg1fmg4cl9gHnK0NGB8XSz094/edit
-    const response = await fetch('https://script.google.com/macros/s/AKfycbxLMtid0yZ_JiX5Ymm02FXfbRXYrpF1AE9nUaDM8P9dhP7uOWJpMRH8SpG5TbCQCRc/exec')
-    const body = await response.text()
+    // Apps Script runs the script at /exec, then 302s to a script.googleusercontent.com URL that
+    // serves the output. The hops are followed by hand so a failure says which one broke.
+    const exec = await fetch('https://script.google.com/macros/s/AKfycbxLMtid0yZ_JiX5Ymm02FXfbRXYrpF1AE9nUaDM8P9dhP7uOWJpMRH8SpG5TbCQCRc/exec', { redirect: 'manual' })
+    const location = exec.headers.get('location')
+    if (location === null) {
+        console.warn(`TOTP exec hop did not redirect: ${exec.status} ${exec.statusText}`)
+        console.warn(`headers: ${JSON.stringify(Object.fromEntries(exec.headers))}`)
+        console.warn(`body: ${await exec.text()}`)
+        throw new Error('TOTP exec hop did not redirect')
+    }
+    // Re-running the exec hop would pop a new TOTP slot, so only this hop is retried.
+    let echo = await fetch(location, { redirect: 'manual' })
+    for (let attempt = 1; attempt <= 2 && !echo.ok; attempt++) {
+        console.warn(`TOTP echo hop ${echo.status} ${echo.statusText}, retry ${attempt}`)
+        await t.wait(1000)
+        echo = await fetch(location, { redirect: 'manual' })
+    }
+    const body = await echo.text()
     let useAfter: number
     try {
         ({ useAfter } = z.object({ useAfter: z.number() }).parse(JSON.parse(body)))
     }
     catch (error) {
-        console.warn(`TOTP endpoint failed: ${response.status} ${response.statusText}, redirected to ${response.url}`)
-        console.warn(`headers: ${JSON.stringify(response.headers)}`)
+        console.warn(`TOTP echo hop failed: ${echo.status} ${echo.statusText} for ${location}`)
+        console.warn(`headers: ${JSON.stringify(Object.fromEntries(echo.headers))}`)
         console.warn(`body: ${body}`)
         throw error
     }


### PR DESCRIPTION
The debug output from #2214 showed the failure is Google's, not ours. The request reached `script.googleusercontent.com/macros/echo` with a valid `user_content_key` and got back a 404 carrying Drive's "Sorry, unable to open the file at this time" page. Anonymous access is intact, since a permissions problem redirects to `accounts.google.com`, and the script didn't throw, since that renders Apps Script's own error page naming the exception. The script ran, its output was stored, and fetching it back failed. The same request then succeeded six more times in the same job, and again by hand today.

Serving an Apps Script web app takes two hops, and only the first one runs the script:

```
GET script.google.com/macros/s/<deployment>/exec
  -> 302, content-length: 0
     Location: script.googleusercontent.com/macros/echo?user_content_key=<per-request>&lib=<stable>

GET script.googleusercontent.com/macros/echo?...
  -> 200 application/json, {"useAfter":1786682250000}
```

Following the hops separately means a failure identifies which one broke instead of leaving it to inference. It also rules out a double-follow spending the one-shot key twice, which the previous logging could not distinguish from a server-side miss. Both hops use `redirect: 'manual'`, so a redirect appearing on the echo hop is reported rather than silently followed.

Only the echo hop retries, up to three attempts a second apart. Re-running exec would pop a new TOTP slot and could push `useAfter` into the next window, costing up to 30 seconds of waiting. That bounds what the retry can fix: it recovers a key that is not visible yet, but not one that is genuinely dead. Three identical 404s in the log would mean re-minting the key is the only recovery, and that it is worth paying the extra exec hop.

This also replaces `JSON.stringify(response.headers)`, which logged `{}` because `Headers` has no enumerable own properties.

Two costs worth naming. The retry delay eats up to 3 seconds of the enclosing `flaky` block's 30-second budget, uncredited; that did not cause the failure here, since the budget was already exhausted before the fetch, but it does make the block tighter. And manual redirect on the echo hop means that if Google ever legitimately adds a third hop, this starts failing where it previously worked.

Verified against the live endpoint: exec 302s, echo returns 200 with the expected JSON, and the retry loop passes through cleanly on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)