### PR TITLE
Size e2e shards for a contended runner pool, not an empty one

### DIFF
--- a/react/test/scripts/list-e2e-tests.ts
+++ b/react/test/scripts/list-e2e-tests.ts
@@ -16,7 +16,7 @@ import { DefaultMap } from '../../src/utils/DefaultMap'
  * This scenario is an instance of the bin packing problem.
  * While a simple heuristic using nested loops can provide a near-optimal solution, a provably optimal solution can be obtained using linear programming (LP).
  * Due to the scale of the problem (approximately 2000 variables), the HiGHS LP solver is required for efficient computation.
- * This approach has reduced the number of jobs in the pipeline from 55 to 35.
+ * This approach packs the 87 test files into 27 jobs.
  */
 
 // This is a command line tool, we take in the test durations via JSON passed to a CLI flag
@@ -76,17 +76,21 @@ for (let t = 0; t < knownTests.length; t++) {
 /*
  * The e2e phase takes as long as its longest job, so the job count is only a means to
  * a wall-clock time. Runner minutes are free on a public repo, so the reason not to
- * shard further is that jobs past the account's concurrency ceiling queue instead of
- * running, which adds latency rather than removing it. 28 shards have been observed
- * starting together; this leaves room for the rest of the pipeline on top.
+ * shard further is that jobs past the account's 40-slot concurrency ceiling queue
+ * instead of running, which adds latency rather than removing it.
+ *
+ * That ceiling is shared with every other run in flight, so the best number depends on
+ * how contended the pool is, and no single value wins everywhere. Replaying a trace of
+ * 60 real runs: 26 costs about two minutes when the pool is free and saves two to five
+ * when it is busy, breaking even at roughly a fifth of the pool occupied.
  */
-const jobBudget = 36
+const jobBudget = 26
 
 /*
  * A single test file cannot be divided, so the longest one sets a floor under the whole
  * phase and packing below it just buys jobs that finish early while everyone waits on
- * that file anyway. Taking the max means splitting up a long test file is what turns
- * into a faster pipeline, with no constant here to retune afterwards.
+ * that file anyway. The budget currently sits above that floor and is what binds, so
+ * splitting up the longest test file would not on its own make the pipeline faster.
  */
 const durationLimit = knownTests.length === 0
     ? 0
@@ -126,8 +130,11 @@ await execa(
         'test/scripts/lp.lp',
         '--solution_file', 'test/scripts/solution',
         // Stopping early only costs us a few extra jobs: it is the duration constraint,
-        // not the objective, that decides how long the pipeline takes.
-        '--time_limit', '60',
+        // not the objective, that decides how long the pipeline takes. The budget leaves
+        // the bins almost no slack, so the last job is usually unprovable rather than
+        // findable and the solver would otherwise spend the whole limit on it. This job
+        // is on the critical path, so that time comes straight off every run.
+        '--time_limit', '10',
     ],
     { stderr: process.stderr, stdout: process.stderr },
 )


### PR DESCRIPTION
`jobBudget` was inert. `durationLimit` takes `max(T/jobBudget, longest test)`, and at `jobBudget = 36` that was `max(412s, 471s)` — the longest test file won, so the budget never touched the output and the pipeline packed to whatever bin count `quiz_auth_x1` happened to imply. At 26 the budget is above the floor and actually decides.

## Why 26

The shard count trades against the account's 40-slot concurrency ceiling, which is shared with every run in flight. Shards beyond a run's share of free slots queue instead of running, so past some point more shards add latency rather than removing it — and where that point sits depends on how contended the pool is, which means no single value wins everywhere.

To find it I replayed a trace of 60 real runs (1,530 jobs, 18 hours) through a discrete-event model of the pool: observed arrivals, observed service times, the full `check.yml` dependency graph, 40 servers. The crossover lands at roughly a fifth of the pool occupied. Below it, 26 costs about two minutes of median turnaround; above it, it saves two to five. Paired per-run comparison against today's packing gives −8% at the load level where the simulator matches observed median turnaround, with the 90% bootstrap interval excluding zero.

The basin is broad — anything from 24 to 28 lands within a point or two — so this is not a tuned constant and shouldn't need retuning as the suite grows.

This produces **27 bins, not 26**. Asking for 26 bins of 570s against 14,819s of work leaves about a second of total slack, so a 26-bin packing would have to be a near-perfect partition. 27 is inside the flat part of the basin, so it makes no practical difference.

## Why the solver limit moved

Forced by the change, not incidental. With almost no slack in the bins, the solver finds 27 in about a second and then cannot prove whether 26 is reachable; the gap sticks at 3.70% and it previously spent the remaining 59s there. `list-e2e-tests` is a dependency of `e2e`, so that time came straight off the critical path of every run and would have eaten roughly a third of what this change is meant to gain. The packing at 10s is byte-identical to the packing at 60s.

## What this does not establish

The simulator reproduces observed median turnaround but under-produces the observed p90 by about a factor of two, because real contention arrives in bursts that a constant background occupancy can't represent. These are median effects; the tail is unmeasured. Job wall time goes from about 8.9m to 10.8m, which leaves the existing 30-minute timeout room even at the observed 2× tail stretch.

Two things I checked and rejected along the way, recorded so they don't get re-proposed: the packer's bins are already balanced (sd 5.5s across 32 bins), so there is no packing fix to make; and the e2e stage is straggler-dominated, with ~2% of shard runs coming in 30–90% above their own median, worth ~25% of the stage and unaddressable from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)