### PR TITLE
Make the pinned snapshot repo actually govern the package set

### DIFF
--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get -y update \
         chromium=143.* chromium-common=143.* \
         xvfb \
         sqlite3 \
+        # the checkout step clones inside the container, and the runner diffs against the
+        # base ref; procps is for the pkill in quiz_test_utils.ts
+        git procps \
         # needed for window resizing in Testcafe
         libc6:i386 libx11-6:i386 fluxbox \
         # needed for downloads directory in TestCafe

--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -2,45 +2,39 @@
 # This version for compatibility with pandas
 # Pinned by digest because the tag moves, which invalidates the entire build cache.
 # Must stay on bookworm to match the snapshot repo below.
-FROM python:3.10-bookworm@sha256:2cffd68eda34762d010cba5de2e4462fcdab15ac2a53722b7cb17e8c76255cb3
+# slim, because the e2e jobs only need python for tests/check_images.py, and the
+# non-slim base's build toolchain is 330MB of the image every shard pulls.
+FROM python:3.10-slim-bookworm@sha256:7ed92b32353e8d8bd865b5ba811e0315d3999c3b57b1c2df2b504a359d4a1707
 
-# 😭
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
-RUN apt-get install -y nodejs
-
-RUN pip3 install --upgrade pip virtualenv
-RUN pip3 cache purge
-
-RUN dpkg --add-architecture i386
-
-# Use only the snapshot repo so all packages come from the same consistent state
-# This is primarily so we can install older Chromium and not have to update all the time
-# The timestamp may need to be bumped if installing newer packages
-RUN echo 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260115T000000Z/ bookworm main' \
-    > /etc/apt/sources.list \
+# One layer, because /var/lib/apt/lists is 44MB that only the build uses.
+RUN apt-get -y update \
+    && apt-get -y install --no-install-recommends curl ca-certificates gnupg \
+    # 😭
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get -y install nodejs \
+    && dpkg --add-architecture i386 \
+    # Use only the snapshot repo so all packages come from the same consistent state
+    # This is primarily so we can install older Chromium and not have to update all the time
+    # The timestamp may need to be bumped if installing newer packages
+    && echo 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260115T000000Z/ bookworm main' \
+        > /etc/apt/sources.list \
     && rm -f /etc/apt/sources.list.d/*.list \
-    && apt-get -o Acquire::Check-Valid-Until=false -y update
-
-RUN apt-get -y install chromium=143.* chromium-common=143.*
-
-RUN apt-get -y install xvfb
-
-RUN apt-get -y install sqlite3
-
-# needed for window resizing in Testcafe
-RUN apt-get -y install libc6:i386
-RUN apt-get -y install libx11-6:i386
-RUN apt-get -y install fluxbox
-
-# needed for downloads directory in TestCafe
-RUN apt-get -y install xdg-user-dirs
-
-# needed for emoji display in tests
-RUN apt-get -y install fonts-noto-color-emoji fonts-noto-core
+    && apt-get -o Acquire::Check-Valid-Until=false -y update \
+    && apt-get -y install \
+        chromium=143.* chromium-common=143.* \
+        xvfb \
+        sqlite3 \
+        # needed for window resizing in Testcafe
+        libc6:i386 libx11-6:i386 fluxbox \
+        # needed for downloads directory in TestCafe
+        xdg-user-dirs \
+        # needed for emoji display in tests
+        fonts-noto-color-emoji fonts-noto-core \
+    && rm -rf /var/lib/apt/lists/*
 
 # Screenshot comparison is all the Python the e2e jobs do, so they install it here rather
 # than restoring the full environment. Last, so editing it doesn't rebuild the apt layers.
 COPY requirements_screenshots.txt /tmp/requirements_screenshots.txt
 RUN pip3 install -r /tmp/requirements_screenshots.txt && pip3 cache purge
 
-ENTRYPOINT [ "/bin/bash", "-l", "-c" ] 
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -13,19 +13,28 @@ RUN apt-get -y update \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get -y install nodejs \
     && dpkg --add-architecture i386 \
+    # needed for window resizing in Testcafe. These come from the base image's own repo
+    # rather than the snapshot below: libc6:i386 has to match the already-installed libc6
+    # exactly, and the snapshot is older than the base image.
+    && apt-get -y update \
+    && apt-get -y install libc6:i386 libx11-6:i386 \
     # Use only the snapshot repo so all packages come from the same consistent state
     # This is primarily so we can install older Chromium and not have to update all the time
     # The timestamp may need to be bumped if installing newer packages
     && echo 'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260115T000000Z/ bookworm main' \
         > /etc/apt/sources.list \
-    && rm -f /etc/apt/sources.list.d/*.list \
+    # Not *.list: Debian's config is debian.sources, in deb822 format, so the old glob left
+    # deb.debian.org enabled and apt took its newer packages over the snapshot's.
+    && rm -f /etc/apt/sources.list.d/* \
     && apt-get -o Acquire::Check-Valid-Until=false -y update \
     && apt-get -y install \
         chromium=143.* chromium-common=143.* \
         xvfb \
         sqlite3 \
-        # needed for window resizing in Testcafe
-        libc6:i386 libx11-6:i386 fluxbox \
+        fluxbox \
+        # the checkout step clones inside the container, and the runner diffs against the
+        # base ref; procps is for the pkill in quiz_test_utils.ts
+        git procps \
         # needed for downloads directory in TestCafe
         xdg-user-dirs \
         # needed for emoji display in tests


### PR DESCRIPTION
Stacked on #2226.

`react/test/Dockerfile` has always meant to install Chromium and its rendering stack from a fixed Debian snapshot, so the image doesn't drift underneath the reference screenshots. It has never actually done that. The line clearing the other apt sources globs `*.list`, but Debian's own config is `/etc/apt/sources.list.d/debian.sources` in deb822 format, so `deb.debian.org` and `bookworm-security` stayed enabled and apt preferred their newer packages. Only Chromium held still, and only because `chromium=143.*` pins it by hand.

The evidence is that the published image carries `xvfb 2:21.1.7-3+deb12u12` while rebuilding the identical Dockerfile today produces `deb12u13`.

Fixing the glob alone doesn't build:

```
libc6 : Breaks: libc6:i386 (!= 2.36-9+deb12u14) but 2.36-9+deb12u13 is to be installed
libc6:i386 : Breaks: libc6 (!= 2.36-9+deb12u13) but 2.36-9+deb12u14 is to be installed
```

`libc6:i386` has to match the installed `libc6` exactly, and the base image comes from a later Debian point release than the snapshot. Bumping the snapshot to match isn't available either — the snapshot carrying the right glibc has Chromium **150**, not 143, which is the whole reason the pin exists. So the i386 packages now come from the base image's own repo, before the switch, and everything that touches rendering comes from the snapshot.

## What moves

28 packages go back to their snapshot versions. The ones that could plausibly change pixels are `libpng16-16` (`deb12u5` → `deb12u1`), `libtiff6`, `liblcms2-2`, `libgraphite2-3`, `libnss3` (`deb12u4` → `deb12u1`), the mesa stack (`deb12u2` → `deb12u1`), `libgdk-pixbuf`, and `xvfb`/`xserver-common` (`deb12u13` → `deb12u11`).

77 packages leave entirely — the systemd, avahi, polkit, dconf and printing stack that live `bookworm-updates` had been dragging in through recommends. `chromium-sandbox` arrives, which the previous resolution had been skipping. Uncompressed size drops 1491MB to 1412MB.

Chromium stays at `143.0.7499.169-1~deb12u1` and `fc-list` output is identical file-for-file at 404 fonts, so the two largest inputs to screenshot rendering are unchanged. Whether those library rollbacks shift any pixels is a question only the e2e run on this PR can answer, and that's the point of landing it separately from #2226 rather than folded into it.

I verified the built image amd64: `chromium`, `git`, `pkill`, `ps`, `shasum`, `npm`, `node`, `python`, `Xvfb`, `fluxbox`, `sqlite3` and `xdg-user-dir` all present, and `libc6:amd64` and `libc6:i386` agreeing at `2.36-9+deb12u14`.

## Still not pinned

`curl`, `ca-certificates` and `gnupg` install from the base image's repo before the switch, and Node comes from NodeSource's rolling `nodistro` suite. Neither affects rendering, and pinning them is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)