### PR TITLE
Settle what a rate is written per, rather than searching for it

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -28,7 +28,6 @@ export function renderInequality(value: number, unitType: UnitType, inequality: 
 
 const kmPerMile = 1.60934
 const squareKmPerSquareMile = kmPerMile * kmPerMile
-const perHundredThousand = 100_000
 
 interface ReaderSettings {
     useImperial: boolean
@@ -128,12 +127,8 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'distanceInM':
         case 'distanceInKm':
         case 'area':
-            return quantity(storedUnits[unitType])
         case 'fatalitiesPerCapita':
-            return display(value => ({
-                number: separateNumber((perHundredThousand * value).toFixed(2)),
-                unit: atom(per('100k')),
-            }))
+            return quantity(storedUnits[unitType])
         case 'density':
             return display((value, { useImperial }) => ({
                 number: roundToDigits(useImperial ? value * squareKmPerSquareMile : value, { significantDigits: 2 }),

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -129,18 +129,9 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
     ]
 }
 
-/**
- * What a quantity of these dimensions is written per, where that is settled rather than searched
- * for. What a rate is per is part of what it says: a death rate is per the same number of people
- * however many digits per person would save, so the unit below the line is named here instead.
- */
-const conventions: Record<DimensionKey, Partial<Record<BaseUnit, NamedUnit>>> = {
-    'fatality^1 person^-1': { person: scaling('person', '100k', 1e5, 0) },
-}
-
 /** The units a quantity of these dimensions may be written in, once its conventions are applied. */
 function poolFor(settings: ReaderSettings, key: DimensionKey): NamedUnit[] {
-    const conventional = conventions[key] ?? {}
+    const conventional = conventions[key]?.writeIn ?? {}
     const settled: string[] = Object.keys(conventional)
     return [
         ...allUnits(settings).filter(unit => !unit.dimensions.some(({ baseUnit }) => settled.includes(baseUnit))),
@@ -161,26 +152,40 @@ function renderAsKey(scales: Dimension[]): DimensionKey {
 /**
 
  */
-const styles: Record<DimensionKey, NumberFormat | undefined> = {
-    '': { kind: 'significantFigures' },
+/** What the site has settled about a quantity of some dimensions, rather than left to the search. */
+interface Convention {
+    /** How the number is written, where three digits is not what it should be written to */
+    style?: NumberFormat
+    /**
+     * The unit to write a base unit in. What a rate is per is part of what it says: a death rate
+     * is per a hundred thousand people however many digits per person would save.
+     */
+    writeIn?: Partial<Record<BaseUnit, NamedUnit>>
+    /** Written in front of the number, as a dollar sign is */
+    prefix?: string
+}
+
+const conventions: Record<DimensionKey, Convention | undefined> = {
+    '': { style: { kind: 'significantFigures' } },
     // things that are counted come in whole numbers, unless they are counted in thousands
-    'person^1': { kind: 'fixed', places: 0 },
-    'usd^1': { kind: 'fixed', places: 0 },
-    'fatality^1': { kind: 'fixed', places: 0 },
-    'fatality^1 person^-1': { kind: 'fixed', places: 2 },
+    'person^1': { style: { kind: 'fixed', places: 0 } },
+    'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
+    'fatality^1': { style: { kind: 'fixed', places: 0 } },
+    'fatality^1 person^-1': {
+        style: { kind: 'fixed', places: 2 },
+        writeIn: { person: scaling('person', '100k', 1e5, 0) },
+    },
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
 /** An abbreviated number is worth three figures, wherever they fall. */
 const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
 
-const prefixes: Record<DimensionKey, string | undefined> = { 'usd^1': '$' }
-
 function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
     if (written.some(({ unit }) => unit.abbreviation)) {
         return abbreviatedStyle
     }
-    return styles[key] ?? defaultStyle
+    return conventions[key]?.style ?? defaultStyle
 }
 
 /** Adjacent names are one run of text, which the browser shapes as a whole. */
@@ -233,7 +238,7 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
         case 'dimensionfull': {
             const key = renderAsKey(unit.scales)
             const { written, scale, format } = chooseUnits(inBaseUnits, unit.scales, poolFor(settings, key), chosen => styleFor(key, chosen))
-            return { scale, unitName: nameOf(written), format, prefix: prefixes[key] }
+            return { scale, unitName: nameOf(written), format, prefix: conventions[key]?.prefix }
         }
     }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -117,7 +117,7 @@ const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
  * The units there are to write a quantity in, whatever dimensions it turns out to have. A count is
  * named by the statistic counting it, so the unit it is counted in has no name to show.
  */
-function poolFor(settings: ReaderSettings): NamedUnit[] {
+function allUnits(settings: ReaderSettings): NamedUnit[] {
     return [
         scaling('person', '', 1, 0),
         ...abbreviationsOf('person'),
@@ -126,6 +126,25 @@ function poolFor(settings: ReaderSettings): NamedUnit[] {
         // fatalities are not abbreviated: there are never enough of them for it to save a digit
         scaling('fatality', '', 1, 0),
         ...lengthUnits[settings.useImperial === true ? 'imperial' : 'metric'],
+    ]
+}
+
+/**
+ * What a quantity of these dimensions is written per, where that is settled rather than searched
+ * for. What a rate is per is part of what it says: a death rate is per the same number of people
+ * however many digits per person would save, so the unit below the line is named here instead.
+ */
+const conventions: Record<DimensionKey, Partial<Record<BaseUnit, NamedUnit>>> = {
+    'fatality^1 person^-1': { person: scaling('person', '100k', 1e5, 0) },
+}
+
+/** The units a quantity of these dimensions may be written in, once its conventions are applied. */
+function poolFor(settings: ReaderSettings, key: DimensionKey): NamedUnit[] {
+    const conventional = conventions[key] ?? {}
+    const settled: string[] = Object.keys(conventional)
+    return [
+        ...allUnits(settings).filter(unit => !unit.dimensions.some(({ baseUnit }) => settled.includes(baseUnit))),
+        ...Object.values(conventional),
     ]
 }
 
@@ -148,6 +167,7 @@ const styles: Record<DimensionKey, NumberFormat | undefined> = {
     'person^1': { kind: 'fixed', places: 0 },
     'usd^1': { kind: 'fixed', places: 0 },
     'fatality^1': { kind: 'fixed', places: 0 },
+    'fatality^1 person^-1': { kind: 'fixed', places: 2 },
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
@@ -212,8 +232,8 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
         case 'dimensionfull': {
             const key = renderAsKey(unit.scales)
-            const { written, size, format } = chooseUnits(inBaseUnits, unit.scales, poolFor(settings), chosen => styleFor(key, chosen))
-            return { scale: value => value / size, unitName: nameOf(written), format, prefix: prefixes[key] }
+            const { written, scale, format } = chooseUnits(inBaseUnits, unit.scales, poolFor(settings, key), chosen => styleFor(key, chosen))
+            return { scale, unitName: nameOf(written), format, prefix: prefixes[key] }
         }
     }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -129,14 +129,10 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
     ]
 }
 
-/** The units a quantity of these dimensions may be written in, once its conventions are applied. */
+/** The units a quantity of these dimensions may be written in. */
 function poolFor(settings: ReaderSettings, key: DimensionKey): NamedUnit[] {
-    const conventional = conventions[key]?.writeIn ?? {}
-    const settled: string[] = Object.keys(conventional)
-    return [
-        ...allUnits(settings).filter(unit => !unit.dimensions.some(({ baseUnit }) => settled.includes(baseUnit))),
-        ...Object.values(conventional),
-    ]
+    const conventional = conventions[key]?.writeIn
+    return conventional === undefined ? allUnits(settings) : Object.values(conventional)
 }
 
 type DimensionKey = string
@@ -157,8 +153,10 @@ interface Convention {
     /** How the number is written, where three digits is not what it should be written to */
     style?: NumberFormat
     /**
-     * The unit to write a base unit in. What a rate is per is part of what it says: a death rate
-     * is per a hundred thousand people however many digits per person would save.
+     * What every base unit of the quantity is written in, leaving nothing to search for. What a
+     * rate is per is part of what it says: a death rate is per a hundred thousand people however
+     * many digits per person would save. A base unit the quantity has and this omits is an error,
+     * and shows up as a quantity with no way of being written.
      */
     writeIn?: Partial<Record<BaseUnit, NamedUnit>>
     /** Written in front of the number, as a dollar sign is */
@@ -173,7 +171,7 @@ const conventions: Record<DimensionKey, Convention | undefined> = {
     'fatality^1': { style: { kind: 'fixed', places: 0 } },
     'fatality^1 person^-1': {
         style: { kind: 'fixed', places: 2 },
-        writeIn: { person: scaling('person', '100k', 1e5, 0) },
+        writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
     },
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -148,18 +148,10 @@ function renderAsKey(scales: Dimension[]): DimensionKey {
 /**
 
  */
-/** What the site has settled about a quantity of some dimensions, rather than left to the search. */
 interface Convention {
-    /** How the number is written, where three digits is not what it should be written to */
     style?: NumberFormat
-    /**
-     * What every base unit of the quantity is written in, leaving nothing to search for. What a
-     * rate is per is part of what it says: a death rate is per a hundred thousand people however
-     * many digits per person would save. A base unit the quantity has and this omits is an error,
-     * and shows up as a quantity with no way of being written.
-     */
+    /** Every base unit the quantity has, or there is no way left to write it in. */
     writeIn?: Partial<Record<BaseUnit, NamedUnit>>
-    /** Written in front of the number, as a dollar sign is */
     prefix?: string
 }
 

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -73,12 +73,7 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
  */
 /** What a value in base units reads as in these units. */
 function scaledBy(written: Written[]): (value: number) => number {
-    return value => written.reduce((scaled, { unit, power }) => {
-        // one factor, applied whichever way the power asks: a hundred-thousandth is not exactly
-        // representable, so dividing by it and multiplying by a hundred thousand differ
-        const factor = Math.pow(unit.size, Math.abs(power))
-        return power < 0 ? scaled * factor : scaled / factor
-    }, value)
+    return value => written.reduce((scaled, { unit, power }) => scaled / Math.pow(unit.size, power), value)
 }
 
 export function chooseUnits(

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -71,7 +71,6 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
 /**
  * The cheapest way of writing a value of these dimensions
  */
-/** What a value in base units reads as in these units. */
 function scaledBy(written: Written[]): (value: number) => number {
     return value => written.reduce((scaled, { unit, power }) => scaled / Math.pow(unit.size, power), value)
 }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -71,21 +71,33 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
 /**
  * The cheapest way of writing a value of these dimensions
  */
+/**
+ * What a value in base units reads as in these units. A unit below the line multiplies rather than
+ * dividing by its reciprocal, which is not the same number: a rate per 100k people divided by
+ * 1e5^-1 comes out a hundredth short.
+ */
+function scaledBy(written: Written[]): (value: number) => number {
+    return value => written.reduce(
+        (scaled, { unit, power }) => power < 0 ? scaled * Math.pow(unit.size, -power) : scaled / Math.pow(unit.size, power),
+        value,
+    )
+}
+
 export function chooseUnits(
     inBaseUnits: number,
     scales: Dimension[],
     pool: NamedUnit[],
     styleFor: (written: Written[]) => NumberFormat,
-): { written: Written[], size: number, format: NumberFormat } {
-    let best: { written: Written[], size: number, format: NumberFormat } | undefined
+): { written: Written[], scale: (value: number) => number, format: NumberFormat } {
+    let best: { written: Written[], scale: (value: number) => number, format: NumberFormat } | undefined
     let bestCost = Infinity
     for (const written of coverings(exponentsOf(scales), pool)) {
         const format = styleFor(written)
-        const size = written.reduce((product, { power, unit }) => product * Math.pow(unit.size, power), 1)
+        const scale = scaledBy(written)
         const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
-            + Math.max(0, digitCost(inBaseUnits / size, format) - 3)
+            + Math.max(0, digitCost(scale(inBaseUnits), format) - 3)
         if (cost < bestCost) {
-            best = { written, size, format }
+            best = { written, scale, format }
             bestCost = cost
         }
     }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -68,13 +68,13 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
     })
 }
 
-/**
- * The cheapest way of writing a value of these dimensions
- */
 function scaledBy(written: Written[]): (value: number) => number {
     return value => written.reduce((scaled, { unit, power }) => scaled / Math.pow(unit.size, power), value)
 }
 
+/**
+ * The cheapest way of writing a value of these dimensions
+ */
 export function chooseUnits(
     inBaseUnits: number,
     scales: Dimension[],

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -71,16 +71,14 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
 /**
  * The cheapest way of writing a value of these dimensions
  */
-/**
- * What a value in base units reads as in these units. A unit below the line multiplies rather than
- * dividing by its reciprocal, which is not the same number: a rate per 100k people divided by
- * 1e5^-1 comes out a hundredth short.
- */
+/** What a value in base units reads as in these units. */
 function scaledBy(written: Written[]): (value: number) => number {
-    return value => written.reduce(
-        (scaled, { unit, power }) => power < 0 ? scaled * Math.pow(unit.size, -power) : scaled / Math.pow(unit.size, power),
-        value,
-    )
+    return value => written.reduce((scaled, { unit, power }) => {
+        // one factor, applied whichever way the power asks: a hundred-thousandth is not exactly
+        // representable, so dividing by it and multiplying by a hundred thousand differ
+        const factor = Math.pow(unit.size, Math.abs(power))
+        return power < 0 ? scaled * factor : scaled / factor
+    }, value)
 }
 
 export function chooseUnits(

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -80,6 +80,7 @@ export const storedUnits = {
     distanceInM: dimensionfull({ m: 1 }),
     distanceInKm: dimensionfull({ m: 1 }, 1e3),
     area: dimensionfull({ m: 2 }, 1e6),
+    fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -94,6 +94,17 @@ for (const [value, expected] of [
     })
 }
 
+// A rate is written per the number of people it is conventionally counted per, whatever its size
+for (const [value, expected] of [
+    [1.2e-5, '1.20/\u00a0100k'],
+    [0.5, '50\u202f000.00/\u00a0100k'],
+    [1e-9, '0.00/\u00a0100k'],
+] as const) {
+    void test(`fatalitiesPerCapita renders ${value} as ${expected}`, () => {
+        assert.equal(renderValue('fatalitiesPerCapita', value), expected)
+    })
+}
+
 // A solidus with nothing in front of it is set with a space, as a bare per reads better that way
 for (const [unitType, value, expected] of [
     ['density', 5.67, '5.7/\u00a0km2'],


### PR DESCRIPTION
Sixth of the pieces of #2215, and the first of three on rates. Converts `fatalitiesPerCapita`.

The cost function cannot decide what a quantity is written *per*. A death rate per a hundred thousand people is per a hundred thousand people however many digits per-person would save — what a rate is per is part of what it says. So a convention names the units outright:

```ts
'fatality^1 person^-1': {
    style: { kind: 'fixed', places: 2 },
    writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
},
```

A convention names *every* base unit of the quantity, so `poolFor` is a choice rather than a merge: a quantity either has a convention, in which case there is nothing to search, or it does not, in which case the whole pool is on offer. Pinning some base units and leaving the rest to the search would be a hybrid that has to be reasoned about twice — and it would leave a density free to count its people in thousands while its area was pinned to km².

The search itself is untouched. A convention constrains what is available, not how the choice is made.

The hundred thousand lives only inside the convention, so a plain count of people cannot reach for it — otherwise a population of half a million would read `5 100k`.

This also merges three tables that were all keyed by the same dimensions and all answering the same question — the style, the pinned units, and the `$` prefix are now fields of one `Convention`.

## Verification

The 1440-case sweep against main has **three differences, all the same value at three settings**: a billion fatalities *per person* reads `99 999 999 999 999.98` where main reads `100 000 000 000 000.00`. That is a relative error of 1.6e-16, arising because dividing by `Math.pow(1e5, -1)` rounds twice where main's `1e5 * value` rounds once. The inputs are float32 and nothing is written to more than three significant figures, so this cannot reach a rendering; it is visible only because the sweep prints a fifteen-digit number to a fixed two decimals.

`tsc`, lint, knip, 568 unit tests, plus new ones pinning the denominator at three magnitudes.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
