### PR TITLE
Choose the unit a count is written in by what the number costs to read

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
 import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
-import { abbreviate, formatToSignificantFigures, roundToDigits, separateNumber } from '../utils/text'
+import { roundToDigits, separateNumber } from '../utils/text'
 import { convertPrecipitation, storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
@@ -124,9 +124,11 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'partyChangeGreen':
         case 'partyChangePurple':
         case 'temperature':
-            return quantity(storedUnits[unitType])
+        case 'number':
+        case 'population':
         case 'fatalities':
-            return display(value => ({ number: separateNumber(value.toFixed(0)), unit: unitlessDisplay }))
+        case 'usd':
+            return quantity(storedUnits[unitType])
         case 'fatalitiesPerCapita':
             return display(value => ({
                 number: separateNumber((perHundredThousand * value).toFixed(2)),
@@ -137,16 +139,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                 number: roundToDigits(useImperial ? value * squareKmPerSquareMile : value, { significantDigits: 2 }),
                 unit: raised(per(useImperial ? 'mi' : 'km'), '2'),
             }))
-        case 'population':
-            return display((value) => {
-                const { number, suffix } = abbreviate(value)
-                return { number, unit: suffix === '' ? unitlessDisplay : atom(suffix) }
-            })
-        case 'usd':
-            return display((value) => {
-                const { number, suffix } = abbreviate(value)
-                return { number: `$${number}`, unit: suffix === '' ? unitlessDisplay : atom(suffix) }
-            })
         case 'area':
             return display((value, { useImperial }) => {
                 if (useImperial) {
@@ -188,8 +180,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                 number: separateNumber(value.toFixed(2)),
                 unit: raised('μg/m', '3'),
             }))
-        case 'number':
-            return display(value => ({ number: separateNumber(formatToSignificantFigures(value, 3)), unit: unitlessDisplay }))
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -1,11 +1,24 @@
 import { HueColors } from '../page_template/color-themes'
 
+import { assert } from './defensive'
 import { HumanReadableElement } from './human-readable-name'
-import { Rounding, roundToDigits, separateNumber } from './text'
+import { formatToSignificantFigures, Rounding, roundToDigits, separateNumber } from './text'
 
 export type Hue = keyof HueColors
 
 type PartySystem = 'democratic' | 'left'
+
+/**
+ * The units everything else is measured in. A value is put in these before it is written out, so
+ * that quantities of the same kind are written the same way however they happen to be stored.
+ */
+export type BaseUnit = 'person' | 'usd' | 'fatality'
+
+/** A base unit raised to a power, e.g., people, or square meters. */
+export interface Dimension {
+    baseUnit: BaseUnit
+    power: number
+}
 
 // Abstract interpretation of a quantity as a unit.
 export type Unit = (
@@ -13,6 +26,7 @@ export type Unit = (
     | { kind: 'delta-percentage', partyColor?: Hue }
     | { kind: 'lead-percentage', partySystem: PartySystem }
     | { kind: 'temperature-F' }
+    | { kind: 'dimensionfull', scales: Dimension[] }
 )
 
 export interface StoredUnit {
@@ -32,6 +46,7 @@ export const missingValue = 'N/A'
 type NumberFormat = (
     { kind: 'fixed', places: number }
     | ({ kind: 'rounded' } & Rounding)
+    | { kind: 'significantFigures' }
 )
 
 interface Representation {
@@ -39,6 +54,8 @@ interface Representation {
     scale: (inBaseUnits: number) => number
     unitName: HumanReadableElement[]
     format: NumberFormat
+    /** Written in front of the number, as a dollar sign is */
+    prefix?: string
 }
 
 function atom(value: string): HumanReadableElement[] {
@@ -62,7 +79,141 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
-function representationFor(unit: Unit, settings: ReaderSettings): Representation {
+/** One of the units a base unit can be written in, e.g., a million people. */
+interface LadderUnit {
+    name: string
+    /** How many base units one of it is: a thousand people is a thousand of them */
+    size: number
+    /**
+     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
+     * ordinarily counted in, and more for one that only earns its place by shortening the number.
+     */
+    cost: number
+}
+
+/** An abbreviation is a unit of its own only in the sense that it saves digits. */
+const abbreviated = 1
+
+/** The unit a quantity is counted in, which a count has no name of its own for. */
+const itself: LadderUnit = { name: '', size: 1, cost: 0 }
+
+/** Thousands, millions and billions, for a quantity that is counted rather than measured. */
+const abbreviations: LadderUnit[] = [
+    { name: 'k', size: 1e3, cost: abbreviated },
+    { name: 'm', size: 1e6, cost: abbreviated },
+    { name: 'B', size: 1e9, cost: abbreviated },
+]
+
+/**
+ * The units each base unit can be written in. A quantity is written by choosing one of them for
+ * each base unit it is measured in.
+ */
+const ladders: Record<BaseUnit, LadderUnit[]> = {
+    person: [itself, ...abbreviations],
+    usd: [itself, ...abbreviations],
+    // fatalities are not abbreviated: there are never enough of them for it to save a digit
+    fatality: [itself],
+}
+
+/** What the dimensions of a quantity are called when they are looked up in a table. */
+function signatureOf(scales: Dimension[]): string {
+    return scales
+        .filter(({ power }) => power !== 0)
+        .sort((a, b) => a.baseUnit < b.baseUnit ? -1 : 1)
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+}
+
+/**
+ * How the number is written once a unit has been chosen for it. Separate from the units: what a
+ * quantity is measured in does not say how precisely it is worth writing.
+ */
+const styles: Record<string, NumberFormat | undefined> = {
+    '': { kind: 'significantFigures' },
+    // things that are counted come in whole numbers, unless they are counted in thousands
+    'person^1': { kind: 'fixed', places: 0 },
+    'usd^1': { kind: 'fixed', places: 0 },
+    'fatality^1': { kind: 'fixed', places: 0 },
+}
+
+const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+/** An abbreviated number is worth three figures, wherever they fall. */
+const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
+
+const prefixes: Record<string, string | undefined> = { 'usd^1': '$' }
+
+/** A base unit together with the unit off its ladder that a quantity is written in. */
+interface Written extends Dimension {
+    unit: LadderUnit
+}
+
+function styleFor(signature: string, written: Written[]): NumberFormat {
+    if (written.some(({ unit }) => unit.cost === abbreviated)) {
+        return abbreviatedStyle
+    }
+    return styles[signature] ?? defaultStyle
+}
+
+/**
+ * What a number costs to read in a given unit: one for every digit past the third before the
+ * point, and nine tenths of one for the point itself and each leading zero after it. The number is
+ * written out to count it, so that a value that rounds up into another unit, such as 999.5 thousand
+ * people, costs what a million costs rather than what nine hundred thousand costs.
+ */
+function digitCost(value: number, format: NumberFormat): number {
+    if (value === 0) {
+        // nothing is shorter than zero in any unit
+        return 0
+    }
+    // the digits alone: neither the sign nor the separators between them make it harder to read
+    const written = formatNumber(value, format).replaceAll('-', '').replaceAll('\u202f', '')
+    const [integerPart, fraction = ''] = written.split('.')
+    if (integerPart !== '0') {
+        return Math.max(0, integerPart.length - 3)
+    }
+    // a shade less than a digit, since a number below one reads a little better than a long one
+    return 0.9 * (1 + (/^0*/.exec(fraction)?.[0].length ?? 0))
+}
+
+/** The name a quantity is written under, which a count has only when it is abbreviated. */
+function nameOf(written: Written[]): HumanReadableElement[] {
+    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
+    return names.length === 0 ? [] : atom(names.join('\u00b7'))
+}
+
+function combinations(dimensions: Dimension[]): Written[][] {
+    if (dimensions.length === 0) {
+        return [[]]
+    }
+    const [dimension, ...rest] = dimensions
+    return ladders[dimension.baseUnit].flatMap(unit => combinations(rest).map(tail => [{ ...dimension, unit }, ...tail]))
+}
+
+/**
+ * The best way of writing a value of these dimensions: of every combination of units from the
+ * ladders of the base units it is measured in, the one that costs least once the number it leaves
+ * behind is counted.
+ */
+function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Representation {
+    const signature = signatureOf(scales)
+    let best: Representation | undefined
+    let bestCost = Infinity
+    for (const written of combinations(scales.filter(({ power }) => power !== 0))) {
+        const format = styleFor(signature, written)
+        const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
+        const scale = (value: number): number => value / size
+        const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
+            + digitCost(scale(inBaseUnits), format)
+        if (cost < bestCost) {
+            best = { scale, unitName: nameOf(written), format, prefix: prefixes[signature] }
+            bestCost = cost
+        }
+    }
+    assert(best !== undefined, 'every quantity has at least one way of being written')
+    return best
+}
+
+function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
     switch (unit.kind) {
         case 'raw-percentage':
         case 'delta-percentage':
@@ -73,6 +224,8 @@ function representationFor(unit: Unit, settings: ReaderSettings): Representation
             return settings.temperatureUnit === 'celsius'
                 ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
+        case 'dimensionfull':
+            return bestRepresentation(inBaseUnits, unit.scales)
     }
 }
 
@@ -82,6 +235,8 @@ function formatNumber(value: number, format: NumberFormat): string {
             return separateNumber(value.toFixed(format.places))
         case 'rounded':
             return roundToDigits(value, format)
+        case 'significantFigures':
+            return separateNumber(formatToSignificantFigures(value, 3))
     }
 }
 
@@ -97,6 +252,7 @@ function hueFor(unit: Unit): Hue | undefined {
             return unit.partyColor
         case 'lead-percentage':
         case 'temperature-F':
+        case 'dimensionfull':
             return undefined
     }
 }
@@ -114,7 +270,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     }
     const { unit } = stored
     let inBaseUnits = value * stored.toBaseUnits
-    const representation = representationFor(unit, settings)
+    const representation = representationFor(inBaseUnits, unit, settings)
     let party = undefined
     if (unit.kind === 'lead-percentage') {
         party = getParty(unit.partySystem, inBaseUnits)
@@ -123,7 +279,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     const explicitSign = unit.kind === 'delta-percentage' && inBaseUnits >= 0 ? '+' : ''
     const written = formatNumber(representation.scale(inBaseUnits), representation.format)
     return {
-        renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${written}`,
+        renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${representation.prefix ?? ''}${written}`,
         unitName: representation.unitName,
         hue: party?.hue ?? hueFor(unit),
     }

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -77,7 +77,8 @@ export function formatToSignificantFigures(value: number, sigFigs: number = 3): 
     }
 
     const factor = Math.pow(10, sigFigs - 1 - Math.floor(Math.log10(Math.abs(value))))
-    const rounded = Math.round(value * factor) / factor
+    // by size, so that a half goes the same way whichever side of zero it falls
+    const rounded = Math.sign(value) * Math.round(Math.abs(value) * factor) / factor
 
     // taken from the rounded value, since rounding can carry into another digit, as 0.9995 does
     const magnitude = Math.floor(Math.log10(Math.abs(rounded)))

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,4 +1,4 @@
-import { StoredUnit } from './quantity'
+import { BaseUnit, StoredUnit } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
@@ -46,6 +46,14 @@ function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
 }
 
+function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 1): StoredUnit {
+    const entries = Object.entries(scales) as [BaseUnit, number][]
+    return {
+        unit: { kind: 'dimensionfull', scales: entries.map(([baseUnit, power]) => ({ baseUnit, power })) },
+        toBaseUnits,
+    }
+}
+
 /* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
 export const storedUnits = {
     percentage: { unit: { kind: 'raw-percentage' }, toBaseUnits: 1 },
@@ -65,6 +73,10 @@ export const storedUnits = {
     partyChangeGreen: { unit: { kind: 'delta-percentage', partyColor: 'green' }, toBaseUnits: 1 },
     partyChangePurple: { unit: { kind: 'delta-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
     temperature: { unit: { kind: 'temperature-F' }, toBaseUnits: 1 },
+    number: dimensionfull({}),
+    population: dimensionfull({ person: 1 }),
+    fatalities: dimensionfull({ fatality: 1 }),
+    usd: dimensionfull({ usd: 1 }),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/unit/formatToSignificantFigures.test.ts
+++ b/react/unit/formatToSignificantFigures.test.ts
@@ -39,6 +39,13 @@ void describe('formatToSignificantFigures', () => {
         assert.equal(formatToSignificantFigures(-0.0123456), '-0.0123')
     })
 
+    void test('rounds a half by size, not by the side of zero it falls on', () => {
+        assert.equal(formatToSignificantFigures(78.45), '78.5')
+        assert.equal(formatToSignificantFigures(-78.45), '-78.5')
+        assert.equal(formatToSignificantFigures(999500), '1000000')
+        assert.equal(formatToSignificantFigures(-999500), '-1000000')
+    })
+
     void test('handles edge cases', () => {
         assert.equal(formatToSignificantFigures(81.407), '81.4')
         assert.equal(formatToSignificantFigures(1.0), '1.00')

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -95,6 +95,19 @@ for (const [unitType, value, expected] of [
     })
 }
 
+// A count is abbreviated by how long the number reads once it is written out, which is the same
+// however large it is and whichever side of zero it falls
+for (const [unitType, value, expected] of [
+    ['population', -999500, '-1.00m'],
+    ['population', 999500000000, '1\u202f000B'],
+    ['population', -999500000000, '-1\u202f000B'],
+    ['usd', 999500000000, '$1\u202f000B'],
+] as const) {
+    void test(`${unitType} renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue(unitType, value), expected)
+    })
+}
+
 // Money and people are counted in thousands at the same point
 for (const [unitType, value, expected] of [
     ['usd', 1234, '$1\u202f234'],


### PR DESCRIPTION
Fourth of the pieces of #2215, off current main.

`population`, `usd` and `fatalities` each had an arm that knew when to abbreviate, sharing one `abbreviate` helper whose ladder and thresholds were stated nowhere. They now say what they are counting:

```ts
number: dimensionfull({}),
population: dimensionfull({ person: 1 }),
fatalities: dimensionfull({ fatality: 1 }),
usd: dimensionfull({ usd: 1 }),
```

and the unit is searched for rather than decided. Each base unit has a ladder of units it can be written in; `bestRepresentation` writes the number out in every one of them and keeps the cheapest, where a digit past the third costs one, a leading zero after the point costs nine tenths, and reaching for an abbreviation costs one.

That reproduces the shared ladder, including the threshold nobody had written down — a thousand is not worth reaching for until the number is five digits long, because `12 345` costs two and `12.3k` costs one — and it reproduces the promotion at `999 500`, because the cost is counted from the number *as printed*, and `999.5k` prints as `1 000k`.

Cost, ladders and `digitCost` are general over products of powers, but nothing uses a power other than one yet. Conventions, the imperial ladders and the `/` in a unit name arrive with area and density.

## Rendering differences

The 1440-case sweep against main is identical. A 60,672-case stress run over the four types, spread across fifteen magnitudes with every value around each of main's thresholds, has **70 differences in three groups**:

| | main | after | when |
|---|---|---|---|
| 66 | `1.00e+3B` | `1 000B` | at or above 999.5 billion |
| 2 | `10 000` | `10.0k` | `9999.5` exactly |
| 2 | `-999 000` | `-1 000 000` | a bare number at an exact negative half |

The first is the `toPrecision(3)` scientific-notation bug — the same one the existing population tests were written to guard against at the lower tiers, which nobody extended to the top of the ladder. A count of a trillion people is not reachable, but a dollar figure is.

The second is the promotion rule applied at the bottom of the ladder: `9999.5` prints as five digits, so it is abbreviated for the same reason `999 500` is. Only reachable for a non-integer count.

The third is a fix I had to make to get the rest right, below.

## Rounding a half by size

`formatToSignificantFigures` rounded with `Math.round`, which takes a half towards positive infinity. So `999 500` read as `1.00m` but `-999 500` read as `-999k`: the ladder promoted one and not the other. It now rounds the magnitude and puts the sign back, which is the rule this stack already applies to which unit and how many places a negative value gets.

This also reaches captions in `derive-human-readable-name.ts`, which share the helper.

## Verification

`tsc`, lint, knip, 530 unit tests. New tests cover the symmetry of a rounded half, the top of the ladder, and `-999 500` reading as `-1.00m`.

Screenshots should not move: every difference above needs a count of a trillion or a fractional one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)