### PR TITLE
Use the e2e container's own node_modules rather than the host's

### DIFF
--- a/react/test/scripts/run-e2e-tests-docker.Dockerfile
+++ b/react/test/scripts/run-e2e-tests-docker.Dockerfile
@@ -3,10 +3,9 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /urbanstats
 
-# Install node_modules at root so that it doesn't conflict with the volume that will be mounted.
-# Resolution only reaches this install because the runner leaves react/node_modules empty; PATH is
-# what gets scripts run inside the container to the binaries that go with it.
+# Install node_modules at root so that it doesn't conflict with the volume that will be mounted
 ENV NODE_PATH=/node_modules
+# For scripts run inside the container
 ENV PATH=/node_modules/.bin:$PATH
 COPY react/package.json react/package-lock.json /
 RUN npm ci --prefix /

--- a/react/test/scripts/run-e2e-tests-docker.Dockerfile
+++ b/react/test/scripts/run-e2e-tests-docker.Dockerfile
@@ -3,8 +3,11 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /urbanstats
 
-# Install node_modules at root so that it doesn't conflict with the volume that will be mounted
+# Install node_modules at root so that it doesn't conflict with the volume that will be mounted.
+# Resolution only reaches this install because the runner leaves react/node_modules empty; PATH is
+# what gets scripts run inside the container to the binaries that go with it.
 ENV NODE_PATH=/node_modules
+ENV PATH=/node_modules/.bin:$PATH
 COPY react/package.json react/package-lock.json /
 RUN npm ci --prefix /
 

--- a/react/test/scripts/run-e2e-tests-docker.ts
+++ b/react/test/scripts/run-e2e-tests-docker.ts
@@ -20,6 +20,11 @@ export async function runE2eTestsDocker(args: string[], hostArch: boolean): Prom
             '--network', 'host',
             ...process.stdout.isTTY ? ['-it'] : [],
             '-v', `${repoRoot}:/urbanstats`,
+            // A tmpfs purely as a way to leave an empty directory here. Otherwise react/node_modules
+            // is the host's, built for the host's platform, and Node finds it long before it
+            // consults NODE_PATH. With nothing in it, the resolution walk falls through to
+            // /node_modules, which is the install that matches the container.
+            '--mount', 'type=tmpfs,dst=/urbanstats/react/node_modules',
             '-w', '/urbanstats/react',
             ...(['PORT', 'TESTCAFE_PORT'].flatMap(envVar => process.env[envVar] ? ['-e', `${envVar}=${process.env[envVar]}`] : [])),
             imageName,

--- a/react/test/scripts/run-e2e-tests-docker.ts
+++ b/react/test/scripts/run-e2e-tests-docker.ts
@@ -20,10 +20,8 @@ export async function runE2eTestsDocker(args: string[], hostArch: boolean): Prom
             '--network', 'host',
             ...process.stdout.isTTY ? ['-it'] : [],
             '-v', `${repoRoot}:/urbanstats`,
-            // A tmpfs purely as a way to leave an empty directory here. Otherwise react/node_modules
-            // is the host's, built for the host's platform, and Node finds it long before it
-            // consults NODE_PATH. With nothing in it, the resolution walk falls through to
-            // /node_modules, which is the install that matches the container.
+            // Empty, so that resolution falls past the host's install to /node_modules, which is
+            // built for the container.
             '--mount', 'type=tmpfs,dst=/urbanstats/react/node_modules',
             '-w', '/urbanstats/react',
             ...(['PORT', 'TESTCAFE_PORT'].flatMap(envVar => process.env[envVar] ? ['-e', `${envVar}=${process.env[envVar]}`] : [])),


### PR DESCRIPTION
A `--docker` run resolves every package from the host's `react/node_modules`, not from the install the container builds for itself. The bind mount puts that directory in Node's resolution walk several levels before `NODE_PATH` is consulted, so `require.resolve('testcafe')` inside the container answers `/urbanstats/react/node_modules/...`. testcafe survives this only because it ships every platform's helper binaries in one package.

Anything with per-platform optional dependencies does not survive it. Starting the embed Worker inside the container fails with `Cannot start service: Host version "0.28.1" does not match binary version "0.25.5"` — wrangler's esbuild JS came from the macOS tree and found a Linux binary through `NODE_PATH`.

The fix is to make the directory empty rather than to work around it at each call site. A tmpfs over `react/node_modules` lets the resolution walk fall through to `/node_modules`, which is where the Dockerfile already installs, and for the stated reason of not conflicting with the mount. `PATH` carries that install's binaries so scripts started inside the container — `npx wrangler` in `og-worker/preview.sh`, for one — reach them too.

Verified in the container on `linux/amd64`: `require.resolve` now answers `/node_modules/...`, and `checkbox_bug` passes with `--compare=true`, so rendering is unchanged. On the branch where the embed Worker test lives, that test also passes with `--compare=true` and needs no special handling of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)