### PR TITLE
Optimize consolidated shape loading

### DIFF
--- a/react/src/consolidated-shapes.ts
+++ b/react/src/consolidated-shapes.ts
@@ -3,8 +3,7 @@
  *
  * Decoding the file through protobufjs costs ~130 MiB on the largest geography, because the schema
  * makes every coordinate its own message and so its own object. This walks the message instead,
- * noting where each shape's bytes start and decoding only the ones the universe holds, straight into
- * the GeoJSON its callers want.
+ * noting where each shape's bytes start and decoding only the ones the universe holds.
  */
 import Pbf from 'pbf'
 
@@ -132,7 +131,7 @@ function readUniverses(pbf: Pbf, end: number): number[] {
     return idxs
 }
 
-/** The geometry of every shape in the file that the universe contains, by longname. */
+/** Keyed by longname. */
 export function shapesInUniverse(shapeFile: Uint8Array, universeIdx: number): Map<string, GeoJSON.Geometry> {
     const pbf = new Pbf(shapeFile)
     const longnames: string[] = []

--- a/react/src/consolidated-shapes.ts
+++ b/react/src/consolidated-shapes.ts
@@ -1,0 +1,172 @@
+/*
+ * Reads a consolidated shape file into the geometries one universe contains.
+ *
+ * Decoding the file through protobufjs costs ~130 MiB on the largest geography, because the schema
+ * makes every coordinate its own message and so its own object. This walks the message instead,
+ * noting where each shape's bytes start and decoding only the ones the universe holds, straight into
+ * the GeoJSON its callers want.
+ */
+import Pbf from 'pbf'
+
+interface Span {
+    start: number
+    end: number
+}
+
+function span(pbf: Pbf): Span {
+    const length = pbf.readVarint()
+    const start = pbf.pos
+    return { start, end: start + length }
+}
+
+function readCoordinate(pbf: Pbf, end: number): GeoJSON.Position {
+    let lon = 0
+    let lat = 0
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint()
+        switch (tag >> 3) {
+            case 1:
+                lon = pbf.readFloat()
+                break
+            case 2:
+                lat = pbf.readFloat()
+                break
+            default:
+                pbf.skip(tag)
+        }
+    }
+    return [lon, lat]
+}
+
+function readRing(pbf: Pbf, end: number): GeoJSON.Position[] {
+    const ring: GeoJSON.Position[] = []
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint()
+        if (tag >> 3 === 1) {
+            const coordinate = span(pbf)
+            ring.push(readCoordinate(pbf, coordinate.end))
+            pbf.pos = coordinate.end
+        }
+        else {
+            pbf.skip(tag)
+        }
+    }
+    return ring
+}
+
+function readPolygon(pbf: Pbf, end: number): GeoJSON.Position[][] {
+    const rings: GeoJSON.Position[][] = []
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint()
+        if (tag >> 3 === 1) {
+            const ring = span(pbf)
+            rings.push(readRing(pbf, ring.end))
+            pbf.pos = ring.end
+        }
+        else {
+            pbf.skip(tag)
+        }
+    }
+    return rings
+}
+
+function readMultiPolygon(pbf: Pbf, end: number): GeoJSON.Position[][][] {
+    const polygons: GeoJSON.Position[][][] = []
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint()
+        if (tag >> 3 === 1) {
+            const polygon = span(pbf)
+            polygons.push(readPolygon(pbf, polygon.end))
+            pbf.pos = polygon.end
+        }
+        else {
+            pbf.skip(tag)
+        }
+    }
+    return polygons
+}
+
+/** A shape with neither geometry field set reads as an empty polygon, as protobufjs's would. */
+function readFeature(pbf: Pbf, feature: Span): GeoJSON.Geometry {
+    let geometry: GeoJSON.Geometry = { type: 'Polygon', coordinates: [] }
+    pbf.pos = feature.start
+    while (pbf.pos < feature.end) {
+        const tag = pbf.readVarint()
+        switch (tag >> 3) {
+            case 1: {
+                const polygon = span(pbf)
+                geometry = { type: 'Polygon', coordinates: readPolygon(pbf, polygon.end) }
+                pbf.pos = polygon.end
+                break
+            }
+            case 2: {
+                const multipolygon = span(pbf)
+                geometry = { type: 'MultiPolygon', coordinates: readMultiPolygon(pbf, multipolygon.end) }
+                pbf.pos = multipolygon.end
+                break
+            }
+            default:
+                pbf.skip(tag)
+        }
+    }
+    return geometry
+}
+
+function readUniverses(pbf: Pbf, end: number): number[] {
+    const idxs: number[] = []
+    while (pbf.pos < end) {
+        const tag = pbf.readVarint()
+        if (tag >> 3 !== 1) {
+            pbf.skip(tag)
+        }
+        else if ((tag & 7) === 2) {
+            const packed = span(pbf)
+            while (pbf.pos < packed.end) {
+                idxs.push(pbf.readVarint())
+            }
+        }
+        else {
+            idxs.push(pbf.readVarint())
+        }
+    }
+    return idxs
+}
+
+/** The geometry of every shape in the file that the universe contains, by longname. */
+export function shapesInUniverse(shapeFile: Uint8Array, universeIdx: number): Map<string, GeoJSON.Geometry> {
+    const pbf = new Pbf(shapeFile)
+    const longnames: string[] = []
+    const universes: number[][] = []
+    const shapes: Span[] = []
+
+    while (pbf.pos < pbf.length) {
+        const tag = pbf.readVarint()
+        switch (tag >> 3) {
+            case 1:
+                longnames.push(pbf.readString())
+                break
+            case 2: {
+                const shape = span(pbf)
+                shapes.push(shape)
+                pbf.pos = shape.end
+                break
+            }
+            case 3: {
+                const universe = span(pbf)
+                universes.push(readUniverses(pbf, universe.end))
+                pbf.pos = universe.end
+                break
+            }
+            default:
+                pbf.skip(tag)
+        }
+    }
+
+    const geometries = new Map<string, GeoJSON.Geometry>()
+    for (let i = 0; i < longnames.length; i++) {
+        if (universes[i].includes(universeIdx)) {
+            geometries.set(longnames[i], readFeature(pbf, shapes[i]))
+        }
+    }
+    return geometries
+}

--- a/react/src/consolidated-shapes.ts
+++ b/react/src/consolidated-shapes.ts
@@ -3,131 +3,74 @@
  *
  * Decoding the file through protobufjs costs ~130 MiB on the largest geography, because the schema
  * makes every coordinate its own message and so its own object. This walks the message instead,
- * noting where each shape's bytes start and decoding only the ones the universe holds.
+ * noting where each shape's bytes start and decoding only the ones the universe holds. The field
+ * numbers here are the ones in data_files.proto.
  */
 import Pbf from 'pbf'
 
-interface Span {
-    start: number
-    end: number
+/** pbf's own readFloat goes through an ieee754 polyfill, which costs about a third of a decode. */
+const float = new Float32Array(1)
+const bits = new Uint32Array(float.buffer)
+
+function readFloat(pbf: Pbf): number {
+    bits[0] = pbf.readFixed32()
+    return float[0]
 }
 
-function span(pbf: Pbf): Span {
-    const length = pbf.readVarint()
-    const start = pbf.pos
-    return { start, end: start + length }
-}
-
-function readCoordinate(pbf: Pbf, end: number): GeoJSON.Position {
-    let lon = 0
-    let lat = 0
-    while (pbf.pos < end) {
-        const tag = pbf.readVarint()
-        switch (tag >> 3) {
+function readCoordinate(pbf: Pbf): GeoJSON.Position {
+    const coordinate: GeoJSON.Position = [0, 0]
+    pbf.readMessage((tag) => {
+        switch (tag) {
             case 1:
-                lon = pbf.readFloat()
+                coordinate[0] = readFloat(pbf)
                 break
             case 2:
-                lat = pbf.readFloat()
+                coordinate[1] = readFloat(pbf)
                 break
-            default:
-                pbf.skip(tag)
         }
-    }
-    return [lon, lat]
+    })
+    return coordinate
 }
 
-function readRing(pbf: Pbf, end: number): GeoJSON.Position[] {
-    const ring: GeoJSON.Position[] = []
-    while (pbf.pos < end) {
-        const tag = pbf.readVarint()
-        if (tag >> 3 === 1) {
-            const coordinate = span(pbf)
-            ring.push(readCoordinate(pbf, coordinate.end))
-            pbf.pos = coordinate.end
+/** Ring, Polygon and MultiPolygon are each a message holding one repeated field 1. */
+function repeated<T>(pbf: Pbf, readItem: (pbf: Pbf) => T): T[] {
+    const items: T[] = []
+    pbf.readMessage((tag) => {
+        if (tag === 1) {
+            items.push(readItem(pbf))
         }
-        else {
-            pbf.skip(tag)
-        }
-    }
-    return ring
+    })
+    return items
 }
 
-function readPolygon(pbf: Pbf, end: number): GeoJSON.Position[][] {
-    const rings: GeoJSON.Position[][] = []
-    while (pbf.pos < end) {
-        const tag = pbf.readVarint()
-        if (tag >> 3 === 1) {
-            const ring = span(pbf)
-            rings.push(readRing(pbf, ring.end))
-            pbf.pos = ring.end
-        }
-        else {
-            pbf.skip(tag)
-        }
-    }
-    return rings
-}
-
-function readMultiPolygon(pbf: Pbf, end: number): GeoJSON.Position[][][] {
-    const polygons: GeoJSON.Position[][][] = []
-    while (pbf.pos < end) {
-        const tag = pbf.readVarint()
-        if (tag >> 3 === 1) {
-            const polygon = span(pbf)
-            polygons.push(readPolygon(pbf, polygon.end))
-            pbf.pos = polygon.end
-        }
-        else {
-            pbf.skip(tag)
-        }
-    }
-    return polygons
-}
+const readRing = (pbf: Pbf): GeoJSON.Position[] => repeated(pbf, readCoordinate)
+const readPolygon = (pbf: Pbf): GeoJSON.Position[][] => repeated(pbf, readRing)
+const readMultiPolygon = (pbf: Pbf): GeoJSON.Position[][][] => repeated(pbf, readPolygon)
 
 /** A shape with neither geometry field set reads as an empty polygon, as protobufjs's would. */
-function readFeature(pbf: Pbf, feature: Span): GeoJSON.Geometry {
+function readFeature(pbf: Pbf, start: number): GeoJSON.Geometry {
     let geometry: GeoJSON.Geometry = { type: 'Polygon', coordinates: [] }
-    pbf.pos = feature.start
-    while (pbf.pos < feature.end) {
-        const tag = pbf.readVarint()
-        switch (tag >> 3) {
-            case 1: {
-                const polygon = span(pbf)
-                geometry = { type: 'Polygon', coordinates: readPolygon(pbf, polygon.end) }
-                pbf.pos = polygon.end
+    pbf.pos = start
+    pbf.readMessage((tag) => {
+        switch (tag) {
+            case 1:
+                geometry = { type: 'Polygon', coordinates: readPolygon(pbf) }
                 break
-            }
-            case 2: {
-                const multipolygon = span(pbf)
-                geometry = { type: 'MultiPolygon', coordinates: readMultiPolygon(pbf, multipolygon.end) }
-                pbf.pos = multipolygon.end
+            case 2:
+                geometry = { type: 'MultiPolygon', coordinates: readMultiPolygon(pbf) }
                 break
-            }
-            default:
-                pbf.skip(tag)
         }
-    }
+    })
     return geometry
 }
 
-function readUniverses(pbf: Pbf, end: number): number[] {
+function readUniverses(pbf: Pbf): number[] {
     const idxs: number[] = []
-    while (pbf.pos < end) {
-        const tag = pbf.readVarint()
-        if (tag >> 3 !== 1) {
-            pbf.skip(tag)
+    pbf.readMessage((tag) => {
+        if (tag === 1) {
+            pbf.readPackedVarint(idxs)
         }
-        else if ((tag & 7) === 2) {
-            const packed = span(pbf)
-            while (pbf.pos < packed.end) {
-                idxs.push(pbf.readVarint())
-            }
-        }
-        else {
-            idxs.push(pbf.readVarint())
-        }
-    }
+    })
     return idxs
 }
 
@@ -136,35 +79,27 @@ export function shapesInUniverse(shapeFile: Uint8Array, universeIdx: number): Ma
     const pbf = new Pbf(shapeFile)
     const longnames: string[] = []
     const universes: number[][] = []
-    const shapes: Span[] = []
+    const shapeStarts: number[] = []
 
-    while (pbf.pos < pbf.length) {
-        const tag = pbf.readVarint()
-        switch (tag >> 3) {
+    pbf.readFields((tag) => {
+        switch (tag) {
             case 1:
                 longnames.push(pbf.readString())
                 break
-            case 2: {
-                const shape = span(pbf)
-                shapes.push(shape)
-                pbf.pos = shape.end
+            case 2:
+                // leaving pos on the length varint both records the shape and makes readFields skip it
+                shapeStarts.push(pbf.pos)
                 break
-            }
-            case 3: {
-                const universe = span(pbf)
-                universes.push(readUniverses(pbf, universe.end))
-                pbf.pos = universe.end
+            case 3:
+                universes.push(readUniverses(pbf))
                 break
-            }
-            default:
-                pbf.skip(tag)
         }
-    }
+    })
 
     const geometries = new Map<string, GeoJSON.Geometry>()
     for (let i = 0; i < longnames.length; i++) {
         if (universes[i].includes(universeIdx)) {
-            geometries.set(longnames[i], readFeature(pbf, shapes[i]))
+            geometries.set(longnames[i], readFeature(pbf, shapeStarts[i]))
         }
     }
     return geometries

--- a/react/src/load_json.ts
+++ b/react/src/load_json.ts
@@ -38,6 +38,18 @@ export async function loadJSON(filePath: string): Promise<unknown> {
     return response.json()
 }
 
+/** The bytes of one of the site's data files, which are all gzipped protobuf. */
+export async function loadGzipped(filePath: string, errorOnMissing: boolean = true): Promise<Uint8Array | undefined> {
+    const response = await fetch(filePath)
+    if (response.status < 200 || response.status > 299) {
+        if (!errorOnMissing) {
+            return undefined
+        }
+        throw new Error(`Expected response status 2xx for ${filePath}, got ${response.status}: ${response.statusText}`)
+    }
+    return new Uint8Array(gunzipSync(Buffer.from(await response.arrayBuffer())))
+}
+
 // Load a protobuf file from the server
 export async function loadProtobuf(filePath: string, name: 'Article', errorOnMissing: boolean): Promise<Article | undefined>
 export async function loadProtobuf(filePath: string, name: 'Feature', errorOnMissing: boolean): Promise<Feature>
@@ -61,26 +73,13 @@ export async function loadProtobuf(filePath: string, name: 'ShardIndex'): Promis
 export async function loadProtobuf(filePath: string, name: string, errorOnMissing: boolean = true): Promise<Article | Feature | ArticleOrderingList | OrderLists | DataLists | CongressionalRepresentativeTable | ConsolidatedShapes | ConsolidatedArticles | SearchIndex | QuizQuestionTronche | QuizFullData | CountsByArticleUniverseAndType | Symlinks | PointSeries | ArticleUniverseList | DefaultUniverseTable | ShardIndex | undefined> {
     let perfCheckpoint = performance.now()
 
-    const response = await fetch(filePath)
-    if (response.status < 200 || response.status > 299) {
-        if (!errorOnMissing) {
-            return undefined
-        }
-        throw new Error(`Expected response status 2xx for ${filePath}, got ${response.status}: ${response.statusText}`)
+    const arr = await loadGzipped(filePath, errorOnMissing)
+    if (arr === undefined) {
+        return undefined
     }
 
-    const compressedBuffer = await response.arrayBuffer()
-
     if (name === 'SearchIndex') {
-        debugPerformance(`Took ${performance.now() - perfCheckpoint}ms networking to load search index`)
-    }
-    perfCheckpoint = performance.now()
-
-    const buffer = gunzipSync(Buffer.from(compressedBuffer))
-    const arr = new Uint8Array(buffer)
-
-    if (name === 'SearchIndex') {
-        debugPerformance(`Took ${performance.now() - perfCheckpoint}ms to decompress search index`)
+        debugPerformance(`Took ${performance.now() - perfCheckpoint}ms to fetch and decompress search index`)
     }
     perfCheckpoint = performance.now()
 

--- a/react/src/load_json.ts
+++ b/react/src/load_json.ts
@@ -38,7 +38,9 @@ export async function loadJSON(filePath: string): Promise<unknown> {
     return response.json()
 }
 
-/** The still-encoded protobuf bytes of a data file. Undefined if it is missing and !errorOnMissing. */
+/** The still-encoded protobuf bytes of a data file. */
+export async function loadGzipped(filePath: string): Promise<Uint8Array>
+export async function loadGzipped(filePath: string, errorOnMissing: boolean): Promise<Uint8Array | undefined>
 export async function loadGzipped(filePath: string, errorOnMissing: boolean = true): Promise<Uint8Array | undefined> {
     const response = await fetch(filePath)
     if (response.status < 200 || response.status > 299) {
@@ -47,7 +49,7 @@ export async function loadGzipped(filePath: string, errorOnMissing: boolean = tr
         }
         throw new Error(`Expected response status 2xx for ${filePath}, got ${response.status}: ${response.statusText}`)
     }
-    return new Uint8Array(gunzipSync(Buffer.from(await response.arrayBuffer())))
+    return gunzipSync(Buffer.from(await response.arrayBuffer()))
 }
 
 // Load a protobuf file from the server

--- a/react/src/load_json.ts
+++ b/react/src/load_json.ts
@@ -38,7 +38,7 @@ export async function loadJSON(filePath: string): Promise<unknown> {
     return response.json()
 }
 
-/** The bytes of one of the site's data files, which are all gzipped protobuf. */
+/** The still-encoded protobuf bytes of a data file. Undefined if it is missing and !errorOnMissing. */
 export async function loadGzipped(filePath: string, errorOnMissing: boolean = true): Promise<Uint8Array | undefined> {
     const response = await fetch(filePath)
     if (response.status < 200 || response.status > 299) {

--- a/react/src/mapper/map-generator.tsx
+++ b/react/src/mapper/map-generator.tsx
@@ -5,10 +5,11 @@ import { MapInstance, MapRef } from 'react-map-gl/maplibre'
 import { CSVExportData, generateMapperCSVData } from '../components/csv-export'
 import { Basemap as BasemapComponent, CommonMaplibreMap, PointFeatureCollection, Polygon, PolygonFeatureCollection } from '../components/map-common'
 import { screencapElement, ScreenshotContext, ScreenshotContextType, withScreenshotMode } from '../components/screenshot'
+import { shapesInUniverse } from '../consolidated-shapes'
 import valid_geographies from '../data/mapper/used_geographies'
 import universes_ordered from '../data/universes_ordered'
-import { loadProtobuf } from '../load_json'
-import { boundingBox, geometry } from '../map-partition'
+import { loadGzipped, loadProtobuf } from '../load_json'
+import { boundingBox } from '../map-partition'
 import { consolidatedShapeLink, indexLink } from '../navigation/links'
 import { RelativeLoader } from '../navigation/loading'
 import { Colors, colorThemes } from '../page_template/color-themes'
@@ -34,8 +35,7 @@ import { furthestColor, interpolateColor } from '../utils/color'
 import { computeAspectRatioForInsets } from '../utils/coordinates'
 import { makeDebugLogger } from '../utils/debug-logging'
 import { HumanReadableName } from '../utils/human-readable-name'
-import { ConsolidatedShapes, Feature, ICoordinate } from '../utils/protos'
-import { NormalizeProto } from '../utils/types'
+import { ICoordinate } from '../utils/protos'
 import { useDebouncedResolve } from '../utils/useDebouncedResolve'
 
 import { Colorbar, RampToDisplay, styleFromBasemap } from './components/Colorbar'
@@ -705,19 +705,14 @@ async function pointsGeojson(geographyKind: typeof valid_geographies[number], un
 
 async function polygonsGeojson(geographyKind: typeof valid_geographies[number], universe: Universe, polygons: Polygon[], cache: MapCache): Promise<GeoJSON.Feature[]> {
     if (cache.geo?.type !== 'polygons' || cache.geo.universe !== universe || cache.geo.geographyKind !== geographyKind) {
-        const universeIdx = universes_ordered.indexOf(universe)
-        const shapes = (await loadProtobuf(consolidatedShapeLink(geographyKind), 'ConsolidatedShapes')) as NormalizeProto<ConsolidatedShapes>
-        const polygonsByName = new Map<string, GeoJSON.Geometry>()
-        for (let i = 0; i < shapes.longnames.length; i++) {
-            if (shapes.universes[i].universeIdxs.includes(universeIdx)) {
-                polygonsByName.set(shapes.longnames[i], geometry(shapes.shapes[i] as NormalizeProto<Feature>))
-            }
-        }
         cache.geo = {
             type: 'polygons',
             universe,
             geographyKind,
-            polygonsByName,
+            polygonsByName: shapesInUniverse(
+                (await loadGzipped(consolidatedShapeLink(geographyKind)))!,
+                universes_ordered.indexOf(universe),
+            ),
         }
     }
 

--- a/react/src/mapper/map-generator.tsx
+++ b/react/src/mapper/map-generator.tsx
@@ -710,7 +710,7 @@ async function polygonsGeojson(geographyKind: typeof valid_geographies[number], 
             universe,
             geographyKind,
             polygonsByName: shapesInUniverse(
-                (await loadGzipped(consolidatedShapeLink(geographyKind)))!,
+                await loadGzipped(consolidatedShapeLink(geographyKind)),
                 universes_ordered.indexOf(universe),
             ),
         }

--- a/react/unit/consolidated-shapes.test.ts
+++ b/react/unit/consolidated-shapes.test.ts
@@ -1,0 +1,42 @@
+import assert from 'assert/strict'
+import { test } from 'node:test'
+
+import { shapesInUniverse } from '../src/consolidated-shapes'
+import universes_ordered from '../src/data/universes_ordered'
+import { loadGzipped, loadProtobuf } from '../src/load_json'
+import { geometry } from '../src/map-partition'
+import { consolidatedShapeLink } from '../src/navigation/links'
+import { Feature } from '../src/utils/protos'
+import { NormalizeProto } from '../src/utils/types'
+
+import './util/fetch'
+
+/*
+ * The reader walks the message rather than decoding it, so what keeps it honest is agreeing with
+ * protobufjs on the same file, shape for shape and coordinate for coordinate.
+ */
+async function checkAgainstProtobuf(geographyKind: string, universe: string): Promise<number> {
+    const universeIdx = universes_ordered.indexOf(universe as typeof universes_ordered[number])
+    const lean = shapesInUniverse((await loadGzipped(consolidatedShapeLink(geographyKind)))!, universeIdx)
+    const whole = await loadProtobuf(consolidatedShapeLink(geographyKind), 'ConsolidatedShapes')
+
+    const expected = new Map<string, GeoJSON.Geometry>()
+    for (let i = 0; i < whole.longnames.length; i++) {
+        if (whole.universes[i].universeIdxs!.includes(universeIdx)) {
+            expected.set(whole.longnames[i], geometry(whole.shapes[i] as NormalizeProto<Feature>))
+        }
+    }
+
+    assert.deepEqual([...lean.keys()].sort(), [...expected.keys()].sort())
+    for (const [longname, shape] of expected) {
+        assert.deepEqual(lean.get(longname), shape, longname)
+    }
+    return expected.size
+}
+
+void test('shapes-in-universe-matches-protobufjs', async () => {
+    // Subnational Region is the largest file and the one whose decode cost this avoids; Urban Center
+    // is a smaller file whose universe holds a different slice of it.
+    assert.ok(await checkAgainstProtobuf('Subnational Region', 'USA') > 0)
+    assert.ok(await checkAgainstProtobuf('Urban Center', 'world') > 0)
+})

--- a/react/unit/consolidated-shapes.test.ts
+++ b/react/unit/consolidated-shapes.test.ts
@@ -11,9 +11,9 @@ import { NormalizeProto } from '../src/utils/types'
 
 import './util/fetch'
 
-async function checkAgainstProtobuf(geographyKind: string, universe: string): Promise<number> {
+async function checkAgainstProtobuf(geographyKind: string, universe: string): Promise<void> {
     const universeIdx = universes_ordered.indexOf(universe as typeof universes_ordered[number])
-    const lean = shapesInUniverse((await loadGzipped(consolidatedShapeLink(geographyKind)))!, universeIdx)
+    const lean = shapesInUniverse(await loadGzipped(consolidatedShapeLink(geographyKind)), universeIdx)
     const whole = await loadProtobuf(consolidatedShapeLink(geographyKind), 'ConsolidatedShapes')
 
     const expected = new Map<string, GeoJSON.Geometry>()
@@ -23,16 +23,16 @@ async function checkAgainstProtobuf(geographyKind: string, universe: string): Pr
         }
     }
 
+    assert.ok(expected.size > 0)
     assert.deepEqual([...lean.keys()].sort(), [...expected.keys()].sort())
     for (const [longname, shape] of expected) {
         assert.deepEqual(lean.get(longname), shape, longname)
     }
-    return expected.size
 }
 
 void test('shapes-in-universe-matches-protobufjs', async () => {
     // Subnational Region is the largest file and the one whose decode cost this avoids; Urban Center
     // is a smaller file whose universe holds a different slice of it.
-    assert.ok(await checkAgainstProtobuf('Subnational Region', 'USA') > 0)
-    assert.ok(await checkAgainstProtobuf('Urban Center', 'world') > 0)
+    await checkAgainstProtobuf('Subnational Region', 'USA')
+    await checkAgainstProtobuf('Urban Center', 'world')
 })

--- a/react/unit/consolidated-shapes.test.ts
+++ b/react/unit/consolidated-shapes.test.ts
@@ -11,10 +11,6 @@ import { NormalizeProto } from '../src/utils/types'
 
 import './util/fetch'
 
-/*
- * The reader walks the message rather than decoding it, so what keeps it honest is agreeing with
- * protobufjs on the same file, shape for shape and coordinate for coordinate.
- */
 async function checkAgainstProtobuf(geographyKind: string, universe: string): Promise<number> {
     const universeIdx = universes_ordered.indexOf(universe as typeof universes_ordered[number])
     const lean = shapesInUniverse((await loadGzipped(consolidatedShapeLink(geographyKind)))!, universeIdx)


### PR DESCRIPTION
Write our own reader for loading consolidated shapes that is more efficient than naive protobuf, and filters out shapes that are not part of the target universe

```
Subnational Region/USA: 56/3651 shapes
  lean 11ms 6MB   protobufjs 202ms 133MB
County/USA: 3222/3222 shapes
  lean 34ms 27MB   protobufjs 46ms 56MB
City/USA: 32132/32132 shapes
  lean 61ms 57MB   protobufjs 110ms 
```