### PR TITLE
Abbreviate a count when doing so shortens the number

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
 import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
-import { abbreviate, formatToSignificantFigures, roundToDigits, separateNumber } from '../utils/text'
+import { abbreviate, roundToDigits, separateNumber } from '../utils/text'
 import { convertPrecipitation, storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
@@ -124,9 +124,9 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'partyChangeGreen':
         case 'partyChangePurple':
         case 'temperature':
-            return quantity(storedUnits[unitType])
+        case 'number':
         case 'fatalities':
-            return display(value => ({ number: separateNumber(value.toFixed(0)), unit: unitlessDisplay }))
+            return quantity(storedUnits[unitType])
         case 'fatalitiesPerCapita':
             return display(value => ({
                 number: separateNumber((perHundredThousand * value).toFixed(2)),
@@ -188,8 +188,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                 number: separateNumber(value.toFixed(2)),
                 unit: raised('μg/m', '3'),
             }))
-        case 'number':
-            return display(value => ({ number: separateNumber(formatToSignificantFigures(value, 3)), unit: unitlessDisplay }))
     }
 }
 

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
 import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
-import { abbreviate, roundToDigits, separateNumber } from '../utils/text'
+import { roundToDigits, separateNumber } from '../utils/text'
 import { convertPrecipitation, storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
@@ -125,7 +125,9 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'partyChangePurple':
         case 'temperature':
         case 'number':
+        case 'population':
         case 'fatalities':
+        case 'usd':
             return quantity(storedUnits[unitType])
         case 'fatalitiesPerCapita':
             return display(value => ({
@@ -137,16 +139,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                 number: roundToDigits(useImperial ? value * squareKmPerSquareMile : value, { significantDigits: 2 }),
                 unit: raised(per(useImperial ? 'mi' : 'km'), '2'),
             }))
-        case 'population':
-            return display((value) => {
-                const { number, suffix } = abbreviate(value)
-                return { number, unit: suffix === '' ? unitlessDisplay : atom(suffix) }
-            })
-        case 'usd':
-            return display((value) => {
-                const { number, suffix } = abbreviate(value)
-                return { number: `$${number}`, unit: suffix === '' ? unitlessDisplay : atom(suffix) }
-            })
         case 'area':
             return display((value, { useImperial }) => {
                 if (useImperial) {

--- a/react/src/utils/human-readable-name.tsx
+++ b/react/src/utils/human-readable-name.tsx
@@ -6,6 +6,11 @@ export type HumanReadableElement = { type: 'atom', value: string } | { type: 'co
 
 export type HumanReadableName = string | HumanReadableElement[]
 
+/** A run of plain text, which most of a unit's name is. */
+export function atom(value: string): HumanReadableElement[] {
+    return [{ type: 'atom', value }]
+}
+
 export function reifyReact(elements: HumanReadableElement[] | string): ReactNode {
     if (typeof elements === 'string') return elements
     return elements.map((element, index) => {

--- a/react/src/utils/human-readable-name.tsx
+++ b/react/src/utils/human-readable-name.tsx
@@ -6,7 +6,6 @@ export type HumanReadableElement = { type: 'atom', value: string } | { type: 'co
 
 export type HumanReadableName = string | HumanReadableElement[]
 
-/** A run of plain text, which most of a unit's name is. */
 export function atom(value: string): HumanReadableElement[] {
     return [{ type: 'atom', value }]
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -136,7 +136,10 @@ function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
     return styles[key] ?? defaultStyle
 }
 
-/** The name a quantity is written under, which a count has only when it is abbreviated. */
+/**
+ * What goes in the unit column. A count has no name of its own, since the statistic says what is
+ * being counted, so this is empty for one unless an abbreviation was chosen and it reads k, m or B.
+ */
 function nameOf(written: Written[]): HumanReadableElement[] {
     const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
     return names.length === 0 ? [] : atom(names.join('\u00b7'))

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -1,5 +1,6 @@
 import { HueColors } from '../page_template/color-themes'
 
+import { assert } from './defensive'
 import { HumanReadableElement } from './human-readable-name'
 import { formatToSignificantFigures, Rounding, roundToDigits, separateNumber } from './text'
 
@@ -11,9 +12,9 @@ type PartySystem = 'democratic' | 'left'
  * The units everything else is measured in. A value is put in these before it is written out, so
  * that quantities of the same kind are written the same way however they happen to be stored.
  */
-export type BaseUnit = 'fatality'
+export type BaseUnit = 'person' | 'usd' | 'fatality'
 
-/** A base unit raised to a power, e.g., fatalities, or square meters. */
+/** A base unit raised to a power, e.g., people, or square meters. */
 export interface Dimension {
     baseUnit: BaseUnit
     power: number
@@ -53,6 +54,8 @@ interface Representation {
     scale: (inBaseUnits: number) => number
     unitName: HumanReadableElement[]
     format: NumberFormat
+    /** Written in front of the number, as a dollar sign is */
+    prefix?: string
 }
 
 function atom(value: string): HumanReadableElement[] {
@@ -76,6 +79,42 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
+/** One of the units a base unit can be written in, e.g., a million people. */
+interface LadderUnit {
+    name: string
+    /** How many base units one of it is: a thousand people is a thousand of them */
+    size: number
+    /**
+     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
+     * ordinarily counted in, and more for one that only earns its place by shortening the number.
+     */
+    cost: number
+}
+
+/** An abbreviation is a unit of its own only in the sense that it saves digits. */
+const abbreviated = 1
+
+/** The unit a quantity is counted in, which a count has no name of its own for. */
+const itself: LadderUnit = { name: '', size: 1, cost: 0 }
+
+/** Thousands, millions and billions, for a quantity that is counted rather than measured. */
+const abbreviations: LadderUnit[] = [
+    { name: 'k', size: 1e3, cost: abbreviated },
+    { name: 'm', size: 1e6, cost: abbreviated },
+    { name: 'B', size: 1e9, cost: abbreviated },
+]
+
+/**
+ * The units each base unit can be written in. A quantity is written by choosing one of them for
+ * each base unit it is measured in.
+ */
+const ladders: Record<BaseUnit, LadderUnit[]> = {
+    person: [itself, ...abbreviations],
+    usd: [itself, ...abbreviations],
+    // fatalities are not abbreviated: there are never enough of them for it to save a digit
+    fatality: [itself],
+}
+
 /** What the dimensions of a quantity are called when they are looked up in a table. */
 function signatureOf(scales: Dimension[]): string {
     return scales
@@ -90,13 +129,90 @@ function signatureOf(scales: Dimension[]): string {
  */
 const styles: Record<string, NumberFormat | undefined> = {
     '': { kind: 'significantFigures' },
-    // things that are counted come in whole numbers
+    // things that are counted come in whole numbers, unless they are counted in thousands
+    'person^1': { kind: 'fixed', places: 0 },
+    'usd^1': { kind: 'fixed', places: 0 },
     'fatality^1': { kind: 'fixed', places: 0 },
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+/** An abbreviated number is worth three figures, wherever they fall. */
+const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
 
-function representationFor(unit: Unit, settings: ReaderSettings): Representation {
+const prefixes: Record<string, string | undefined> = { 'usd^1': '$' }
+
+/** A base unit together with the unit off its ladder that a quantity is written in. */
+interface Written extends Dimension {
+    unit: LadderUnit
+}
+
+function styleFor(signature: string, written: Written[]): NumberFormat {
+    if (written.some(({ unit }) => unit.cost === abbreviated)) {
+        return abbreviatedStyle
+    }
+    return styles[signature] ?? defaultStyle
+}
+
+/**
+ * What a number costs to read in a given unit: one for every digit past the third before the
+ * point, and nine tenths of one for the point itself and each leading zero after it. The number is
+ * written out to count it, so that a value that rounds up into another unit, such as 999.5 thousand
+ * people, costs what a million costs rather than what nine hundred thousand costs.
+ */
+function digitCost(value: number, format: NumberFormat): number {
+    if (value === 0) {
+        // nothing is shorter than zero in any unit
+        return 0
+    }
+    // the digits alone: neither the sign nor the separators between them make it harder to read
+    const written = formatNumber(value, format).replaceAll('-', '').replaceAll('\u202f', '')
+    const [integerPart, fraction = ''] = written.split('.')
+    if (integerPart !== '0') {
+        return Math.max(0, integerPart.length - 3)
+    }
+    // a shade less than a digit, since a number below one reads a little better than a long one
+    return 0.9 * (1 + (/^0*/.exec(fraction)?.[0].length ?? 0))
+}
+
+/** The name a quantity is written under, which a count has only when it is abbreviated. */
+function nameOf(written: Written[]): HumanReadableElement[] {
+    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
+    return names.length === 0 ? [] : atom(names.join('\u00b7'))
+}
+
+function combinations(dimensions: Dimension[]): Written[][] {
+    if (dimensions.length === 0) {
+        return [[]]
+    }
+    const [dimension, ...rest] = dimensions
+    return ladders[dimension.baseUnit].flatMap(unit => combinations(rest).map(tail => [{ ...dimension, unit }, ...tail]))
+}
+
+/**
+ * The best way of writing a value of these dimensions: of every combination of units from the
+ * ladders of the base units it is measured in, the one that costs least once the number it leaves
+ * behind is counted.
+ */
+function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Representation {
+    const signature = signatureOf(scales)
+    let best: Representation | undefined
+    let bestCost = Infinity
+    for (const written of combinations(scales.filter(({ power }) => power !== 0))) {
+        const format = styleFor(signature, written)
+        const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
+        const scale = (value: number): number => value / size
+        const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
+            + digitCost(scale(inBaseUnits), format)
+        if (cost < bestCost) {
+            best = { scale, unitName: nameOf(written), format, prefix: prefixes[signature] }
+            bestCost = cost
+        }
+    }
+    assert(best !== undefined, 'every quantity has at least one way of being written')
+    return best
+}
+
+function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
     switch (unit.kind) {
         case 'raw-percentage':
         case 'delta-percentage':
@@ -108,8 +224,7 @@ function representationFor(unit: Unit, settings: ReaderSettings): Representation
                 ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
         case 'dimensionfull':
-            // a count is named by the statistic it counts, so it has no name of its own here
-            return { unitName: [], scale: value => value, format: styles[signatureOf(unit.scales)] ?? defaultStyle }
+            return bestRepresentation(inBaseUnits, unit.scales)
     }
 }
 
@@ -154,7 +269,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     }
     const { unit } = stored
     let inBaseUnits = value * stored.toBaseUnits
-    const representation = representationFor(unit, settings)
+    const representation = representationFor(inBaseUnits, unit, settings)
     let party = undefined
     if (unit.kind === 'lead-percentage') {
         party = getParty(unit.partySystem, inBaseUnits)
@@ -163,7 +278,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     const explicitSign = unit.kind === 'delta-percentage' && inBaseUnits >= 0 ? '+' : ''
     const written = formatNumber(representation.scale(inBaseUnits), representation.format)
     return {
-        renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${written}`,
+        renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${representation.prefix ?? ''}${written}`,
         unitName: representation.unitName,
         hue: party?.hue ?? hueFor(unit),
     }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -1,11 +1,23 @@
 import { HueColors } from '../page_template/color-themes'
 
 import { HumanReadableElement } from './human-readable-name'
-import { Rounding, roundToDigits, separateNumber } from './text'
+import { formatToSignificantFigures, Rounding, roundToDigits, separateNumber } from './text'
 
 export type Hue = keyof HueColors
 
 type PartySystem = 'democratic' | 'left'
+
+/**
+ * The units everything else is measured in. A value is put in these before it is written out, so
+ * that quantities of the same kind are written the same way however they happen to be stored.
+ */
+export type BaseUnit = 'fatality'
+
+/** A base unit raised to a power, e.g., fatalities, or square meters. */
+export interface Dimension {
+    baseUnit: BaseUnit
+    power: number
+}
 
 // Abstract interpretation of a quantity as a unit.
 export type Unit = (
@@ -13,6 +25,7 @@ export type Unit = (
     | { kind: 'delta-percentage', partyColor?: Hue }
     | { kind: 'lead-percentage', partySystem: PartySystem }
     | { kind: 'temperature-F' }
+    | { kind: 'dimensionfull', scales: Dimension[] }
 )
 
 export interface StoredUnit {
@@ -32,6 +45,7 @@ export const missingValue = 'N/A'
 type NumberFormat = (
     { kind: 'fixed', places: number }
     | ({ kind: 'rounded' } & Rounding)
+    | { kind: 'significantFigures' }
 )
 
 interface Representation {
@@ -62,6 +76,26 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
+/** What the dimensions of a quantity are called when they are looked up in a table. */
+function signatureOf(scales: Dimension[]): string {
+    return scales
+        .filter(({ power }) => power !== 0)
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+}
+
+/**
+ * How the number is written once a unit has been chosen for it. Separate from the units: what a
+ * quantity is measured in does not say how precisely it is worth writing.
+ */
+const styles: Record<string, NumberFormat | undefined> = {
+    '': { kind: 'significantFigures' },
+    // things that are counted come in whole numbers
+    'fatality^1': { kind: 'fixed', places: 0 },
+}
+
+const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+
 function representationFor(unit: Unit, settings: ReaderSettings): Representation {
     switch (unit.kind) {
         case 'raw-percentage':
@@ -73,6 +107,9 @@ function representationFor(unit: Unit, settings: ReaderSettings): Representation
             return settings.temperatureUnit === 'celsius'
                 ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
+        case 'dimensionfull':
+            // a count is named by the statistic it counts, so it has no name of its own here
+            return { unitName: [], scale: value => value, format: styles[signatureOf(unit.scales)] ?? defaultStyle }
     }
 }
 
@@ -82,6 +119,8 @@ function formatNumber(value: number, format: NumberFormat): string {
             return separateNumber(value.toFixed(format.places))
         case 'rounded':
             return roundToDigits(value, format)
+        case 'significantFigures':
+            return separateNumber(formatToSignificantFigures(value, 3))
     }
 }
 
@@ -97,6 +136,7 @@ function hueFor(unit: Unit): Hue | undefined {
             return unit.partyColor
         case 'lead-percentage':
         case 'temperature-F':
+        case 'dimensionfull':
             return undefined
     }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -139,10 +139,40 @@ function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
     return styles[key] ?? defaultStyle
 }
 
-/** The names of the units chosen, in order. The ones with no name of their own are left out. */
-function nameOf(written: Written[]): HumanReadableElement[] {
-    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
-    return names.length === 0 ? [] : atom(names.join('\u00b7'))
+/** Adjacent names are one run of text, which the browser shapes as a whole. */
+function merged(name: HumanReadableElement[]): HumanReadableElement[] {
+    return name.reduce<HumanReadableElement[]>((run, element) => {
+        const last = run.length === 0 ? undefined : run[run.length - 1]
+        if (last?.type === 'atom' && element.type === 'atom') {
+            return [...run.slice(0, -1), { type: 'atom', value: last.value + element.value }]
+        }
+        return [...run, element]
+    }, [])
+}
+
+function raisedTo(power: number): HumanReadableElement[] {
+    return Math.abs(power) === 1 ? [] : [{ type: 'superscript', value: atom(Math.abs(power).toString()) }]
+}
+
+/** The units multiplied together, e.g., km^2, or people per km^2 for a quantity with a denominator. */
+function product(written: Written[]): HumanReadableElement[] {
+    return written.flatMap(({ unit, power }, index) => [
+        ...index === 0 ? [] : atom('\u00b7'),
+        ...atom(unit.name),
+        ...raisedTo(power),
+    ])
+}
+
+/** The names of the units chosen. The ones with no name of their own are left out. */
+export function nameOf(written: Written[]): HumanReadableElement[] {
+    const named = written.filter(({ unit }) => unit.name !== '')
+    const over = named.filter(({ power }) => power > 0)
+    const under = named.filter(({ power }) => power < 0)
+    if (under.length === 0) {
+        return merged(product(over))
+    }
+    // a solidus with nothing in front of it is set with a space, as a bare per reads better that way
+    return merged([...product(over), ...atom(over.length === 0 ? '/\u00a0' : '/'), ...product(under)])
 }
 
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -92,7 +92,10 @@ function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
         .map(([name, size]) => ({ ...scaling(baseUnit, name, size, 1), abbreviation: true })) // relatively low cost, just the abbreviation's length
 }
 
-/** The units there are to write a quantity in, whatever dimensions it turns out to have. */
+/**
+ * The units there are to write a quantity in, whatever dimensions it turns out to have. A count is
+ * named by the statistic counting it, so the unit it is counted in has no name to show.
+ */
 const unitPool: NamedUnit[] = [
     scaling('person', '', 1, 0),
     ...abbreviationsOf('person'),
@@ -136,10 +139,7 @@ function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
     return styles[key] ?? defaultStyle
 }
 
-/**
- * What goes in the unit column. A count has no name of its own, since the statistic says what is
- * being counted, so this is empty for one unless an abbreviation was chosen and it reads k, m or B.
- */
+/** The names of the units chosen, in order. The ones with no name of their own are left out. */
 function nameOf(written: Written[]): HumanReadableElement[] {
     const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
     return names.length === 0 ? [] : atom(names.join('\u00b7'))

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -67,34 +67,29 @@ const partyHues = {
 /* eslint-enable no-restricted-syntax */
 
 /**
- * One of the units a quantity can be written in: a named scaling of some dimensions. Most are a
- * scaling of a single base unit, but one that is its own thing rather than a power of another,
- * such as an acre, is one of these too.
+ * One of the units a quantity can be written in. Not a base unit necessarily, e.g.,
+ * an acre is a unit of area, but it is not a base unit.
  */
 export interface NamedUnit {
     name: string
     /** What one of it is, e.g., m^2 for an acre */
     dimensions: Dimension[]
-    /** How many base units one of it is: a thousand people is a thousand of them */
+    /** E.g., for an acre, 4046.86 */
     size: number
-    /**
-     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
-     * ordinarily counted in, and more for one that only earns its place by shortening the number.
-     */
+    /* How much should we discourage using this, in units of cost (digits) */
     cost: number
+    /** Whether it shortens the number rather than measuring in something else, as k and m do */
+    abbreviation: boolean
 }
 
-/** An abbreviation is a unit of its own only in the sense that it saves digits. */
-const abbreviated = 1
-
 function scaling(baseUnit: BaseUnit, name: string, size: number, cost: number): NamedUnit {
-    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost }
+    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost, abbreviation: false }
 }
 
 /** Thousands, millions and billions, for a quantity that is counted rather than measured. */
 function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
     return ([['k', 1e3], ['m', 1e6], ['B', 1e9]] as const)
-        .map(([name, size]) => scaling(baseUnit, name, size, abbreviated))
+        .map(([name, size]) => ({ ...scaling(baseUnit, name, size, 1), abbreviation: true })) // relatively low cost, just the abbreviation's length
 }
 
 /** The units there are to write a quantity in, whatever dimensions it turns out to have. */
@@ -135,7 +130,7 @@ const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
 const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
 
 function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
-    if (written.some(({ unit }) => unit.cost === abbreviated)) {
+    if (written.some(({ unit }) => unit.abbreviation)) {
         return abbreviatedStyle
     }
     return styles[key] ?? defaultStyle

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -9,12 +9,10 @@ export type Hue = keyof HueColors
 type PartySystem = 'democratic' | 'left'
 
 /**
- * The units everything else is measured in. A value is put in these before it is written out, so
- * that quantities of the same kind are written the same way however they happen to be stored.
+ * Base units, combined together via multiplication to form the units that correspond to the inBaseUnits value
  */
 export type BaseUnit = 'person' | 'usd' | 'fatality'
 
-/** A base unit raised to a power, e.g., people, or square meters. */
 export interface Dimension {
     baseUnit: BaseUnit
     power: number
@@ -115,19 +113,20 @@ const ladders: Record<BaseUnit, LadderUnit[]> = {
     fatality: [itself],
 }
 
-/** What the dimensions of a quantity are called when they are looked up in a table. */
-function signatureOf(scales: Dimension[]): string {
+type DimensionKey = string
+
+function renderAsKey(scales: Dimension[]): DimensionKey {
     return scales
         .filter(({ power }) => power !== 0)
         .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .sort((a, b) => a.localeCompare(b))
         .join(' ')
 }
 
 /**
- * How the number is written once a unit has been chosen for it. Separate from the units: what a
- * quantity is measured in does not say how precisely it is worth writing.
+ * Certain dimensionfull units have specific styles.
  */
-const styles: Record<string, NumberFormat | undefined> = {
+const styles: Record<DimensionKey, NumberFormat | undefined> = {
     '': { kind: 'significantFigures' },
     // things that are counted come in whole numbers, unless they are counted in thousands
     'person^1': { kind: 'fixed', places: 0 },
@@ -139,18 +138,18 @@ const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
 /** An abbreviated number is worth three figures, wherever they fall. */
 const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
 
-const prefixes: Record<string, string | undefined> = { 'usd^1': '$' }
+const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
 
 /** A base unit together with the unit off its ladder that a quantity is written in. */
 interface Written extends Dimension {
     unit: LadderUnit
 }
 
-function styleFor(signature: string, written: Written[]): NumberFormat {
+function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
     if (written.some(({ unit }) => unit.cost === abbreviated)) {
         return abbreviatedStyle
     }
-    return styles[signature] ?? defaultStyle
+    return styles[key] ?? defaultStyle
 }
 
 /**
@@ -194,17 +193,17 @@ function combinations(dimensions: Dimension[]): Written[][] {
  * behind is counted.
  */
 function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Representation {
-    const signature = signatureOf(scales)
+    const key = renderAsKey(scales)
     let best: Representation | undefined
     let bestCost = Infinity
     for (const written of combinations(scales.filter(({ power }) => power !== 0))) {
-        const format = styleFor(signature, written)
+        const format = styleFor(key, written)
         const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
         const scale = (value: number): number => value / size
         const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
             + digitCost(scale(inBaseUnits), format)
         if (cost < bestCost) {
-            best = { scale, unitName: nameOf(written), format, prefix: prefixes[signature] }
+            best = { scale, unitName: nameOf(written), format, prefix: prefixes[key] }
             bestCost = cost
         }
     }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -76,9 +76,15 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
-/** One of the units a base unit can be written in, e.g., m, km, cm. */
-interface LadderUnit {
+/**
+ * One of the units a quantity can be written in: a named scaling of some dimensions. Most are a
+ * scaling of a single base unit, but one that is its own thing rather than a power of another,
+ * such as an acre, is one of these too.
+ */
+interface NamedUnit {
     name: string
+    /** What one of it is, e.g., m^2 for an acre */
+    dimensions: Dimension[]
     /** How many base units one of it is: a thousand people is a thousand of them */
     size: number
     /**
@@ -91,26 +97,25 @@ interface LadderUnit {
 /** An abbreviation is a unit of its own only in the sense that it saves digits. */
 const abbreviated = 1
 
-/** The unit a quantity is counted in, which a count has no name of its own for. */
-const itself: LadderUnit = { name: '', size: 1, cost: 0 }
+function scaling(baseUnit: BaseUnit, name: string, size: number, cost: number): NamedUnit {
+    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost }
+}
 
 /** Thousands, millions and billions, for a quantity that is counted rather than measured. */
-const abbreviations: LadderUnit[] = [
-    { name: 'k', size: 1e3, cost: abbreviated },
-    { name: 'm', size: 1e6, cost: abbreviated },
-    { name: 'B', size: 1e9, cost: abbreviated },
-]
-
-/**
- * The units each base unit can be written in. A quantity is written by choosing one of them for
- * each base unit it is measured in.
- */
-const ladders: Record<BaseUnit, LadderUnit[]> = {
-    person: [itself, ...abbreviations],
-    usd: [itself, ...abbreviations],
-    // fatalities are not abbreviated: there are never enough of them for it to save a digit
-    fatality: [itself],
+function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
+    return ([['k', 1e3], ['m', 1e6], ['B', 1e9]] as const)
+        .map(([name, size]) => scaling(baseUnit, name, size, abbreviated))
 }
+
+/** The units there are to write a quantity in, whatever dimensions it turns out to have. */
+const unitPool: NamedUnit[] = [
+    scaling('person', '', 1, 0),
+    ...abbreviationsOf('person'),
+    scaling('usd', '', 1, 0),
+    ...abbreviationsOf('usd'),
+    // fatalities are not abbreviated: there are never enough of them for it to save a digit
+    scaling('fatality', '', 1, 0),
+]
 
 type DimensionKey = string
 
@@ -139,9 +144,10 @@ const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
 
 const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
 
-/** A base unit together with the unit off its ladder that a quantity is written in. */
-interface Written extends Dimension {
-    unit: LadderUnit
+/** A unit a quantity is written in, and the power it is written to. */
+interface Written {
+    unit: NamedUnit
+    power: number
 }
 
 function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
@@ -178,12 +184,42 @@ function nameOf(written: Written[]): HumanReadableElement[] {
     return names.length === 0 ? [] : atom(names.join('\u00b7'))
 }
 
-function combinations(dimensions: Dimension[]): Written[][] {
-    if (dimensions.length === 0) {
+type Exponents = Partial<Record<BaseUnit, number>>
+
+function exponentsOf(dimensions: Dimension[]): Exponents {
+    const exponents: Exponents = {}
+    for (const { baseUnit, power } of dimensions) {
+        exponents[baseUnit] = (exponents[baseUnit] ?? 0) + power
+    }
+    return exponents
+}
+
+/**
+ * Every way of writing these dimensions as a product of units from the pool. A unit may be used to
+ * a power, so that a length covers an area, and one that spans several base units covers all of
+ * them at once. Base units are taken in turn and settled outright, so a unit that would reopen one
+ * already settled is not offered -- which also keeps the search from going round in circles.
+ */
+function coverings(needed: Exponents, settled: BaseUnit[] = []): Written[][] {
+    const entries = Object.entries(needed) as [BaseUnit, number][]
+    const next = entries.find(([baseUnit, power]) => power !== 0 && !settled.includes(baseUnit))
+    if (next === undefined) {
         return [[]]
     }
-    const [dimension, ...rest] = dimensions
-    return ladders[dimension.baseUnit].flatMap(unit => combinations(rest).map(tail => [{ ...dimension, unit }, ...tail]))
+    const [baseUnit, power] = next
+    return unitPool.flatMap((unit) => {
+        const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
+        // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
+        if (covers === 0 || power % covers !== 0 || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
+            return []
+        }
+        const times = power / covers
+        const rest = { ...needed }
+        for (const dimension of unit.dimensions) {
+            rest[dimension.baseUnit] = (rest[dimension.baseUnit] ?? 0) - times * dimension.power
+        }
+        return coverings(rest, [...settled, baseUnit]).map(tail => [{ unit, power: times }, ...tail])
+    })
 }
 
 /**
@@ -195,7 +231,7 @@ function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Represent
     const key = renderAsKey(scales)
     let best: Representation | undefined
     let bestCost = Infinity
-    for (const written of combinations(scales.filter(({ power }) => power !== 0))) {
+    for (const written of coverings(exponentsOf(scales))) {
         const format = styleFor(key, written)
         const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
         const scale = (value: number): number => value / size

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -1,8 +1,8 @@
 import { HueColors } from '../page_template/color-themes'
 
-import { assert } from './defensive'
-import { HumanReadableElement } from './human-readable-name'
-import { formatToSignificantFigures, Rounding, roundToDigits, separateNumber } from './text'
+import { atom, HumanReadableElement } from './human-readable-name'
+import { formatNumber, NumberFormat } from './text'
+import { bestRepresentation } from './unit-search'
 
 export type Hue = keyof HueColors
 
@@ -40,23 +40,13 @@ export interface ReaderSettings {
 
 export const missingValue = 'N/A'
 
-/** How the number is written: to a fixed number of decimal places, or to a number of digits. */
-type NumberFormat = (
-    { kind: 'fixed', places: number }
-    | ({ kind: 'rounded' } & Rounding)
-    | { kind: 'significantFigures' }
-)
-
-interface Representation {
+/** How a quantity is written: what to scale it by, what to call the result, and to how many places. */
+export interface Representation {
     /** E.g., for cm this is x => x * 100 */
     scale: (inBaseUnits: number) => number
     unitName: HumanReadableElement[]
     format: NumberFormat
     prefix?: string
-}
-
-function atom(value: string): HumanReadableElement[] {
-    return [{ type: 'atom', value }]
 }
 
 const percent: Representation = { unitName: atom('%'), scale: value => value * 100, format: { kind: 'fixed', places: 2 } }
@@ -76,176 +66,6 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
-/**
- * One of the units a quantity can be written in: a named scaling of some dimensions. Most are a
- * scaling of a single base unit, but one that is its own thing rather than a power of another,
- * such as an acre, is one of these too.
- */
-interface NamedUnit {
-    name: string
-    /** What one of it is, e.g., m^2 for an acre */
-    dimensions: Dimension[]
-    /** How many base units one of it is: a thousand people is a thousand of them */
-    size: number
-    /**
-     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
-     * ordinarily counted in, and more for one that only earns its place by shortening the number.
-     */
-    cost: number
-}
-
-/** An abbreviation is a unit of its own only in the sense that it saves digits. */
-const abbreviated = 1
-
-function scaling(baseUnit: BaseUnit, name: string, size: number, cost: number): NamedUnit {
-    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost }
-}
-
-/** Thousands, millions and billions, for a quantity that is counted rather than measured. */
-function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
-    return ([['k', 1e3], ['m', 1e6], ['B', 1e9]] as const)
-        .map(([name, size]) => scaling(baseUnit, name, size, abbreviated))
-}
-
-/** The units there are to write a quantity in, whatever dimensions it turns out to have. */
-const unitPool: NamedUnit[] = [
-    scaling('person', '', 1, 0),
-    ...abbreviationsOf('person'),
-    scaling('usd', '', 1, 0),
-    ...abbreviationsOf('usd'),
-    // fatalities are not abbreviated: there are never enough of them for it to save a digit
-    scaling('fatality', '', 1, 0),
-]
-
-type DimensionKey = string
-
-function renderAsKey(scales: Dimension[]): DimensionKey {
-    return scales
-        .filter(({ power }) => power !== 0)
-        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
-        .sort((a, b) => a.localeCompare(b))
-        .join(' ')
-}
-
-/**
- * Certain dimensionfull units have specific styles.
- */
-const styles: Record<DimensionKey, NumberFormat | undefined> = {
-    '': { kind: 'significantFigures' },
-    // things that are counted come in whole numbers, unless they are counted in thousands
-    'person^1': { kind: 'fixed', places: 0 },
-    'usd^1': { kind: 'fixed', places: 0 },
-    'fatality^1': { kind: 'fixed', places: 0 },
-}
-
-const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
-/** An abbreviated number is worth three figures, wherever they fall. */
-const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
-
-const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
-
-/** A unit a quantity is written in, and the power it is written to. */
-interface Written {
-    unit: NamedUnit
-    power: number
-}
-
-function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
-    if (written.some(({ unit }) => unit.cost === abbreviated)) {
-        return abbreviatedStyle
-    }
-    return styles[key] ?? defaultStyle
-}
-
-/**
- * What a number costs to read in a given unit: one for every digit past the third before the
- * point, and nine tenths of one for the point itself and each leading zero after it. The number is
- * written out to count it, so that a value that rounds up into another unit, such as 999.5 thousand
- * people, costs what a million costs rather than what nine hundred thousand costs.
- */
-function digitCost(value: number, format: NumberFormat): number {
-    if (value === 0) {
-        // nothing is shorter than zero in any unit
-        return 0
-    }
-    // the digits alone: neither the sign nor the separators between them make it harder to read
-    const written = formatNumber(value, format).replaceAll('-', '').replaceAll('\u202f', '')
-    const [integerPart, fraction = ''] = written.split('.')
-    if (integerPart !== '0') {
-        return Math.max(0, integerPart.length - 3)
-    }
-    // a shade less than a digit, since a number below one reads a little better than a long one
-    return 0.9 * (1 + (/^0*/.exec(fraction)?.[0].length ?? 0))
-}
-
-/** The name a quantity is written under, which a count has only when it is abbreviated. */
-function nameOf(written: Written[]): HumanReadableElement[] {
-    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
-    return names.length === 0 ? [] : atom(names.join('\u00b7'))
-}
-
-type Exponents = Partial<Record<BaseUnit, number>>
-
-function exponentsOf(dimensions: Dimension[]): Exponents {
-    const exponents: Exponents = {}
-    for (const { baseUnit, power } of dimensions) {
-        exponents[baseUnit] = (exponents[baseUnit] ?? 0) + power
-    }
-    return exponents
-}
-
-/**
- * Every way of writing these dimensions as a product of units from the pool. A unit may be used to
- * a power, so that a length covers an area, and one that spans several base units covers all of
- * them at once. Base units are taken in turn and settled outright, so a unit that would reopen one
- * already settled is not offered -- which also keeps the search from going round in circles.
- */
-function coverings(needed: Exponents, settled: BaseUnit[] = []): Written[][] {
-    const entries = Object.entries(needed) as [BaseUnit, number][]
-    const next = entries.find(([baseUnit, power]) => power !== 0 && !settled.includes(baseUnit))
-    if (next === undefined) {
-        return [[]]
-    }
-    const [baseUnit, power] = next
-    return unitPool.flatMap((unit) => {
-        const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
-        // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
-        if (covers === 0 || power % covers !== 0 || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
-            return []
-        }
-        const times = power / covers
-        const rest = { ...needed }
-        for (const dimension of unit.dimensions) {
-            rest[dimension.baseUnit] = (rest[dimension.baseUnit] ?? 0) - times * dimension.power
-        }
-        return coverings(rest, [...settled, baseUnit]).map(tail => [{ unit, power: times }, ...tail])
-    })
-}
-
-/**
- * The best way of writing a value of these dimensions: of every combination of units from the
- * ladders of the base units it is measured in, the one that costs least once the number it leaves
- * behind is counted.
- */
-function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Representation {
-    const key = renderAsKey(scales)
-    let best: Representation | undefined
-    let bestCost = Infinity
-    for (const written of coverings(exponentsOf(scales))) {
-        const format = styleFor(key, written)
-        const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
-        const scale = (value: number): number => value / size
-        const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
-            + digitCost(scale(inBaseUnits), format)
-        if (cost < bestCost) {
-            best = { scale, unitName: nameOf(written), format, prefix: prefixes[key] }
-            bestCost = cost
-        }
-    }
-    assert(best !== undefined, 'every quantity has at least one way of being written')
-    return best
-}
-
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
     switch (unit.kind) {
         case 'raw-percentage':
@@ -259,17 +79,6 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
         case 'dimensionfull':
             return bestRepresentation(inBaseUnits, unit.scales)
-    }
-}
-
-function formatNumber(value: number, format: NumberFormat): string {
-    switch (format.kind) {
-        case 'fixed':
-            return separateNumber(value.toFixed(format.places))
-        case 'rounded':
-            return roundToDigits(value, format)
-        case 'significantFigures':
-            return separateNumber(formatToSignificantFigures(value, 3))
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -2,7 +2,7 @@ import { HueColors } from '../page_template/color-themes'
 
 import { atom, HumanReadableElement } from './human-readable-name'
 import { formatNumber, NumberFormat } from './text'
-import { bestRepresentation } from './unit-search'
+import { chooseUnits, Written } from './unit-search'
 
 export type Hue = keyof HueColors
 
@@ -66,6 +66,87 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
+/**
+ * One of the units a quantity can be written in: a named scaling of some dimensions. Most are a
+ * scaling of a single base unit, but one that is its own thing rather than a power of another,
+ * such as an acre, is one of these too.
+ */
+export interface NamedUnit {
+    name: string
+    /** What one of it is, e.g., m^2 for an acre */
+    dimensions: Dimension[]
+    /** How many base units one of it is: a thousand people is a thousand of them */
+    size: number
+    /**
+     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
+     * ordinarily counted in, and more for one that only earns its place by shortening the number.
+     */
+    cost: number
+}
+
+/** An abbreviation is a unit of its own only in the sense that it saves digits. */
+const abbreviated = 1
+
+function scaling(baseUnit: BaseUnit, name: string, size: number, cost: number): NamedUnit {
+    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost }
+}
+
+/** Thousands, millions and billions, for a quantity that is counted rather than measured. */
+function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
+    return ([['k', 1e3], ['m', 1e6], ['B', 1e9]] as const)
+        .map(([name, size]) => scaling(baseUnit, name, size, abbreviated))
+}
+
+/** The units there are to write a quantity in, whatever dimensions it turns out to have. */
+const unitPool: NamedUnit[] = [
+    scaling('person', '', 1, 0),
+    ...abbreviationsOf('person'),
+    scaling('usd', '', 1, 0),
+    ...abbreviationsOf('usd'),
+    // fatalities are not abbreviated: there are never enough of them for it to save a digit
+    scaling('fatality', '', 1, 0),
+]
+
+type DimensionKey = string
+
+function renderAsKey(scales: Dimension[]): DimensionKey {
+    return scales
+        .filter(({ power }) => power !== 0)
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .sort((a, b) => a.localeCompare(b))
+        .join(' ')
+}
+
+/**
+
+ */
+const styles: Record<DimensionKey, NumberFormat | undefined> = {
+    '': { kind: 'significantFigures' },
+    // things that are counted come in whole numbers, unless they are counted in thousands
+    'person^1': { kind: 'fixed', places: 0 },
+    'usd^1': { kind: 'fixed', places: 0 },
+    'fatality^1': { kind: 'fixed', places: 0 },
+}
+
+const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+/** An abbreviated number is worth three figures, wherever they fall. */
+const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
+
+const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
+
+function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
+    if (written.some(({ unit }) => unit.cost === abbreviated)) {
+        return abbreviatedStyle
+    }
+    return styles[key] ?? defaultStyle
+}
+
+/** The name a quantity is written under, which a count has only when it is abbreviated. */
+function nameOf(written: Written[]): HumanReadableElement[] {
+    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
+    return names.length === 0 ? [] : atom(names.join('\u00b7'))
+}
+
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
     switch (unit.kind) {
         case 'raw-percentage':
@@ -77,8 +158,11 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
             return settings.temperatureUnit === 'celsius'
                 ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
-        case 'dimensionfull':
-            return bestRepresentation(inBaseUnits, unit.scales)
+        case 'dimensionfull': {
+            const key = renderAsKey(unit.scales)
+            const { written, size, format } = chooseUnits(inBaseUnits, unit.scales, unitPool, chosen => styleFor(key, chosen))
+            return { scale: value => value / size, unitName: nameOf(written), format, prefix: prefixes[key] }
+        }
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -52,7 +52,6 @@ interface Representation {
     scale: (inBaseUnits: number) => number
     unitName: HumanReadableElement[]
     format: NumberFormat
-    /** Written in front of the number, as a dollar sign is */
     prefix?: string
 }
 
@@ -77,7 +76,7 @@ const partyHues = {
 } as const
 /* eslint-enable no-restricted-syntax */
 
-/** One of the units a base unit can be written in, e.g., a million people. */
+/** One of the units a base unit can be written in, e.g., m, km, cm. */
 interface LadderUnit {
     name: string
     /** How many base units one of it is: a thousand people is a thousand of them */

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -60,6 +60,24 @@ export function roundToDigits(value: number, rounding: Rounding): string {
     return separateNumber(value.toFixed(decimalPlaces(value, rounding)))
 }
 
+/** How a number is written: to a fixed number of decimal places, or to a number of digits. */
+export type NumberFormat = (
+    { kind: 'fixed', places: number }
+    | ({ kind: 'rounded' } & Rounding)
+    | { kind: 'significantFigures' }
+)
+
+export function formatNumber(value: number, format: NumberFormat): string {
+    switch (format.kind) {
+        case 'fixed':
+            return separateNumber(value.toFixed(format.places))
+        case 'rounded':
+            return roundToDigits(value, format)
+        case 'significantFigures':
+            return separateNumber(formatToSignificantFigures(value, 3))
+    }
+}
+
 // add in the B/m/k suffixes.
 export function abbreviate(value: number): { number: string, suffix: string } {
     for (const [threshold, divisor, suffix] of [[999.5e6, 1e9, 'B'], [999.5e3, 1e6, 'm'], [1e4, 1e3, 'k']] as const) {

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -77,7 +77,8 @@ export function formatToSignificantFigures(value: number, sigFigs: number = 3): 
     }
 
     const factor = Math.pow(10, sigFigs - 1 - Math.floor(Math.log10(Math.abs(value))))
-    const rounded = Math.round(value * factor) / factor
+    // by size, so that a half goes the same way whichever side of zero it falls
+    const rounded = Math.sign(value) * Math.round(Math.abs(value) * factor) / factor
 
     // taken from the rounded value, since rounding can carry into another digit, as 0.9995 does
     const magnitude = Math.floor(Math.log10(Math.abs(rounded)))

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -7,26 +7,25 @@ export interface Written {
     power: number
 }
 
-/** Rounding a quantity away, where the style asked for figures, is worse than any number of digits. */
-const roundsAway = 100
+const artificialZeroCost = 100
 
 /**
- * What a number costs to read in a given unit: a digit for every one past the three that three
- * significant figures fit in, wherever they fall. A number below one pays for its leading zeros,
- * which are digits like any other, and a unit that leaves a quantity with no figures at all pays
- * everything.
+ * We charge 1 for every digit that is printed.
  *
- * Counted from the number as printed rather than from a logarithm, so that a value that rounds up
- * into another unit, such as 999.5 thousand people, costs what a million costs.
+ * This is almost, but not quite, the same as the number of significant figures, because
+ * e.g., 1000 is counted as 4, not 1.
+ *
+ * Two caveats:
+ * 1. It is counted from the number as printed, so 999.5 is counted as if it were 1000.
+ * 2. If a number is formatted to an "artificial 0" e.g., 0.0001 -> 0.000, we apply a huge penalty
+ *      unless in fixed point.
  */
 function digitCost(value: number, format: NumberFormat): number {
     const digits = formatNumber(value, format).replace(/[^0-9]/g, '')
-    // a nonzero quantity written as 0 costs everything, unless the style fixed the places, which
-    // decided that rounding it away is precise enough
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
-        return roundsAway
+        return artificialZeroCost
     }
-    return Math.max(0, digits.length - 3)
+    return digits.length
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>
@@ -46,12 +45,14 @@ function exponentsOf(dimensions: Dimension[]): Exponents {
  * already settled is not offered -- which also keeps the search from going round in circles.
  */
 function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = []): Written[][] {
-    const entries = Object.entries(needed) as [BaseUnit, number][]
-    const next = entries.find(([baseUnit, power]) => power !== 0 && !settled.includes(baseUnit))
-    if (next === undefined) {
+    const entries = Object.entries(needed).filter(
+        ([baseUnit, power]) => (power ?? 0) !== 0 && !settled.includes(baseUnit),
+    ).sort(([baseUnitA], [baseUnitB]) => baseUnitA.localeCompare(baseUnitB))
+    if (entries.length === 0) {
         return [[]]
     }
-    const [baseUnit, power] = next
+    const [baseUnit, power] = entries[0]
+    assert(power !== undefined, 'we filtered out undefined powers')
     return pool.flatMap((unit) => {
         const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
         // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
@@ -68,8 +69,7 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
 }
 
 /**
- * The cheapest way of writing a value of these dimensions: of every way of covering them with
- * units from the pool, the one that costs least once the number it leaves behind is counted.
+ * The cheapest way of writing a value of these dimensions
  */
 export function chooseUnits(
     inBaseUnits: number,
@@ -83,7 +83,7 @@ export function chooseUnits(
         const format = styleFor(written)
         const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
         const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
-            + digitCost(inBaseUnits / size, format)
+            + Math.max(0, digitCost(inBaseUnits / size, format) - 3)
         if (cost < bestCost) {
             best = { written, size, format }
             bestCost = cost

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -1,87 +1,11 @@
 import { assert } from './defensive'
-import { atom, HumanReadableElement } from './human-readable-name'
-import type { BaseUnit, Dimension, Representation } from './quantity'
+import type { BaseUnit, Dimension, NamedUnit } from './quantity'
 import { formatNumber, NumberFormat } from './text'
 
-/**
- * One of the units a quantity can be written in: a named scaling of some dimensions. Most are a
- * scaling of a single base unit, but one that is its own thing rather than a power of another,
- * such as an acre, is one of these too.
- */
-interface NamedUnit {
-    name: string
-    /** What one of it is, e.g., m^2 for an acre */
-    dimensions: Dimension[]
-    /** How many base units one of it is: a thousand people is a thousand of them */
-    size: number
-    /**
-     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
-     * ordinarily counted in, and more for one that only earns its place by shortening the number.
-     */
-    cost: number
-}
-
-/** An abbreviation is a unit of its own only in the sense that it saves digits. */
-const abbreviated = 1
-
-function scaling(baseUnit: BaseUnit, name: string, size: number, cost: number): NamedUnit {
-    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost }
-}
-
-/** Thousands, millions and billions, for a quantity that is counted rather than measured. */
-function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
-    return ([['k', 1e3], ['m', 1e6], ['B', 1e9]] as const)
-        .map(([name, size]) => scaling(baseUnit, name, size, abbreviated))
-}
-
-/** The units there are to write a quantity in, whatever dimensions it turns out to have. */
-const unitPool: NamedUnit[] = [
-    scaling('person', '', 1, 0),
-    ...abbreviationsOf('person'),
-    scaling('usd', '', 1, 0),
-    ...abbreviationsOf('usd'),
-    // fatalities are not abbreviated: there are never enough of them for it to save a digit
-    scaling('fatality', '', 1, 0),
-]
-
-type DimensionKey = string
-
-function renderAsKey(scales: Dimension[]): DimensionKey {
-    return scales
-        .filter(({ power }) => power !== 0)
-        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
-        .sort((a, b) => a.localeCompare(b))
-        .join(' ')
-}
-
-/**
- * Certain dimensionfull units have specific styles.
- */
-const styles: Record<DimensionKey, NumberFormat | undefined> = {
-    '': { kind: 'significantFigures' },
-    // things that are counted come in whole numbers, unless they are counted in thousands
-    'person^1': { kind: 'fixed', places: 0 },
-    'usd^1': { kind: 'fixed', places: 0 },
-    'fatality^1': { kind: 'fixed', places: 0 },
-}
-
-const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
-/** An abbreviated number is worth three figures, wherever they fall. */
-const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
-
-const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
-
 /** A unit a quantity is written in, and the power it is written to. */
-interface Written {
+export interface Written {
     unit: NamedUnit
     power: number
-}
-
-function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
-    if (written.some(({ unit }) => unit.cost === abbreviated)) {
-        return abbreviatedStyle
-    }
-    return styles[key] ?? defaultStyle
 }
 
 /**
@@ -105,12 +29,6 @@ function digitCost(value: number, format: NumberFormat): number {
     return 0.9 * (1 + (/^0*/.exec(fraction)?.[0].length ?? 0))
 }
 
-/** The name a quantity is written under, which a count has only when it is abbreviated. */
-function nameOf(written: Written[]): HumanReadableElement[] {
-    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
-    return names.length === 0 ? [] : atom(names.join('\u00b7'))
-}
-
 type Exponents = Partial<Record<BaseUnit, number>>
 
 function exponentsOf(dimensions: Dimension[]): Exponents {
@@ -127,14 +45,14 @@ function exponentsOf(dimensions: Dimension[]): Exponents {
  * them at once. Base units are taken in turn and settled outright, so a unit that would reopen one
  * already settled is not offered -- which also keeps the search from going round in circles.
  */
-function coverings(needed: Exponents, settled: BaseUnit[] = []): Written[][] {
+function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = []): Written[][] {
     const entries = Object.entries(needed) as [BaseUnit, number][]
     const next = entries.find(([baseUnit, power]) => power !== 0 && !settled.includes(baseUnit))
     if (next === undefined) {
         return [[]]
     }
     const [baseUnit, power] = next
-    return unitPool.flatMap((unit) => {
+    return pool.flatMap((unit) => {
         const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
         // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
         if (covers === 0 || power % covers !== 0 || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
@@ -145,27 +63,29 @@ function coverings(needed: Exponents, settled: BaseUnit[] = []): Written[][] {
         for (const dimension of unit.dimensions) {
             rest[dimension.baseUnit] = (rest[dimension.baseUnit] ?? 0) - times * dimension.power
         }
-        return coverings(rest, [...settled, baseUnit]).map(tail => [{ unit, power: times }, ...tail])
+        return coverings(rest, pool, [...settled, baseUnit]).map(tail => [{ unit, power: times }, ...tail])
     })
 }
 
 /**
- * The best way of writing a value of these dimensions: of every combination of units from the
- * ladders of the base units it is measured in, the one that costs least once the number it leaves
- * behind is counted.
+ * The cheapest way of writing a value of these dimensions: of every way of covering them with
+ * units from the pool, the one that costs least once the number it leaves behind is counted.
  */
-export function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Representation {
-    const key = renderAsKey(scales)
-    let best: Representation | undefined
+export function chooseUnits(
+    inBaseUnits: number,
+    scales: Dimension[],
+    pool: NamedUnit[],
+    styleFor: (written: Written[]) => NumberFormat,
+): { written: Written[], size: number, format: NumberFormat } {
+    let best: { written: Written[], size: number, format: NumberFormat } | undefined
     let bestCost = Infinity
-    for (const written of coverings(exponentsOf(scales))) {
-        const format = styleFor(key, written)
+    for (const written of coverings(exponentsOf(scales), pool)) {
+        const format = styleFor(written)
         const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
-        const scale = (value: number): number => value / size
         const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
-            + digitCost(scale(inBaseUnits), format)
+            + digitCost(inBaseUnits / size, format)
         if (cost < bestCost) {
-            best = { scale, unitName: nameOf(written), format, prefix: prefixes[key] }
+            best = { written, size, format }
             bestCost = cost
         }
     }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -1,0 +1,174 @@
+import { assert } from './defensive'
+import { atom, HumanReadableElement } from './human-readable-name'
+import type { BaseUnit, Dimension, Representation } from './quantity'
+import { formatNumber, NumberFormat } from './text'
+
+/**
+ * One of the units a quantity can be written in: a named scaling of some dimensions. Most are a
+ * scaling of a single base unit, but one that is its own thing rather than a power of another,
+ * such as an acre, is one of these too.
+ */
+interface NamedUnit {
+    name: string
+    /** What one of it is, e.g., m^2 for an acre */
+    dimensions: Dimension[]
+    /** How many base units one of it is: a thousand people is a thousand of them */
+    size: number
+    /**
+     * What reaching for it costs, before the digits it saves. Zero for the unit a quantity is
+     * ordinarily counted in, and more for one that only earns its place by shortening the number.
+     */
+    cost: number
+}
+
+/** An abbreviation is a unit of its own only in the sense that it saves digits. */
+const abbreviated = 1
+
+function scaling(baseUnit: BaseUnit, name: string, size: number, cost: number): NamedUnit {
+    return { name, dimensions: [{ baseUnit, power: 1 }], size, cost }
+}
+
+/** Thousands, millions and billions, for a quantity that is counted rather than measured. */
+function abbreviationsOf(baseUnit: BaseUnit): NamedUnit[] {
+    return ([['k', 1e3], ['m', 1e6], ['B', 1e9]] as const)
+        .map(([name, size]) => scaling(baseUnit, name, size, abbreviated))
+}
+
+/** The units there are to write a quantity in, whatever dimensions it turns out to have. */
+const unitPool: NamedUnit[] = [
+    scaling('person', '', 1, 0),
+    ...abbreviationsOf('person'),
+    scaling('usd', '', 1, 0),
+    ...abbreviationsOf('usd'),
+    // fatalities are not abbreviated: there are never enough of them for it to save a digit
+    scaling('fatality', '', 1, 0),
+]
+
+type DimensionKey = string
+
+function renderAsKey(scales: Dimension[]): DimensionKey {
+    return scales
+        .filter(({ power }) => power !== 0)
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .sort((a, b) => a.localeCompare(b))
+        .join(' ')
+}
+
+/**
+ * Certain dimensionfull units have specific styles.
+ */
+const styles: Record<DimensionKey, NumberFormat | undefined> = {
+    '': { kind: 'significantFigures' },
+    // things that are counted come in whole numbers, unless they are counted in thousands
+    'person^1': { kind: 'fixed', places: 0 },
+    'usd^1': { kind: 'fixed', places: 0 },
+    'fatality^1': { kind: 'fixed', places: 0 },
+}
+
+const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+/** An abbreviated number is worth three figures, wherever they fall. */
+const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
+
+const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
+
+/** A unit a quantity is written in, and the power it is written to. */
+interface Written {
+    unit: NamedUnit
+    power: number
+}
+
+function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
+    if (written.some(({ unit }) => unit.cost === abbreviated)) {
+        return abbreviatedStyle
+    }
+    return styles[key] ?? defaultStyle
+}
+
+/**
+ * What a number costs to read in a given unit: one for every digit past the third before the
+ * point, and nine tenths of one for the point itself and each leading zero after it. The number is
+ * written out to count it, so that a value that rounds up into another unit, such as 999.5 thousand
+ * people, costs what a million costs rather than what nine hundred thousand costs.
+ */
+function digitCost(value: number, format: NumberFormat): number {
+    if (value === 0) {
+        // nothing is shorter than zero in any unit
+        return 0
+    }
+    // the digits alone: neither the sign nor the separators between them make it harder to read
+    const written = formatNumber(value, format).replaceAll('-', '').replaceAll('\u202f', '')
+    const [integerPart, fraction = ''] = written.split('.')
+    if (integerPart !== '0') {
+        return Math.max(0, integerPart.length - 3)
+    }
+    // a shade less than a digit, since a number below one reads a little better than a long one
+    return 0.9 * (1 + (/^0*/.exec(fraction)?.[0].length ?? 0))
+}
+
+/** The name a quantity is written under, which a count has only when it is abbreviated. */
+function nameOf(written: Written[]): HumanReadableElement[] {
+    const names = written.map(({ unit }) => unit.name).filter(name => name !== '')
+    return names.length === 0 ? [] : atom(names.join('\u00b7'))
+}
+
+type Exponents = Partial<Record<BaseUnit, number>>
+
+function exponentsOf(dimensions: Dimension[]): Exponents {
+    const exponents: Exponents = {}
+    for (const { baseUnit, power } of dimensions) {
+        exponents[baseUnit] = (exponents[baseUnit] ?? 0) + power
+    }
+    return exponents
+}
+
+/**
+ * Every way of writing these dimensions as a product of units from the pool. A unit may be used to
+ * a power, so that a length covers an area, and one that spans several base units covers all of
+ * them at once. Base units are taken in turn and settled outright, so a unit that would reopen one
+ * already settled is not offered -- which also keeps the search from going round in circles.
+ */
+function coverings(needed: Exponents, settled: BaseUnit[] = []): Written[][] {
+    const entries = Object.entries(needed) as [BaseUnit, number][]
+    const next = entries.find(([baseUnit, power]) => power !== 0 && !settled.includes(baseUnit))
+    if (next === undefined) {
+        return [[]]
+    }
+    const [baseUnit, power] = next
+    return unitPool.flatMap((unit) => {
+        const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
+        // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
+        if (covers === 0 || power % covers !== 0 || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
+            return []
+        }
+        const times = power / covers
+        const rest = { ...needed }
+        for (const dimension of unit.dimensions) {
+            rest[dimension.baseUnit] = (rest[dimension.baseUnit] ?? 0) - times * dimension.power
+        }
+        return coverings(rest, [...settled, baseUnit]).map(tail => [{ unit, power: times }, ...tail])
+    })
+}
+
+/**
+ * The best way of writing a value of these dimensions: of every combination of units from the
+ * ladders of the base units it is measured in, the one that costs least once the number it leaves
+ * behind is counted.
+ */
+export function bestRepresentation(inBaseUnits: number, scales: Dimension[]): Representation {
+    const key = renderAsKey(scales)
+    let best: Representation | undefined
+    let bestCost = Infinity
+    for (const written of coverings(exponentsOf(scales))) {
+        const format = styleFor(key, written)
+        const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
+        const scale = (value: number): number => value / size
+        const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
+            + digitCost(scale(inBaseUnits), format)
+        if (cost < bestCost) {
+            best = { scale, unitName: nameOf(written), format, prefix: prefixes[key] }
+            bestCost = cost
+        }
+    }
+    assert(best !== undefined, 'every quantity has at least one way of being written')
+    return best
+}

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -2,17 +2,23 @@ import { assert } from './defensive'
 import type { BaseUnit, Dimension, NamedUnit } from './quantity'
 import { formatNumber, NumberFormat } from './text'
 
-/** A unit a quantity is written in, and the power it is written to. */
 export interface Written {
     unit: NamedUnit
     power: number
 }
 
 /**
- * What a number costs to read in a given unit: one for every digit past the third before the
- * point, and nine tenths of one for the point itself and each leading zero after it. The number is
- * written out to count it, so that a value that rounds up into another unit, such as 999.5 thousand
- * people, costs what a million costs rather than what nine hundred thousand costs.
+ * What a number costs to read in a given unit: how far its magnitude is from the range three
+ * significant figures fit in, which is one to a thousand. A factor of ten above that costs a
+ * digit, and one below costs nine tenths of a digit, a number just under one reading a little
+ * easier than a long one.
+ *
+ * The places after the point are not counted. At three significant figures they are what a shorter
+ * integer part buys, so charging for both would mean the trade never paid: 1.00m would cost more
+ * than 1 000k, and nothing would ever be abbreviated.
+ *
+ * Measured from the number as printed rather than from a logarithm, so that a value that rounds up
+ * into another unit, such as 999.5 thousand people, costs what a million costs.
  */
 function digitCost(value: number, format: NumberFormat): number {
     if (value === 0) {
@@ -22,6 +28,7 @@ function digitCost(value: number, format: NumberFormat): number {
     // the digits alone: neither the sign nor the separators between them make it harder to read
     const written = formatNumber(value, format).replaceAll('-', '').replaceAll('\u202f', '')
     const [integerPart, fraction = ''] = written.split('.')
+    // where the magnitude shows up: in the digits before the point, or in the zeros after it
     if (integerPart !== '0') {
         return Math.max(0, integerPart.length - 3)
     }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -14,8 +14,9 @@ export interface Written {
  * easier than a long one.
  *
  * The places after the point are not counted. At three significant figures they are what a shorter
- * integer part buys, so charging for both would mean the trade never paid: 1.00m would cost more
- * than 1 000k, and nothing would ever be abbreviated.
+ * integer part buys: a million people reads as 1 000k, a digit past the third, or as 1.00m, which
+ * spends two places to save that digit. Charging for both would leave the trade never worth
+ * making, and nothing would ever be abbreviated.
  *
  * Measured from the number as printed rather than from a logarithm, so that a value that rounds up
  * into another unit, such as 999.5 thousand people, costs what a million costs.

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -21,8 +21,8 @@ const roundsAway = 100
  */
 function digitCost(value: number, format: NumberFormat): number {
     const digits = formatNumber(value, format).replace(/[^0-9]/g, '')
-    // a fixed number of places is a decision that the places past them do not matter, so a value
-    // that rounds away under one is being written as precisely as it was meant to be
+    // a nonzero quantity written as 0 costs everything, unless the style fixed the places, which
+    // decided that rounding it away is precise enough
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return roundsAway
     }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -7,34 +7,26 @@ export interface Written {
     power: number
 }
 
+/** Rounding a quantity away, where the style asked for figures, is worse than any number of digits. */
+const roundsAway = 100
+
 /**
- * What a number costs to read in a given unit: how far its magnitude is from the range three
- * significant figures fit in, which is one to a thousand. A factor of ten above that costs a
- * digit, and one below costs nine tenths of a digit, a number just under one reading a little
- * easier than a long one.
+ * What a number costs to read in a given unit: a digit for every one past the three that three
+ * significant figures fit in, wherever they fall. A number below one pays for its leading zeros,
+ * which are digits like any other, and a unit that leaves a quantity with no figures at all pays
+ * everything.
  *
- * The places after the point are not counted. At three significant figures they are what a shorter
- * integer part buys: a million people reads as 1 000k, a digit past the third, or as 1.00m, which
- * spends two places to save that digit. Charging for both would leave the trade never worth
- * making, and nothing would ever be abbreviated.
- *
- * Measured from the number as printed rather than from a logarithm, so that a value that rounds up
+ * Counted from the number as printed rather than from a logarithm, so that a value that rounds up
  * into another unit, such as 999.5 thousand people, costs what a million costs.
  */
 function digitCost(value: number, format: NumberFormat): number {
-    if (value === 0) {
-        // nothing is shorter than zero in any unit
-        return 0
+    const digits = formatNumber(value, format).replace(/[^0-9]/g, '')
+    // a fixed number of places is a decision that the places past them do not matter, so a value
+    // that rounds away under one is being written as precisely as it was meant to be
+    if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
+        return roundsAway
     }
-    // the digits alone: neither the sign nor the separators between them make it harder to read
-    const written = formatNumber(value, format).replaceAll('-', '').replaceAll('\u202f', '')
-    const [integerPart, fraction = ''] = written.split('.')
-    // where the magnitude shows up: in the digits before the point, or in the zeros after it
-    if (integerPart !== '0') {
-        return Math.max(0, integerPart.length - 3)
-    }
-    // a shade less than a digit, since a number below one reads a little better than a long one
-    return 0.9 * (1 + (/^0*/.exec(fraction)?.[0].length ?? 0))
+    return Math.max(0, digits.length - 3)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,4 +1,4 @@
-import { StoredUnit } from './quantity'
+import { BaseUnit, StoredUnit } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
@@ -46,6 +46,14 @@ function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
 }
 
+function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 1): StoredUnit {
+    const entries = Object.entries(scales) as [BaseUnit, number][]
+    return {
+        unit: { kind: 'dimensionfull', scales: entries.map(([baseUnit, power]) => ({ baseUnit, power })) },
+        toBaseUnits,
+    }
+}
+
 /* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
 export const storedUnits = {
     percentage: { unit: { kind: 'raw-percentage' }, toBaseUnits: 1 },
@@ -65,6 +73,8 @@ export const storedUnits = {
     partyChangeGreen: { unit: { kind: 'delta-percentage', partyColor: 'green' }, toBaseUnits: 1 },
     partyChangePurple: { unit: { kind: 'delta-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
     temperature: { unit: { kind: 'temperature-F' }, toBaseUnits: 1 },
+    number: dimensionfull({}),
+    fatalities: dimensionfull({ fatality: 1 }),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -74,7 +74,9 @@ export const storedUnits = {
     partyChangePurple: { unit: { kind: 'delta-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
     temperature: { unit: { kind: 'temperature-F' }, toBaseUnits: 1 },
     number: dimensionfull({}),
+    population: dimensionfull({ person: 1 }),
     fatalities: dimensionfull({ fatality: 1 }),
+    usd: dimensionfull({ usd: 1 }),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/unit/formatToSignificantFigures.test.ts
+++ b/react/unit/formatToSignificantFigures.test.ts
@@ -39,6 +39,13 @@ void describe('formatToSignificantFigures', () => {
         assert.equal(formatToSignificantFigures(-0.0123456), '-0.0123')
     })
 
+    void test('rounds a half by size, not by the side of zero it falls on', () => {
+        assert.equal(formatToSignificantFigures(78.45), '78.5')
+        assert.equal(formatToSignificantFigures(-78.45), '-78.5')
+        assert.equal(formatToSignificantFigures(999500), '1000000')
+        assert.equal(formatToSignificantFigures(-999500), '-1000000')
+    })
+
     void test('handles edge cases', () => {
         assert.equal(formatToSignificantFigures(81.407), '81.4')
         assert.equal(formatToSignificantFigures(1.0), '1.00')

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -95,6 +95,19 @@ for (const [unitType, value, expected] of [
     })
 }
 
+// A count is abbreviated by how long the number reads once it is written out, which is the same
+// however large it is and whichever side of zero it falls
+for (const [unitType, value, expected] of [
+    ['population', -999500, '-1.00m'],
+    ['population', 999500000000, '1\u202f000B'],
+    ['population', -999500000000, '-1\u202f000B'],
+    ['usd', 999500000000, '$1\u202f000B'],
+] as const) {
+    void test(`${unitType} renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue(unitType, value), expected)
+    })
+}
+
 // Money and people are counted in thousands at the same point
 for (const [unitType, value, expected] of [
     ['usd', 1234, '$1\u202f234'],

--- a/react/unit/unit-search.test.ts
+++ b/react/unit/unit-search.test.ts
@@ -1,0 +1,100 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { reifyString } from '../src/utils/human-readable-name'
+import { BaseUnit, Dimension, NamedUnit, nameOf } from '../src/utils/quantity'
+import { NumberFormat } from '../src/utils/text'
+import { chooseUnits } from '../src/utils/unit-search'
+
+function unit(name: string, dimensions: Partial<Record<BaseUnit, number>>, size: number, cost = 0): NamedUnit {
+    const entries = Object.entries(dimensions) as [BaseUnit, number][]
+    return { name, dimensions: entries.map(([baseUnit, power]) => ({ baseUnit, power })), size, cost, abbreviation: false }
+}
+
+const people = unit('', { person: 1 }, 1)
+const thousands = { ...unit('k', { person: 1 }, 1e3, 1), abbreviation: true }
+const millions = { ...unit('m', { person: 1 }, 1e6, 1), abbreviation: true }
+const counting: NamedUnit[] = [people, thousands, millions]
+
+const dimensionsOf = (dimensions: Partial<Record<BaseUnit, number>>): Dimension[] =>
+    (Object.entries(dimensions) as [BaseUnit, number][]).map(([baseUnit, power]) => ({ baseUnit, power }))
+
+const wholeNumbers: NumberFormat = { kind: 'fixed', places: 0 }
+const threeFigures: NumberFormat = { kind: 'significantFigures' }
+/** What the site does: an abbreviated number is worth three figures, a counted one is whole. */
+const countingStyle = (written: { unit: NamedUnit }[]): NumberFormat =>
+    written.some(({ unit: each }) => each.abbreviation) ? threeFigures : wholeNumbers
+
+/** The units chosen, as they would be written: a name, and the power it is raised to. */
+function chosen(inBaseUnits: number, dimensions: Partial<Record<BaseUnit, number>>, pool: NamedUnit[], styleFor = countingStyle): string {
+    const { written } = chooseUnits(inBaseUnits, dimensionsOf(dimensions), pool, styleFor)
+    return written.map(({ unit: chosenUnit, power }) => `${chosenUnit.name === '' ? '<none>' : chosenUnit.name}^${power}`).join(' ')
+}
+
+// A unit is worth reaching for once the number it leaves behind is shorter by more than it costs
+for (const [value, expected] of [
+    [999, '<none>^1'],
+    [9999, '<none>^1'],
+    // five digits cost two, against three figures and the cost of the abbreviation
+    [10000, 'k^1'],
+    [12345, 'k^1'],
+    [999499, 'k^1'],
+    // counted from the number as printed: 999.5k prints as 1 000k, which is four digits
+    [999500, 'm^1'],
+    [1e9, 'm^1'],
+] as const) {
+    void test(`a count of ${value} is written in ${expected}`, () => {
+        assert.equal(chosen(value, { person: 1 }, counting), expected)
+    })
+}
+
+void test('a unit covers a dimension by being raised to its power', () => {
+    // a thousand people squared is a million of them, which is where the digits are saved
+    assert.equal(chosen(1e6, { person: 2 }, counting), 'k^2')
+})
+
+void test('a unit raised to a power costs what it costs each time it is used', () => {
+    const pricey = [people, { ...unit('K', { person: 1 }, 1e3, 3), abbreviation: true }]
+    // three per use is six over two uses, more than the four digits it saves
+    assert.equal(chosen(1e6, { person: 2 }, pricey), '<none>^2')
+})
+
+void test('a unit of its own for the whole dimension competes with a power of a smaller one', () => {
+    const pair = unit('pairs', { person: 2 }, 1e6, 0.5)
+    // the same number either way, so the one that costs less to reach for wins
+    assert.equal(chosen(1e6, { person: 2 }, [...counting, pair]), 'pairs^1')
+})
+
+void test('a unit can be used at a negative power, for what a quantity is written per', () => {
+    const deaths = unit('', { fatality: 1 }, 1)
+    const hundredThousand = unit('100k', { person: 1 }, 1e5, 0.5)
+    // a death per hundred thousand people reads as 1.00 that way, and as 0.0000100 per person
+    assert.equal(chosen(1e-5, { fatality: 1, person: -1 }, [deaths, people, hundredThousand], () => threeFigures), '<none>^1 100k^-1')
+})
+
+void test('a unit that rounds the quantity away is not worth choosing', () => {
+    const threeDigits: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+    // one person per hundred thousand reads as 0.000 in people, and as 1.00 in hundreds of thousands
+    const hundredThousand = unit('100k', { person: 1 }, 1e5, 0.5)
+    assert.equal(chosen(1e-5, { person: -1 }, [people, hundredThousand], () => threeDigits), '100k^-1')
+})
+
+void test('a fixed number of places is a decision that rounding away is precise enough', () => {
+    // a fraction of a person is no people, which is what whole numbers of them means
+    assert.equal(chosen(0.123, { person: 1 }, counting), '<none>^1')
+})
+
+// The name the chosen units are written under, which is what goes in the unit column
+for (const [written, expected] of [
+    [[{ unit: people, power: 1 }], ''],
+    [[{ unit: thousands, power: 1 }], 'k'],
+    // a unit raised to a power says so, and one below the line goes under a solidus
+    [[{ unit: unit('km', { person: 1 }, 1e3), power: 2 }], 'km^{2}'],
+    [[{ unit: people, power: 1 }, { unit: unit('km', { person: 1 }, 1e3), power: -2 }], '/ km^{2}'],
+    [[{ unit: unit('g', { fatality: 1 }, 1), power: 1 }, { unit: unit('km', { person: 1 }, 1e3), power: -2 }], 'g/km^{2}'],
+    [[{ unit: unit('g', { fatality: 1 }, 1), power: 1 }, { unit: unit('k', { person: 1 }, 1e3), power: 1 }], 'g·k'],
+] as const) {
+    void test(`${expected === '' ? 'an unnamed unit' : expected} is the name of its units`, () => {
+        assert.equal(reifyString(nameOf([...written])), expected)
+    })
+}


### PR DESCRIPTION
Third of three split out of #2253. Based on #2256; the diff shown here is against it.

`population` and `usd` each had an arm that knew when to reach for a thousand or a million, sharing an `abbreviate` helper whose ladder and thresholds were written down nowhere. Each base unit now has a ladder of units it can be written in:

```ts
const ladders: Record<BaseUnit, LadderUnit[]> = {
    person: [itself, ...abbreviations],
    usd: [itself, ...abbreviations],
    // fatalities are not abbreviated: there are never enough of them for it to save a digit
    fatality: [itself],
}
```

and the unit a quantity is written in is searched for rather than decided: write the number out in every rung, keep the cheapest, where a digit past the third costs one, a leading zero after the point costs nine tenths, and reaching for an abbreviation costs one.

That reproduces the threshold neither arm had stated — a thousand is not worth reaching for until the number is five digits long, because `12 345` costs two and `12.3k` costs one — and the promotion at `999 500`, because the cost is counted from the number *as it prints*, and `999.5k` prints as `1 000k`.

Cost and `digitCost` are written over products of powers, but nothing uses a power other than one yet.

## Rendering differences

The 1440-case sweep is identical to main. A 60,672-case stress run over the four counted types, spread across fifteen magnitudes with every value around each of main's thresholds, has **70 differences in two groups**:

| | main | after | when |
|---|---|---|---|
| 68 | `1.00e+3B` | `1 000B` | at or above 999.5 billion |
| 2 | `10 000` | `10.0k` | `9999.5` exactly |

The first is the `toPrecision(3)` scientific-notation bug — the same one the existing population tests were written to guard against at the lower tiers, which nobody extended to the top of the ladder. A count of a trillion people is not reachable; a dollar figure is.

The second is the promotion rule at the bottom of the ladder: `9999.5` prints as five digits, so it abbreviates for the same reason `999 500` does. Only reachable for a non-integer count.

## Verification

`tsc`, lint, knip, 531 unit tests, including the top of the ladder and `-999 500` reading as `-1.00m`.

Screenshots should not move: every difference needs a count of a trillion or a fractional one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)