### PR TITLE
Add DOM.Iterable to tsconfig's lib

### DIFF
--- a/react/src/components/plots-tip-dismiss.ts
+++ b/react/src/components/plots-tip-dismiss.ts
@@ -71,7 +71,7 @@ export function dismissButtonTipIndex(target: EventTarget | null): number | null
 export function attachDismissButtons(plot: Element, transpose: boolean, onDismiss: (tipIndex: number) => void): void {
     // transposed plots draw at double the font size, so the buttons scale to match
     const scale = transpose ? 2 : 1
-    for (const tip of Array.from(plot.querySelectorAll(`g.${pinnedTipClassName}`))) {
+    for (const tip of plot.querySelectorAll(`g.${pinnedTipClassName}`)) {
         const tipIndex = Number(tip.getAttribute(tipIndexAttribute))
         // the tooltip proper is the first child of the mark's group, which may also hold the leader
         // drawn back to a displaced tooltip's point -- measuring that too would misplace the button

--- a/react/src/utils/IFrameInput.tsx
+++ b/react/src/utils/IFrameInput.tsx
@@ -15,7 +15,7 @@ function IFrameInputRef(props: React.DetailedHTMLProps<React.InputHTMLAttributes
 
     useEffect(() => {
         const doc = frameRef.current!.contentWindow!.document
-        for (const style of Array.from(document.head.querySelectorAll('style'))) {
+        for (const style of document.head.querySelectorAll('style')) {
             doc.head.appendChild(style.cloneNode(true))
         }
         setFrameDoc(doc)

--- a/react/test/disclaimers.test.ts
+++ b/react/test/disclaimers.test.ts
@@ -104,7 +104,7 @@ test('disclaimer-and-expand-buttons-vertically-aligned', async (t) => {
     await t.resizeWindow(1400, 800)
     await waitForLoading()
     const centers = await t.eval(() => {
-        for (const disclaimer of Array.from(document.getElementsByClassName('disclaimer-toggle'))) {
+        for (const disclaimer of document.getElementsByClassName('disclaimer-toggle')) {
             // climb to the stat-name row that also holds the expand "+" button
             let container = disclaimer.parentElement
             while (container !== null && container.getElementsByClassName('expand-toggle').length === 0) {

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -163,7 +163,7 @@ async function prepForImage(t: TestController, options: { hover: boolean, remove
     await t.eval(() => {
         if (options.removeEntireMap) {
             // disable the map, so that we're not testing the tiles
-            for (const x of Array.from(document.getElementsByClassName('maplibregl-canvas-container'))) {
+            for (const x of document.getElementsByClassName('maplibregl-canvas-container')) {
                 if (x instanceof HTMLElement) {
                     x.style.visibility = 'hidden'
                 }
@@ -174,7 +174,7 @@ async function prepForImage(t: TestController, options: { hover: boolean, remove
             (window as unknown as TestWindow).testUtils.disableBasemapLayers()
         }
 
-        for (const x of Array.from(document.getElementsByClassName('juxtastat-user-id'))) {
+        for (const x of document.getElementsByClassName('juxtastat-user-id')) {
             x.innerHTML = '&lt;USER ID&gt;'
         }
 

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -3,7 +3,8 @@
         "strict": true,
         "lib": [
             "ES2022",
-            "DOM"
+            "DOM",
+            "DOM.Iterable"
         ],
         "jsx": "react",
         "esModuleInterop": true,


### PR DESCRIPTION
`Headers`, `FormData`, `NodeList` and friends are iterable at runtime, but with only `DOM` in `lib` TypeScript doesn't know that, so `Object.fromEntries(response.headers)` fails to compile and has to be rewritten as a `forEach` loop. That happened in #2224. Adding `DOM.Iterable` costs nothing: it only adds declarations for iterators that already exist, so no code that compiled before stops compiling.

`tsc --noEmit` is clean with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)