### PR TITLE
Build the e2e image on slim, halving per-shard container init

### DIFF
--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get -y update \
         chromium=143.* chromium-common=143.* \
         xvfb \
         sqlite3 \
+        # the checkout step clones inside the container, and the runner diffs against the
+        # base ref; procps is for the pkill in quiz_test_utils.ts
+        git procps \
         # needed for window resizing in Testcafe
         libc6:i386 libx11-6:i386 fluxbox \
         # needed for downloads directory in TestCafe

--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -2,45 +2,39 @@
 # This version for compatibility with pandas
 # Pinned by digest because the tag moves, which invalidates the entire build cache.
 # Must stay on bookworm to match the snapshot repo below.
-FROM python:3.10-bookworm@sha256:2cffd68eda34762d010cba5de2e4462fcdab15ac2a53722b7cb17e8c76255cb3
+# slim, because the e2e jobs only need python for tests/check_images.py, and the
+# non-slim base's build toolchain is 330MB of the image every shard pulls.
+FROM python:3.10-slim-bookworm@sha256:7ed92b32353e8d8bd865b5ba811e0315d3999c3b57b1c2df2b504a359d4a1707
 
-# 😭
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
-RUN apt-get install -y nodejs
-
-RUN pip3 install --upgrade pip virtualenv
-RUN pip3 cache purge
-
-RUN dpkg --add-architecture i386
-
-# Use only the snapshot repo so all packages come from the same consistent state
-# This is primarily so we can install older Chromium and not have to update all the time
-# The timestamp may need to be bumped if installing newer packages
-RUN echo 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260115T000000Z/ bookworm main' \
-    > /etc/apt/sources.list \
+# One layer, because /var/lib/apt/lists is 44MB that only the build uses.
+RUN apt-get -y update \
+    && apt-get -y install --no-install-recommends curl ca-certificates gnupg \
+    # 😭
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get -y install nodejs \
+    && dpkg --add-architecture i386 \
+    # Use only the snapshot repo so all packages come from the same consistent state
+    # This is primarily so we can install older Chromium and not have to update all the time
+    # The timestamp may need to be bumped if installing newer packages
+    && echo 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260115T000000Z/ bookworm main' \
+        > /etc/apt/sources.list \
     && rm -f /etc/apt/sources.list.d/*.list \
-    && apt-get -o Acquire::Check-Valid-Until=false -y update
-
-RUN apt-get -y install chromium=143.* chromium-common=143.*
-
-RUN apt-get -y install xvfb
-
-RUN apt-get -y install sqlite3
-
-# needed for window resizing in Testcafe
-RUN apt-get -y install libc6:i386
-RUN apt-get -y install libx11-6:i386
-RUN apt-get -y install fluxbox
-
-# needed for downloads directory in TestCafe
-RUN apt-get -y install xdg-user-dirs
-
-# needed for emoji display in tests
-RUN apt-get -y install fonts-noto-color-emoji fonts-noto-core
+    && apt-get -o Acquire::Check-Valid-Until=false -y update \
+    && apt-get -y install \
+        chromium=143.* chromium-common=143.* \
+        xvfb \
+        sqlite3 \
+        # needed for window resizing in Testcafe
+        libc6:i386 libx11-6:i386 fluxbox \
+        # needed for downloads directory in TestCafe
+        xdg-user-dirs \
+        # needed for emoji display in tests
+        fonts-noto-color-emoji fonts-noto-core \
+    && rm -rf /var/lib/apt/lists/*
 
 # Screenshot comparison is all the Python the e2e jobs do, so they install it here rather
 # than restoring the full environment. Last, so editing it doesn't rebuild the apt layers.
 COPY requirements_screenshots.txt /tmp/requirements_screenshots.txt
 RUN pip3 install -r /tmp/requirements_screenshots.txt && pip3 cache purge
 
-ENTRYPOINT [ "/bin/bash", "-l", "-c" ] 
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]


### PR DESCRIPTION
Every e2e shard spends about 36s on "Initialize containers" — 1289s of runner time across 36 shards, 7.2% of the e2e total. This cuts the image from 2315MB to 1451MB uncompressed, which is the number that governs that step.

Container init turns out to be bounded by layer extraction, not by download. Isolating it with `docker load` from a local uncompressed tar, the old image takes 22.5s and the new one 11.3s; a full network pull of the new image also takes ~11.3s, so download and decompression sit entirely behind extraction. That is why the change targets uncompressed size. Compressed size falls 898MB to 526MB as a side effect, but compression is not where the time was. I tested zstd (481MB, 8.6% fewer bytes) and splitting the large layer into four so downloads could overlap extraction, and neither moved the clock, which is consistent with extraction being the constraint.

Almost all the removed weight is `python:3.10-bookworm`'s build toolchain — gcc, imagemagick, tcl/tk, subversion, mercurial, and roughly 200 dev header packages. The e2e jobs only run `tests/check_images.py`, so none of it is reachable. `virtualenv` goes too, since `.github/actions/python_environment` is its only consumer and the e2e job deliberately skips that action. Collapsing the apt work into a single `RUN` drops a 44MB layer of `/var/lib/apt/lists` that only the build reads.

Since screenshots are the fragile thing here, I checked this against a fresh amd64 build of the previous Dockerfile rather than against the cached image: zero version differences among packages present in both, `fc-list` output identical file-for-file (404 fonts), and the same Chromium build, 143.0.7499.169. The only delta is the toolchain disappearing.

Two things I found while measuring but deliberately left alone:

`rm -f /etc/apt/sources.list.d/*.list` does not match Debian's `debian.sources`, which is deb822 format, so live `deb.debian.org` and `bookworm-security` stay enabled alongside the pinned snapshot repo and win on version. This is why the published image carries `xvfb` `2:21.1.7-3+deb12u12` while a rebuild today produces `deb12u13`. Fixing the glob would roll packages *backward* to the snapshot's versions, which is its own screenshot-affecting change and does not belong here.

Roughly 100MB of the remainder is still surplus — `adwaita-icon-theme`, `libgs10`, `libx265`, `cpp-12` — reachable with `--no-install-recommends`. That is worth about a second per shard and is the one edit that could plausibly alter rendering, so it needs a real screenshot run rather than a package diff. The rest of the image is load-bearing: LLVM-15 and libz3 look like dead weight in a headless container but arrive through `libgl1-mesa-dri`, a hard `Depends` of `chromium-common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)