### PR TITLE
Treat react/package-lock.json as a binary file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 react/src/data/** linguist-vendored
 react/package-lock.json linguist-vendored
 react/src/utils/protos.js linguist-vendored
+react/package-lock.json -diff


### PR DESCRIPTION
Prevents it from distorting line counts