### PR TITLE
Run check once per commit, not once per synchronize event

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+concurrency:
+  # A PR gets a synchronize event when its base branch is updated, as well as when its own
+  # head is. Pushing a stack of branches therefore starts two identical runs for every PR
+  # above the bottom one. Grouping by commit collapses those, while leaving a run for an
+  # earlier commit alone.
+  group: check-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 env:
   # This is used in ci_proxy, do not remove. It is necessary so that
   # we can test against non-production data


### PR DESCRIPTION
A pull request receives a `synchronize` event when its base branch is updated, not only when its own head is. In a stacked chain every PR except the bottom one is based on another branch in the chain, so pushing the stack starts two identical runs for each of them — one second apart, at the same head SHA. Across the last 300 runs of this workflow, 35 were duplicates of that kind. The universe-selector stack on Aug 14 shows it cleanly: `02` through `06` each ran twice at an identical SHA, and `01-borderless-button`, the only branch based on `main`, ran once.

The two events are indistinguishable in the payload, so no `types:` filter can separate them. A concurrency group collapses them instead: the second run supersedes the first, and since the surviving run is the later one, its `tests-passed` check is the most recent for the commit and the merge gate resolves from it. The cancelled run stays visible in the PR's checks list.

The group is keyed on the head SHA rather than the PR number so that pushing a new commit doesn't cancel the run for the previous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)