### PR TITLE
Write the quantities that have a fixed unit through one function

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 
 import { HueColors } from '../page_template/color-themes'
 import { useColors } from '../page_template/colors'
+import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
 import { abbreviate, formatToSignificantFigures, roundToDigits, separateNumber } from '../utils/text'
 import { convertPrecipitation, convertTemperature, UnitType } from '../utils/unit'
 
@@ -57,46 +58,43 @@ interface ReaderSettings {
 
 interface Written {
     number: string
-    unit: ReactNode
+    unit: HumanReadableElement[]
 }
 
-const blank = <span>&nbsp;</span>
-const percentSign = <span>%</span>
+/** No unit, for the quantities that are just a count, and for the ones we do not have. */
+const blank: HumanReadableElement[] = []
+
+function atom(value: string): HumanReadableElement[] {
+    return [{ type: 'atom', value }]
+}
+
+function raised(name: string, power: string): HumanReadableElement[] {
+    return [{ type: 'atom', value: name }, { type: 'superscript', value: atom(power) }]
+}
+
+const percentSign = atom('%')
+
+/** A unit with no name still occupies its column, which is set against the values above it. */
+function unitColumn(name: HumanReadableElement[]): ReactNode {
+    return <span>{name.length === 0 ? '\u00a0' : reifyReact(name)}</span>
+}
 
 function display(write: (value: number, settings: ReaderSettings) => Written, inequality = renderInequality): UnitDisplay {
     return {
         renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
             if (!isFinite(value)) {
-                return { value: <span>{missing}</span>, unit: blank }
+                return { value: <span>{missing}</span>, unit: unitColumn(blank) }
             }
             const { number, unit } = write(value, { useImperial: useImperial ?? false, temperatureUnit: temperatureUnit ?? 'fahrenheit' })
-            return { value: <span>{number}</span>, unit }
+            return { value: <span>{number}</span>, unit: unitColumn(unit) }
         },
         renderInequality: inequality,
     }
 }
 
-function squared(name: string): ReactNode {
-    return (
-        <span>
-            {name}
-            <sup>2</sup>
-        </span>
-    )
-}
-
 /** A solidus with a numerator in front of it is set tight; one without gets a space. */
 function per(name: string): string {
     return `/\u00a0${name}`
-}
-
-function perSquared(name: string): ReactNode {
-    return (
-        <span>
-            {per(name)}
-            <sup>2</sup>
-        </span>
-    )
 }
 
 /** Durations read as hours and minutes, or as minutes alone where there are no hours. */
@@ -106,9 +104,9 @@ function hoursAndMinutes(hours: number): Written {
     const wholeHours = Math.floor(totalMinutes / 60)
     const minutes = totalMinutes % 60
     if (wholeHours === 0) {
-        return { number: `${sign}${minutes}`, unit: <span>min</span> }
+        return { number: `${sign}${minutes}`, unit: atom('min') }
     }
-    return { number: `${sign}${wholeHours}:${minutes.toString().padStart(2, '0')}`, unit: <span>h</span> }
+    return { number: `${sign}${wholeHours}:${minutes.toString().padStart(2, '0')}`, unit: atom('h') }
 }
 
 function percentage(value: number): string {
@@ -149,10 +147,10 @@ function PartyPercentage({ value, emphasis }: { value: number, emphasis: PartyNu
 function partyDisplay(emphasis: PartyNumberStyling): UnitDisplay {
     return {
         renderValue: (value: number) => !isFinite(value)
-            ? { value: <span>{missing}</span>, unit: blank }
+            ? { value: <span>{missing}</span>, unit: unitColumn(blank) }
             : {
                     value: <PartyPercentage value={value} emphasis={emphasis} />,
-                    unit: percentSign,
+                    unit: unitColumn(percentSign),
                 },
         renderInequality: emphasis.kind === 'lead' ? renderMarginInequality : renderInequality,
     }
@@ -199,51 +197,51 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'fatalitiesPerCapita':
             return display(value => ({
                 number: separateNumber((perHundredThousand * value).toFixed(2)),
-                unit: <span>{per('100k')}</span>,
+                unit: atom(per('100k')),
             }))
         case 'density':
             return display((value, { useImperial }) => ({
                 number: roundToDigits(useImperial ? value * squareKmPerSquareMile : value, { significantDigits: 2 }),
-                unit: perSquared(useImperial ? 'mi' : 'km'),
+                unit: raised(per(useImperial ? 'mi' : 'km'), '2'),
             }))
         case 'population':
             return display((value) => {
                 const { number, suffix } = abbreviate(value)
-                return { number, unit: suffix === '' ? blank : <span>{suffix}</span> }
+                return { number, unit: suffix === '' ? blank : atom(suffix) }
             })
         case 'usd':
             return display((value) => {
                 const { number, suffix } = abbreviate(value)
-                return { number: `$${number}`, unit: suffix === '' ? blank : <span>{suffix}</span> }
+                return { number: `$${number}`, unit: suffix === '' ? blank : atom(suffix) }
             })
         case 'area':
             return display((value, { useImperial }) => {
                 if (useImperial) {
                     const squareMiles = value / squareKmPerSquareMile
                     if (Math.abs(squareMiles) < 1) {
-                        return { number: roundToDigits(squareMiles * acresPerSquareMile, { significantDigits: 3 }), unit: <span>acres</span> }
+                        return { number: roundToDigits(squareMiles * acresPerSquareMile, { significantDigits: 3 }), unit: atom('acres') }
                     }
-                    return { number: roundToDigits(squareMiles, { significantDigits: 3 }), unit: squared('mi') }
+                    return { number: roundToDigits(squareMiles, { significantDigits: 3 }), unit: raised('mi', '2') }
                 }
                 if (Math.abs(value) < 0.01) {
-                    return { number: roundToDigits(value * squareMetersPerSquareKm, { significantDigits: 3 }), unit: squared('m') }
+                    return { number: roundToDigits(value * squareMetersPerSquareKm, { significantDigits: 3 }), unit: raised('m', '2') }
                 }
-                return { number: roundToDigits(value, { significantDigits: 3 }), unit: squared('km') }
+                return { number: roundToDigits(value, { significantDigits: 3 }), unit: raised('km', '2') }
             })
         case 'distanceInKm':
             return display((value, { useImperial }) => ({
                 number: separateNumber((useImperial ? value / kmPerMile : value).toFixed(2)),
-                unit: <span>{useImperial ? 'mi' : 'km'}</span>,
+                unit: atom(useImperial ? 'mi' : 'km'),
             }))
         case 'distanceInM':
             return display((value, { useImperial }) => ({
                 number: separateNumber((useImperial ? value * feetPerMeter : value).toFixed(0)),
-                unit: <span>{useImperial ? 'ft' : 'm'}</span>,
+                unit: atom(useImperial ? 'ft' : 'm'),
             }))
         case 'temperature':
             return display((value, { temperatureUnit }) => {
                 const converted = convertTemperature(value, temperatureUnit)
-                return { number: separateNumber(converted.value.toFixed(1)), unit: <span>{converted.unit}</span> }
+                return { number: separateNumber(converted.value.toFixed(1)), unit: atom(converted.unit) }
             })
         case 'time':
             return display(value => hoursAndMinutes(value))
@@ -254,18 +252,13 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                 const converted = convertPrecipitation(value, useImperial)
                 return {
                     number: separateNumber(converted.value.toFixed(1)),
-                    unit: <span>{`${converted.unit}/yr`}</span>,
+                    unit: atom(`${converted.unit}/yr`),
                 }
             })
         case 'contaminantLevel':
             return display(value => ({
                 number: separateNumber(value.toFixed(2)),
-                unit: (
-                    <span>
-                        &mu;g/m
-                        <sup>3</sup>
-                    </span>
-                ),
+                unit: raised('\u03bcg/m', '3'),
             }))
         case 'number':
             return display(value => ({ number: separateNumber(formatToSignificantFigures(value, 3)), unit: blank }))

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -93,14 +93,13 @@ function InParty({ number, hue }: { number: string, hue: Hue }): ReactNode {
     return <span style={spanStyle}>{number}</span>
 }
 
-/** The unit types that writeQuantity writes, rather than an arm of their own. */
 function quantity(stored: StoredUnit): UnitDisplay {
     return {
         renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-            const { number, name, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
+            const { number, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
             return {
                 value: hue === undefined ? <span>{number}</span> : <InParty number={number} hue={hue} />,
-                unit: unitColumn(name),
+                unit: unitColumn(unitName),
             }
         },
     }

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -61,8 +61,7 @@ interface Written {
     unit: HumanReadableElement[]
 }
 
-/** No unit, for the quantities that are just a count, and for the ones we do not have. */
-const blank: HumanReadableElement[] = []
+const unitlessDisplay: HumanReadableElement[] = []
 
 function atom(value: string): HumanReadableElement[] {
     return [{ type: 'atom', value }]
@@ -74,16 +73,15 @@ function raised(name: string, power: string): HumanReadableElement[] {
 
 const percentSign = atom('%')
 
-/** A unit with no name still occupies its column, which is set against the values above it. */
 function unitColumn(name: HumanReadableElement[]): ReactNode {
-    return <span>{name.length === 0 ? '\u00a0' : reifyReact(name)}</span>
+    return <span>{name.length === 0 ? <>&nbsp;</> : reifyReact(name)}</span>
 }
 
 function display(write: (value: number, settings: ReaderSettings) => Written, inequality = renderInequality): UnitDisplay {
     return {
         renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
             if (!isFinite(value)) {
-                return { value: <span>{missing}</span>, unit: unitColumn(blank) }
+                return { value: <span>{missing}</span>, unit: unitColumn(unitlessDisplay) }
             }
             const { number, unit } = write(value, { useImperial: useImperial ?? false, temperatureUnit: temperatureUnit ?? 'fahrenheit' })
             return { value: <span>{number}</span>, unit: unitColumn(unit) }
@@ -147,7 +145,7 @@ function PartyPercentage({ value, emphasis }: { value: number, emphasis: PartyNu
 function partyDisplay(emphasis: PartyNumberStyling): UnitDisplay {
     return {
         renderValue: (value: number) => !isFinite(value)
-            ? { value: <span>{missing}</span>, unit: unitColumn(blank) }
+            ? { value: <span>{missing}</span>, unit: unitColumn(unitlessDisplay) }
             : {
                     value: <PartyPercentage value={value} emphasis={emphasis} />,
                     unit: unitColumn(percentSign),
@@ -193,7 +191,7 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'partyChangePurple':
             return partyDisplay({ kind: 'change', hue: 'purple' })
         case 'fatalities':
-            return display(value => ({ number: separateNumber(value.toFixed(0)), unit: blank }))
+            return display(value => ({ number: separateNumber(value.toFixed(0)), unit: unitlessDisplay }))
         case 'fatalitiesPerCapita':
             return display(value => ({
                 number: separateNumber((perHundredThousand * value).toFixed(2)),
@@ -207,12 +205,12 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'population':
             return display((value) => {
                 const { number, suffix } = abbreviate(value)
-                return { number, unit: suffix === '' ? blank : atom(suffix) }
+                return { number, unit: suffix === '' ? unitlessDisplay : atom(suffix) }
             })
         case 'usd':
             return display((value) => {
                 const { number, suffix } = abbreviate(value)
-                return { number: `$${number}`, unit: suffix === '' ? blank : atom(suffix) }
+                return { number: `$${number}`, unit: suffix === '' ? unitlessDisplay : atom(suffix) }
             })
         case 'area':
             return display((value, { useImperial }) => {
@@ -258,10 +256,10 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'contaminantLevel':
             return display(value => ({
                 number: separateNumber(value.toFixed(2)),
-                unit: raised('\u03bcg/m', '3'),
+                unit: raised('μg/m', '3'),
             }))
         case 'number':
-            return display(value => ({ number: separateNumber(formatToSignificantFigures(value, 3)), unit: blank }))
+            return display(value => ({ number: separateNumber(formatToSignificantFigures(value, 3)), unit: unitlessDisplay }))
     }
 }
 /* eslint-enable no-restricted-syntax */

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -87,18 +87,18 @@ function hoursAndMinutes(hours: number): Written {
 }
 
 /** A quantity written in a party's color, set flush right so that a fourth digit overflows left. */
-function InParty({ number, hue }: { number: string, hue: Hue }): ReactNode {
+function InParty({ value, hue }: { value: string, hue: Hue }): ReactNode {
     const colors = useColors()
     const spanStyle: CSSProperties = { color: colors.hueColors[hue], display: 'flex', justifyContent: 'flex-end' }
-    return <span style={spanStyle}>{number}</span>
+    return <span style={spanStyle}>{value}</span>
 }
 
 function quantity(stored: StoredUnit): UnitDisplay {
     return {
         renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-            const { number, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
+            const { renderedValue, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
             return {
-                value: hue === undefined ? <span>{number}</span> : <InParty number={number} hue={hue} />,
+                value: hue === undefined ? <span>{renderedValue}</span> : <InParty value={renderedValue} hue={hue} />,
                 unit: unitColumn(unitName),
             }
         },

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,12 +1,10 @@
 import React, { CSSProperties, ReactNode } from 'react'
 
-import { HueColors } from '../page_template/color-themes'
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
+import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
 import { abbreviate, formatToSignificantFigures, roundToDigits, separateNumber } from '../utils/text'
-import { convertPrecipitation, convertTemperature, UnitType } from '../utils/unit'
-
-type Hue = keyof HueColors
+import { convertPrecipitation, storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
     renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
@@ -28,15 +26,12 @@ export function renderInequality(value: number, unitType: UnitType, inequality: 
     return reads === 'leq' ? '\u2264' /* ≤ */ : '\u2265' /* ≥ */
 }
 
-const missing = 'N/A'
-
 const kmPerMile = 1.60934
 const squareKmPerSquareMile = kmPerMile * kmPerMile
 const acresPerSquareMile = 640
 const feetPerMeter = 3.28084
 const squareMetersPerSquareKm = 1000 * 1000
 const perHundredThousand = 100_000
-const asPercent = 100
 
 interface ReaderSettings {
     useImperial: boolean
@@ -58,8 +53,6 @@ function raised(name: string, power: string): HumanReadableElement[] {
     return [{ type: 'atom', value: name }, { type: 'superscript', value: atom(power) }]
 }
 
-const percentSign = atom('%')
-
 function unitColumn(name: HumanReadableElement[]): ReactNode {
     return <span>{name.length === 0 ? <>&nbsp;</> : reifyReact(name)}</span>
 }
@@ -68,7 +61,7 @@ function display(write: (value: number, settings: ReaderSettings) => Written): U
     return {
         renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
             if (!isFinite(value)) {
-                return { value: <span>{missing}</span>, unit: unitColumn(unitlessDisplay) }
+                return { value: <span>{missingValue}</span>, unit: unitColumn(unitlessDisplay) }
             }
             const { number, unit } = write(value, { useImperial: useImperial ?? false, temperatureUnit: temperatureUnit ?? 'fahrenheit' })
             return { value: <span>{number}</span>, unit: unitColumn(unit) }
@@ -93,88 +86,46 @@ function hoursAndMinutes(hours: number): Written {
     return { number: `${sign}${wholeHours}:${minutes.toString().padStart(2, '0')}`, unit: atom('h') }
 }
 
-function percentage(value: number): string {
-    return separateNumber((value * asPercent).toFixed(2))
-}
-
-type PartyNumberStyling = (
-    { kind: 'lead', labels: { positive: string, negative: string }, hues: { positive: Hue, negative: Hue } }
-    | { kind: 'share', hue: Hue }
-    | { kind: 'change', hue: Hue }
-)
-
-function PartyPercentage({ value, emphasis }: { value: number, emphasis: PartyNumberStyling }): ReactNode {
+/** A quantity written in a party's color, set flush right so that a fourth digit overflows left. */
+function InParty({ number, hue }: { number: string, hue: Hue }): ReactNode {
     const colors = useColors()
-    const side = value > 0 ? 'positive' : 'negative'
-    const spanStyle: CSSProperties = {
-        color: colors.hueColors[emphasis.kind === 'lead' ? emphasis.hues[side] : emphasis.hue],
-        // So that on 4 digits, we overflow left
-        display: 'flex',
-        justifyContent: 'flex-end',
-    }
-    switch (emphasis.kind) {
-        case 'lead':
-            // a lead is given more digits the closer it is
-            const magnitude = Math.abs(value) * asPercent
-            return (
-                <span style={spanStyle}>
-                    {`${emphasis.labels[side]}+${roundToDigits(magnitude, { significantDigits: 3, minDecimals: 1, maxDecimals: 4 })}`}
-                </span>
-            )
-        case 'change':
-            return <span style={spanStyle}>{`${value >= 0 ? '+' : ''}${percentage(value)}`}</span>
-        case 'share':
-            return <span style={spanStyle}>{percentage(value)}</span>
-    }
+    const spanStyle: CSSProperties = { color: colors.hueColors[hue], display: 'flex', justifyContent: 'flex-end' }
+    return <span style={spanStyle}>{number}</span>
 }
 
-function partyDisplay(emphasis: PartyNumberStyling): UnitDisplay {
+/** The unit types that writeQuantity writes, rather than an arm of their own. */
+function quantity(stored: StoredUnit): UnitDisplay {
     return {
-        renderValue: (value: number) => !isFinite(value)
-            ? { value: <span>{missing}</span>, unit: unitColumn(unitlessDisplay) }
-            : {
-                    value: <PartyPercentage value={value} emphasis={emphasis} />,
-                    unit: unitColumn(percentSign),
-                },
+        renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
+            const { number, name, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
+            return {
+                value: hue === undefined ? <span>{number}</span> : <InParty number={number} hue={hue} />,
+                unit: unitColumn(name),
+            }
+        },
     }
 }
 
-/* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
 export function getUnitDisplay(unitType: UnitType): UnitDisplay {
     switch (unitType) {
         case 'percentage':
-            return display(value => ({ number: percentage(value), unit: percentSign }))
         case 'percentageChange':
-            return display(value => ({ number: `${value >= 0 ? '+' : ''}${percentage(value)}`, unit: percentSign }))
         case 'democraticMargin':
-            return partyDisplay({ kind: 'lead', labels: { positive: 'D', negative: 'R' }, hues: { positive: 'blue', negative: 'red' } })
         case 'leftMargin':
-            // in Canada, left is red
-            return partyDisplay({ kind: 'lead', labels: { positive: 'L', negative: 'R' }, hues: { positive: 'red', negative: 'blue' } })
         case 'partyPctBlue':
-            return partyDisplay({ kind: 'share', hue: 'blue' })
         case 'partyPctRed':
-            return partyDisplay({ kind: 'share', hue: 'red' })
         case 'partyPctOrange':
-            return partyDisplay({ kind: 'share', hue: 'orange' })
         case 'partyPctTeal':
-            return partyDisplay({ kind: 'share', hue: 'cyan' })
         case 'partyPctGreen':
-            return partyDisplay({ kind: 'share', hue: 'green' })
         case 'partyPctPurple':
-            return partyDisplay({ kind: 'share', hue: 'purple' })
         case 'partyChangeBlue':
-            return partyDisplay({ kind: 'change', hue: 'blue' })
         case 'partyChangeRed':
-            return partyDisplay({ kind: 'change', hue: 'red' })
         case 'partyChangeOrange':
-            return partyDisplay({ kind: 'change', hue: 'orange' })
         case 'partyChangeTeal':
-            return partyDisplay({ kind: 'change', hue: 'cyan' })
         case 'partyChangeGreen':
-            return partyDisplay({ kind: 'change', hue: 'green' })
         case 'partyChangePurple':
-            return partyDisplay({ kind: 'change', hue: 'purple' })
+        case 'temperature':
+            return quantity(storedUnits[unitType])
         case 'fatalities':
             return display(value => ({ number: separateNumber(value.toFixed(0)), unit: unitlessDisplay }))
         case 'fatalitiesPerCapita':
@@ -221,11 +172,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                 number: separateNumber((useImperial ? value * feetPerMeter : value).toFixed(0)),
                 unit: atom(useImperial ? 'ft' : 'm'),
             }))
-        case 'temperature':
-            return display((value, { temperatureUnit }) => {
-                const converted = convertTemperature(value, temperatureUnit)
-                return { number: separateNumber(converted.value.toFixed(1)), unit: atom(converted.unit) }
-            })
         case 'time':
             return display(value => hoursAndMinutes(value))
         case 'minutes':
@@ -247,7 +193,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
             return display(value => ({ number: separateNumber(formatToSignificantFigures(value, 3)), unit: unitlessDisplay }))
     }
 }
-/* eslint-enable no-restricted-syntax */
 
 export function getUnit(unit: UnitType): ReactNode {
     switch (unit) {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -1,0 +1,136 @@
+import { HueColors } from '../page_template/color-themes'
+
+import { HumanReadableElement } from './human-readable-name'
+import { Rounding, roundToDigits, separateNumber } from './text'
+
+export type Hue = keyof HueColors
+
+/**
+ * What kind of quantity a number is. A share of a vote and a lead in one are both fractions, but
+ * they are not written the same way, so what a number means is kept apart from how large it is.
+ */
+export type Unit = (
+    { kind: 'raw-percentage', partyColor?: Hue }
+    | { kind: 'delta-percentage', partyColor?: Hue }
+    | { kind: 'lead-percentage', partySystem: 'democratic' | 'left' }
+    | { kind: 'temperature-F' }
+)
+
+/**
+ * A unit together with what numbers written in it are multiplied by to be in base units. Units are
+ * abstract, so how a particular column of numbers is stored belongs here rather than in the unit.
+ */
+export interface StoredUnit {
+    unit: Unit
+    toBaseUnits: number
+}
+
+export interface ReaderSettings {
+    useImperial?: boolean
+    temperatureUnit?: string
+}
+
+export const missingValue = 'N/A'
+
+/** How the number is written: to a fixed number of decimal places, or to a number of digits. */
+type NumberFormat = number | Rounding
+
+/** How a quantity is written: the unit chosen for it, and the style the number is in. */
+interface Representation {
+    /** What a value in base units reads as in this unit */
+    scale: (inBaseUnits: number) => number
+    name: HumanReadableElement[]
+    format: NumberFormat
+}
+
+function atom(value: string): HumanReadableElement[] {
+    return [{ type: 'atom', value }]
+}
+
+const percent: Representation = { name: atom('%'), scale: value => value * 100, format: 2 }
+/** A margin is written as the size of the lead, which is given more digits the closer it is. */
+const margin: Representation = { ...percent, format: { significantDigits: 3, minDecimals: 1, maxDecimals: 4 } }
+
+const partyLabels = {
+    democratic: { positive: 'D', negative: 'R' },
+    // outside the US the left is drawn in red, and the right in blue
+    left: { positive: 'L', negative: 'R' },
+} as const
+
+/* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
+const partyHues = {
+    democratic: { positive: 'blue', negative: 'red' },
+    left: { positive: 'red', negative: 'blue' },
+} as const
+/* eslint-enable no-restricted-syntax */
+
+function representationFor(unit: Unit, settings: ReaderSettings): Representation {
+    switch (unit.kind) {
+        case 'raw-percentage':
+        case 'delta-percentage':
+            return percent
+        case 'lead-percentage':
+            return margin
+        case 'temperature-F':
+            return settings.temperatureUnit === 'celsius'
+                ? { name: atom('°C'), scale: value => (value - 32) * (5 / 9), format: 1 }
+                : { name: atom('°F'), scale: value => value, format: 1 }
+    }
+}
+
+function formatNumber(value: number, format: NumberFormat): string {
+    return typeof format === 'number' ? separateNumber(value.toFixed(format)) : roundToDigits(value, format)
+}
+
+/** The party a quantity written as a lead belongs to, if it is written as one. */
+function party(unit: Unit, value: number): { label: string, hue: Hue } | undefined {
+    if (unit.kind !== 'lead-percentage') {
+        return undefined
+    }
+    const side = value > 0 ? 'positive' : 'negative'
+    return { label: partyLabels[unit.partySystem][side], hue: partyHues[unit.partySystem][side] }
+}
+
+function hueFor(unit: Unit, value: number): Hue | undefined {
+    switch (unit.kind) {
+        case 'raw-percentage':
+        case 'delta-percentage':
+            return unit.partyColor
+        case 'lead-percentage':
+            return party(unit, value)?.hue
+        case 'temperature-F':
+            return undefined
+    }
+}
+
+/**
+ * A quantity written out: the number as it reads, the name of the unit it is written in, and the
+ * hue to write it in, for the quantities that are written in a party's color.
+ */
+export interface WrittenQuantity {
+    /** What the number reads as, a lead including its party and a plus, as in D+4.5 */
+    number: string
+    name: HumanReadableElement[]
+    hue?: Hue
+}
+
+/** Writes out a value stored in the given unit, e.g., 0.125 of a vote as `12.50` and `%`. */
+export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): WrittenQuantity {
+    if (!isFinite(value)) {
+        // a quantity we do not have is not measured in anything, and belongs to no party
+        return { number: missingValue, name: [] }
+    }
+    const { unit } = stored
+    const inBaseUnits = value * stored.toBaseUnits
+    const representation = representationFor(unit, settings)
+    // a lead is written as a size, with the party that holds it in front of the number
+    const lead = party(unit, value)
+    const magnitude = lead === undefined ? inBaseUnits : Math.abs(inBaseUnits)
+    const explicitSign = unit.kind === 'delta-percentage' && magnitude >= 0 ? '+' : ''
+    const written = formatNumber(representation.scale(magnitude), representation.format)
+    return {
+        number: `${lead === undefined ? '' : `${lead.label}+`}${explicitSign}${written}`,
+        name: representation.name,
+        hue: hueFor(unit, value),
+    }
+}

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -5,10 +5,7 @@ import { Rounding, roundToDigits, separateNumber } from './text'
 
 export type Hue = keyof HueColors
 
-/**
- * What kind of quantity a number is. A share of a vote and a lead in one are both fractions, but
- * they are not written the same way, so what a number means is kept apart from how large it is.
- */
+// Abstract interpretation of a quantity as a unit.
 export type Unit = (
     { kind: 'raw-percentage', partyColor?: Hue }
     | { kind: 'delta-percentage', partyColor?: Hue }
@@ -16,12 +13,9 @@ export type Unit = (
     | { kind: 'temperature-F' }
 )
 
-/**
- * A unit together with what numbers written in it are multiplied by to be in base units. Units are
- * abstract, so how a particular column of numbers is stored belongs here rather than in the unit.
- */
 export interface StoredUnit {
     unit: Unit
+    // e.g., a value stored in cm will have 0.01 for this field
     toBaseUnits: number
 }
 
@@ -33,13 +27,15 @@ export interface ReaderSettings {
 export const missingValue = 'N/A'
 
 /** How the number is written: to a fixed number of decimal places, or to a number of digits. */
-type NumberFormat = number | Rounding
+type NumberFormat = (
+    { kind: 'fixed', places: number }
+    | ({ kind: 'rounded' } & Rounding)
+)
 
-/** How a quantity is written: the unit chosen for it, and the style the number is in. */
 interface Representation {
-    /** What a value in base units reads as in this unit */
+    /** E.g., for cm this is x => x * 100 */
     scale: (inBaseUnits: number) => number
-    name: HumanReadableElement[]
+    unitName: HumanReadableElement[]
     format: NumberFormat
 }
 
@@ -47,9 +43,9 @@ function atom(value: string): HumanReadableElement[] {
     return [{ type: 'atom', value }]
 }
 
-const percent: Representation = { name: atom('%'), scale: value => value * 100, format: 2 }
+const percent: Representation = { unitName: atom('%'), scale: value => value * 100, format: { kind: 'fixed', places: 2 } }
 /** A margin is written as the size of the lead, which is given more digits the closer it is. */
-const margin: Representation = { ...percent, format: { significantDigits: 3, minDecimals: 1, maxDecimals: 4 } }
+const margin: Representation = { ...percent, format: { kind: 'rounded', significantDigits: 3, minDecimals: 1, maxDecimals: 4 } }
 
 const partyLabels = {
     democratic: { positive: 'D', negative: 'R' },
@@ -73,13 +69,18 @@ function representationFor(unit: Unit, settings: ReaderSettings): Representation
             return margin
         case 'temperature-F':
             return settings.temperatureUnit === 'celsius'
-                ? { name: atom('°C'), scale: value => (value - 32) * (5 / 9), format: 1 }
-                : { name: atom('°F'), scale: value => value, format: 1 }
+                ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
+                : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
     }
 }
 
 function formatNumber(value: number, format: NumberFormat): string {
-    return typeof format === 'number' ? separateNumber(value.toFixed(format)) : roundToDigits(value, format)
+    switch (format.kind) {
+        case 'fixed':
+            return separateNumber(value.toFixed(format.places))
+        case 'rounded':
+            return roundToDigits(value, format)
+    }
 }
 
 /** The party a quantity written as a lead belongs to, if it is written as one. */
@@ -110,7 +111,7 @@ function hueFor(unit: Unit, value: number): Hue | undefined {
 export interface WrittenQuantity {
     /** What the number reads as, a lead including its party and a plus, as in D+4.5 */
     number: string
-    name: HumanReadableElement[]
+    unitName: HumanReadableElement[]
     hue?: Hue
 }
 
@@ -118,7 +119,7 @@ export interface WrittenQuantity {
 export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): WrittenQuantity {
     if (!isFinite(value)) {
         // a quantity we do not have is not measured in anything, and belongs to no party
-        return { number: missingValue, name: [] }
+        return { number: missingValue, unitName: [] }
     }
     const { unit } = stored
     const inBaseUnits = value * stored.toBaseUnits
@@ -130,7 +131,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     const written = formatNumber(representation.scale(magnitude), representation.format)
     return {
         number: `${lead === undefined ? '' : `${lead.label}+`}${explicitSign}${written}`,
-        name: representation.name,
+        unitName: representation.unitName,
         hue: hueFor(unit, value),
     }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -5,11 +5,13 @@ import { Rounding, roundToDigits, separateNumber } from './text'
 
 export type Hue = keyof HueColors
 
+type PartySystem = 'democratic' | 'left'
+
 // Abstract interpretation of a quantity as a unit.
 export type Unit = (
     { kind: 'raw-percentage', partyColor?: Hue }
     | { kind: 'delta-percentage', partyColor?: Hue }
-    | { kind: 'lead-percentage', partySystem: 'democratic' | 'left' }
+    | { kind: 'lead-percentage', partySystem: PartySystem }
     | { kind: 'temperature-F' }
 )
 
@@ -83,21 +85,17 @@ function formatNumber(value: number, format: NumberFormat): string {
     }
 }
 
-function party(unit: Unit, value: number): { label: string, hue: Hue } | undefined {
-    if (unit.kind !== 'lead-percentage') {
-        return undefined
-    }
+function getParty(partySystem: PartySystem, value: number): { label: string, hue: Hue } {
     const side = value > 0 ? 'positive' : 'negative'
-    return { label: partyLabels[unit.partySystem][side], hue: partyHues[unit.partySystem][side] }
+    return { label: partyLabels[partySystem][side], hue: partyHues[partySystem][side] }
 }
 
-function hueFor(unit: Unit, value: number): Hue | undefined {
+function hueFor(unit: Unit): Hue | undefined {
     switch (unit.kind) {
         case 'raw-percentage':
         case 'delta-percentage':
             return unit.partyColor
         case 'lead-percentage':
-            return party(unit, value)?.hue
         case 'temperature-F':
             return undefined
     }
@@ -110,21 +108,23 @@ export interface WrittenQuantity {
     hue?: Hue
 }
 
-/** Writes out a value stored in the given unit, e.g., 0.125 of a vote as `12.50` and `%`. */
 export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): WrittenQuantity {
     if (!isFinite(value)) {
         return { renderedValue: missingValue, unitName: [] }
     }
     const { unit } = stored
-    const inBaseUnits = value * stored.toBaseUnits
+    let inBaseUnits = value * stored.toBaseUnits
     const representation = representationFor(unit, settings)
-    const lead = party(unit, value)
-    const magnitude = lead === undefined ? inBaseUnits : Math.abs(inBaseUnits)
-    const explicitSign = unit.kind === 'delta-percentage' && magnitude >= 0 ? '+' : ''
-    const written = formatNumber(representation.scale(magnitude), representation.format)
+    let party = undefined
+    if (unit.kind === 'lead-percentage') {
+        party = getParty(unit.partySystem, inBaseUnits)
+        inBaseUnits = Math.abs(inBaseUnits)
+    }
+    const explicitSign = unit.kind === 'delta-percentage' && inBaseUnits >= 0 ? '+' : ''
+    const written = formatNumber(representation.scale(inBaseUnits), representation.format)
     return {
-        renderedValue: `${lead === undefined ? '' : `${lead.label}+`}${explicitSign}${written}`,
+        renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${written}`,
         unitName: representation.unitName,
-        hue: hueFor(unit, value),
+        hue: party?.hue ?? hueFor(unit),
     }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -83,7 +83,6 @@ function formatNumber(value: number, format: NumberFormat): string {
     }
 }
 
-/** The party a quantity written as a lead belongs to, if it is written as one. */
 function party(unit: Unit, value: number): { label: string, hue: Hue } | undefined {
     if (unit.kind !== 'lead-percentage') {
         return undefined
@@ -104,13 +103,9 @@ function hueFor(unit: Unit, value: number): Hue | undefined {
     }
 }
 
-/**
- * A quantity written out: the number as it reads, the name of the unit it is written in, and the
- * hue to write it in, for the quantities that are written in a party's color.
- */
 export interface WrittenQuantity {
     /** What the number reads as, a lead including its party and a plus, as in D+4.5 */
-    number: string
+    renderedValue: string
     unitName: HumanReadableElement[]
     hue?: Hue
 }
@@ -119,7 +114,7 @@ export interface WrittenQuantity {
 export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): WrittenQuantity {
     if (!isFinite(value)) {
         // a quantity we do not have is not measured in anything, and belongs to no party
-        return { number: missingValue, unitName: [] }
+        return { renderedValue: missingValue, unitName: [] }
     }
     const { unit } = stored
     const inBaseUnits = value * stored.toBaseUnits
@@ -130,7 +125,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     const explicitSign = unit.kind === 'delta-percentage' && magnitude >= 0 ? '+' : ''
     const written = formatNumber(representation.scale(magnitude), representation.format)
     return {
-        number: `${lead === undefined ? '' : `${lead.label}+`}${explicitSign}${written}`,
+        renderedValue: `${lead === undefined ? '' : `${lead.label}+`}${explicitSign}${written}`,
         unitName: representation.unitName,
         hue: hueFor(unit, value),
     }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -113,13 +113,11 @@ export interface WrittenQuantity {
 /** Writes out a value stored in the given unit, e.g., 0.125 of a vote as `12.50` and `%`. */
 export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): WrittenQuantity {
     if (!isFinite(value)) {
-        // a quantity we do not have is not measured in anything, and belongs to no party
         return { renderedValue: missingValue, unitName: [] }
     }
     const { unit } = stored
     const inBaseUnits = value * stored.toBaseUnits
     const representation = representationFor(unit, settings)
-    // a lead is written as a size, with the party that holds it in front of the number
     const lead = party(unit, value)
     const magnitude = lead === undefined ? inBaseUnits : Math.abs(inBaseUnits)
     const explicitSign = unit.kind === 'delta-percentage' && magnitude >= 0 ? '+' : ''

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -46,10 +46,6 @@ function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
 }
 
-/**
- * What each unit type is a quantity of. Filled in a kind at a time as the unit types move over to
- * being written by `writeQuantity` rather than by an arm of their own.
- */
 /* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
 export const storedUnits = {
     percentage: { unit: { kind: 'raw-percentage' }, toBaseUnits: 1 },

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,3 +1,5 @@
+import { StoredUnit } from './quantity'
+
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
     | 'contaminantLevel' | 'number' | 'usd' | 'minutes'
@@ -43,6 +45,32 @@ export const allUnitTypes = [
 function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
 }
+
+/**
+ * What each unit type is a quantity of. Filled in a kind at a time as the unit types move over to
+ * being written by `writeQuantity` rather than by an arm of their own.
+ */
+/* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
+export const storedUnits = {
+    percentage: { unit: { kind: 'raw-percentage' }, toBaseUnits: 1 },
+    percentageChange: { unit: { kind: 'delta-percentage' }, toBaseUnits: 1 },
+    democraticMargin: { unit: { kind: 'lead-percentage', partySystem: 'democratic' }, toBaseUnits: 1 },
+    leftMargin: { unit: { kind: 'lead-percentage', partySystem: 'left' }, toBaseUnits: 1 },
+    partyPctBlue: { unit: { kind: 'raw-percentage', partyColor: 'blue' }, toBaseUnits: 1 },
+    partyPctRed: { unit: { kind: 'raw-percentage', partyColor: 'red' }, toBaseUnits: 1 },
+    partyPctOrange: { unit: { kind: 'raw-percentage', partyColor: 'orange' }, toBaseUnits: 1 },
+    partyPctTeal: { unit: { kind: 'raw-percentage', partyColor: 'cyan' }, toBaseUnits: 1 },
+    partyPctGreen: { unit: { kind: 'raw-percentage', partyColor: 'green' }, toBaseUnits: 1 },
+    partyPctPurple: { unit: { kind: 'raw-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
+    partyChangeBlue: { unit: { kind: 'delta-percentage', partyColor: 'blue' }, toBaseUnits: 1 },
+    partyChangeRed: { unit: { kind: 'delta-percentage', partyColor: 'red' }, toBaseUnits: 1 },
+    partyChangeOrange: { unit: { kind: 'delta-percentage', partyColor: 'orange' }, toBaseUnits: 1 },
+    partyChangeTeal: { unit: { kind: 'delta-percentage', partyColor: 'cyan' }, toBaseUnits: 1 },
+    partyChangeGreen: { unit: { kind: 'delta-percentage', partyColor: 'green' }, toBaseUnits: 1 },
+    partyChangePurple: { unit: { kind: 'delta-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
+    temperature: { unit: { kind: 'temperature-F' }, toBaseUnits: 1 },
+} satisfies Partial<Record<UnitType, StoredUnit>>
+/* eslint-enable no-restricted-syntax */
 
 function fahrenheitToCelsius(value: number): number {
     return (value - 32) * (5 / 9)

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -189,7 +189,7 @@ for (const [unitType, value, expected, hue] of [
 ] as const) {
     void test(`${unitType} writes ${value} as ${expected} in ${hue}`, () => {
         const written = writeQuantity(value, storedUnits[unitType])
-        assert.equal(written.number, expected)
+        assert.equal(written.renderedValue, expected)
         assert.equal(written.hue, hue)
     })
 }
@@ -198,7 +198,7 @@ for (const [unitType, value, expected, hue] of [
 // A quantity we do not have belongs to no party, and is measured in nothing
 for (const unitType of ['democraticMargin', 'partyPctOrange', 'percentage', 'temperature'] as const) {
     void test(`${unitType} writes a missing value plainly`, () => {
-        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType]), { number: 'N/A', unitName: [] })
+        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType]), { renderedValue: 'N/A', unitName: [] })
     })
 }
 

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -59,7 +59,7 @@ for (const [unitType, value, expected] of [
     ['distanceInM', 1234, '1\u202f234m'],
     ['area', 1234, '1\u202f234km2'],
     ['distanceInKm', 1234, '1\u202f234.00km'],
-    ['contaminantLevel', 1234, '1\u202f234.00\u03bcg/m3'],
+    ['contaminantLevel', 1234, '1\u202f234.00μg/m3'],
     ['percentage', 12.34, '1\u202f234.00%'],
     ['fatalitiesPerCapita', 0.01234, '1\u202f234.00/\u00a0100k'],
     ['distancePerYear', 12.34, '1\u202f234.0cm/yr'],
@@ -86,7 +86,7 @@ for (const [value, expected] of [
 for (const [unitType, value, expected] of [
     ['density', 5.67, '5.7/\u00a0km2'],
     ['fatalitiesPerCapita', 1.2e-5, '1.20/\u00a0100k'],
-    ['contaminantLevel', 8.2, '8.20\u03bcg/m3'],
+    ['contaminantLevel', 8.2, '8.20μg/m3'],
     ['distancePerYear', 1.2, '120.0cm/yr'],
 ] as const) {
     void test(`${unitType} writes ${value} as ${expected}`, () => {

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -4,7 +4,8 @@ import assert from 'assert/strict'
 import test from 'node:test'
 
 import { getUnitDisplay, renderInequality } from '../src/components/unit-display'
-import { UnitType } from '../src/utils/unit'
+import { writeQuantity } from '../src/utils/quantity'
+import { storedUnits, UnitType } from '../src/utils/unit'
 
 // Flatten a React element tree into its text content.
 function textOf(node: unknown): string {
@@ -15,8 +16,8 @@ function textOf(node: unknown): string {
     return textOf((node as { props?: { children?: unknown } }).props?.children)
 }
 
-function renderValue(unitType: UnitType, value: number, useImperial = false): string {
-    const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value, useImperial)
+function renderValue(unitType: UnitType, value: number, useImperial = false, temperatureUnit = 'fahrenheit'): string {
+    const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value, useImperial, temperatureUnit)
     return `${textOf(valueEl)}${textOf(unitEl)}`.trim()
 }
 
@@ -172,3 +173,36 @@ for (const [unitType, value, inequality, expected] of [
         assert.equal(renderInequality(value, unitType, inequality), expected)
     })
 }
+
+// A quantity written in a party's color says which party it belongs to, and in which hue
+/* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
+for (const [unitType, value, expected, hue] of [
+    ['democraticMargin', 0.123, 'D+12.3', 'blue'],
+    ['democraticMargin', -0.081, 'R+8.10', 'red'],
+    // a lead is given more digits the closer it is
+    ['democraticMargin', 0.0005, 'D+0.0500', 'blue'],
+    ['leftMargin', 0.123, 'L+12.3', 'red'],
+    ['leftMargin', -0.123, 'R+12.3', 'blue'],
+    ['partyPctOrange', 0.125, '12.50', 'orange'],
+    ['partyChangeTeal', 0.125, '+12.50', 'cyan'],
+    ['partyChangeTeal', -0.125, '-12.50', 'cyan'],
+] as const) {
+    void test(`${unitType} writes ${value} as ${expected} in ${hue}`, () => {
+        const written = writeQuantity(value, storedUnits[unitType])
+        assert.equal(written.number, expected)
+        assert.equal(written.hue, hue)
+    })
+}
+/* eslint-enable no-restricted-syntax */
+
+// A quantity we do not have belongs to no party, and is measured in nothing
+for (const unitType of ['democraticMargin', 'partyPctOrange', 'percentage', 'temperature'] as const) {
+    void test(`${unitType} writes a missing value plainly`, () => {
+        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType]), { number: 'N/A', name: [] })
+    })
+}
+
+void test('temperature is written in the reader\'s own unit', () => {
+    assert.equal(renderValue('temperature', 50), '50.0°F')
+    assert.equal(renderValue('temperature', 50, false, 'celsius'), '10.0°C')
+})

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -198,7 +198,7 @@ for (const [unitType, value, expected, hue] of [
 // A quantity we do not have belongs to no party, and is measured in nothing
 for (const unitType of ['democraticMargin', 'partyPctOrange', 'percentage', 'temperature'] as const) {
     void test(`${unitType} writes a missing value plainly`, () => {
-        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType]), { number: 'N/A', name: [] })
+        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType]), { number: 'N/A', unitName: [] })
     })
 }
 


### PR DESCRIPTION
Third of the pieces of #2215. Stacked on #2251; the diff below is against that branch, so this one wants merging after it.

Sixteen of the thirty unit types are a percentage, a lead in one, or a temperature — quantities whose unit is decided before the value is seen, with no ladder to search. They had six arms between them, each doing its own arithmetic and its own rounding, plus a `PartyNumberStyling` union and a `PartyPercentage` component to say which of three ways a fraction of a vote is written.

They now say what kind of quantity they are:

```ts
percentage: { unit: { kind: 'raw-percentage' }, toBaseUnits: 1 },
democraticMargin: { unit: { kind: 'lead-percentage', partySystem: 'democratic' }, toBaseUnits: 1 },
partyChangeTeal: { unit: { kind: 'delta-percentage', partyColor: 'cyan' }, toBaseUnits: 1 },
temperature: { unit: { kind: 'temperature-F' }, toBaseUnits: 1 },
```

and `writeQuantity` in the new `src/utils/quantity.ts` writes them: convert to base units, pick the representation the kind calls for, format the number to the places that representation asks for. A lead still carries its party's letter in front of the number and its hue with it, but as data rather than as a component of its own — `getUnitDisplay` turns the hue into the colored span.

`storedUnits` in `unit.ts` is deliberately `Partial<Record<UnitType, StoredUnit>>`: the remaining fourteen types move over as the later PRs give them ladders.

`Unit` has no `dimensionfull` kind yet, and `quantity.ts` has no base units, ladders or costs. Those arrive with the first unit type that needs them.

## One thing that is not a pure restatement

A representation converts with a function rather than a factor to divide by:

```ts
const percent: Representation = { name: atom('%'), scale: value => value * 100, format: 2 }
```

I wrote it as `size: 1 / 100` first, dividing uniformly. That is wrong: `x / 0.01` and `x * 100` differ in the last bit, and `.toFixed(2)` is decided by that bit at a rounding boundary. A stress run found it — `-0.04955` reads as `-4.96%` on main and `-4.95%` when divided. Converting the way each unit actually converts fixes it, and drops the `offset` field, which existed only so that Fahrenheit could be subtracted from before dividing.

## Verification

- The 1440-case markup sweep against main (30 types × 16 values × 3 settings, through `renderToString`): identical.
- A 168,028-case stress run over the seven types whose arithmetic this restates, on a spread of magnitudes plus every value near a rounding boundary: identical. This is what caught the division above.
- `tsc`, lint, knip, 512 unit tests. New tests cover `writeQuantity` directly: the party letter, the hue, the extra digits a close lead gets, and a missing value belonging to no party.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)