### PR TITLE
Count a number's decimal places after rounding it, not before

### DIFF
--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -40,9 +40,11 @@ export function formatToSignificantFigures(value: number, sigFigs: number = 3): 
         return value.toString()
     }
 
-    const magnitude = Math.floor(Math.log10(Math.abs(value)))
-    const factor = Math.pow(10, sigFigs - 1 - magnitude)
+    const factor = Math.pow(10, sigFigs - 1 - Math.floor(Math.log10(Math.abs(value))))
     const rounded = Math.round(value * factor) / factor
+
+    // taken from the rounded value, since rounding can carry into another digit, as 0.9995 does
+    const magnitude = Math.floor(Math.log10(Math.abs(rounded)))
 
     // Count significant figures needed after decimal point
     if (magnitude >= 0) {

--- a/react/unit/formatToSignificantFigures.test.ts
+++ b/react/unit/formatToSignificantFigures.test.ts
@@ -10,6 +10,9 @@ void describe('formatToSignificantFigures', () => {
         assert.equal(formatToSignificantFigures(1.23456), '1.23')
         assert.equal(formatToSignificantFigures(1000.5), '1000')
         assert.equal(formatToSignificantFigures(999.9), '1000')
+        // rounding carries into another digit, so the places are counted after it
+        assert.equal(formatToSignificantFigures(0.9995), '1.00')
+        assert.equal(formatToSignificantFigures(0.09995), '0.100')
         assert.equal(formatToSignificantFigures(78.5), '78.5')
         assert.equal(formatToSignificantFigures(78.45), '78.5')
         assert.equal(formatToSignificantFigures(78.456), '78.5')


### PR DESCRIPTION
Split off #2215.

`formatToSignificantFigures` took the magnitude of the value it was given, rounded to that many significant figures, and then counted decimal places from the original magnitude. When rounding carries into another digit the count is one too many, so three significant figures of `0.9995` came out as `1.000`, which is four.

```ts
const factor = Math.pow(10, sigFigs - 1 - Math.floor(Math.log10(Math.abs(value))))
const rounded = Math.round(value * factor) / factor

// taken from the rounded value, since rounding can carry into another digit, as 0.9995 does
const magnitude = Math.floor(Math.log10(Math.abs(rounded)))
```

It shows up in #2215, where the same value has to choose between being written as `999.5k` and `1.00m`, and the extra figure made the abbreviation look shorter than it is.

## Test plan

- `unit/formatToSignificantFigures.test.ts` covers the carry in both branches: `0.9995` → `1.00` and `0.09995` → `0.100`. Its existing cases, including `999.9` → `1000`, are unchanged.
- `npm run test:unit`, `tsc` and eslint pass.
- The only other caller is the number formatting in USS captions, which is affected only at a rounding boundary of this kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
