### PR TITLE
Write a density per square kilometer, or per square mile

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
 import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
-import { roundToDigits, separateNumber } from '../utils/text'
+import { separateNumber } from '../utils/text'
 import { convertPrecipitation, storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
@@ -25,9 +25,6 @@ export function renderInequality(value: number, unitType: UnitType, inequality: 
     const reads = flipsInequality(unitType, value) ? (inequality === 'leq' ? 'geq' : 'leq') : inequality
     return reads === 'leq' ? '\u2264' /* ≤ */ : '\u2265' /* ≥ */
 }
-
-const kmPerMile = 1.60934
-const squareKmPerSquareMile = kmPerMile * kmPerMile
 
 interface ReaderSettings {
     useImperial: boolean
@@ -63,11 +60,6 @@ function display(write: (value: number, settings: ReaderSettings) => Written): U
             return { value: <span>{number}</span>, unit: unitColumn(unit) }
         },
     }
-}
-
-/** A solidus with a numerator in front of it is set tight; one without gets a space. */
-function per(name: string): string {
-    return `/\u00a0${name}`
 }
 
 /** Durations read as hours and minutes, or as minutes alone where there are no hours. */
@@ -128,12 +120,8 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'distanceInKm':
         case 'area':
         case 'fatalitiesPerCapita':
-            return quantity(storedUnits[unitType])
         case 'density':
-            return display((value, { useImperial }) => ({
-                number: roundToDigits(useImperial ? value * squareKmPerSquareMile : value, { significantDigits: 2 }),
-                unit: raised(per(useImperial ? 'mi' : 'km'), '2'),
-            }))
+            return quantity(storedUnits[unitType])
         case 'time':
             return display(value => hoursAndMinutes(value))
         case 'minutes':

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -98,16 +98,24 @@ const costScaledUnit = 0
 const metersPerFoot = 1 / 3.28084
 const metersPerMile = 1609.34
 
+function systemOf(settings: ReaderSettings): 'metric' | 'imperial' {
+    return settings.useImperial === true ? 'imperial' : 'metric'
+}
+
+const kilometer = scaling('m', 'km', 1e3, costScaledUnit)
+const mile = scaling('m', 'mi', metersPerMile, costScaledUnit)
+const people = scaling('person', '', 1, 0)
+
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
     metric: [
         scaling('m', 'm', 1, 0),
         scaling('m', 'cm', 0.01, costScaledUnit),
-        scaling('m', 'km', 1e3, costScaledUnit),
+        kilometer,
     ],
     imperial: [
         scaling('m', 'ft', metersPerFoot, 0),
         scaling('m', 'in', metersPerFoot / 12, costScaledUnit),
-        scaling('m', 'mi', metersPerMile, costScaledUnit),
+        mile,
         // an acre is a unit of area in its own right, and the square of no length anybody writes
         { name: 'acres', dimensions: [{ baseUnit: 'm', power: 2 }], size: 4046.8564224, cost: costScaledUnit, abbreviation: false },
     ],
@@ -125,14 +133,8 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
         ...abbreviationsOf('usd'),
         // fatalities are not abbreviated: there are never enough of them for it to save a digit
         scaling('fatality', '', 1, 0),
-        ...lengthUnits[settings.useImperial === true ? 'imperial' : 'metric'],
+        ...lengthUnits[systemOf(settings)],
     ]
-}
-
-/** The units a quantity of these dimensions may be written in. */
-function poolFor(settings: ReaderSettings, key: DimensionKey): NamedUnit[] {
-    const conventional = conventions[key]?.writeIn
-    return conventional === undefined ? allUnits(settings) : Object.values(conventional)
 }
 
 type DimensionKey = string
@@ -155,27 +157,36 @@ interface Convention {
     prefix?: string
 }
 
-const conventions: Record<DimensionKey, Convention | undefined> = {
-    '': { style: { kind: 'significantFigures' } },
-    // things that are counted come in whole numbers, unless they are counted in thousands
-    'person^1': { style: { kind: 'fixed', places: 0 } },
-    'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
-    'fatality^1': { style: { kind: 'fixed', places: 0 } },
-    'fatality^1 person^-1': {
-        style: { kind: 'fixed', places: 2 },
-        writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
-    },
+function conventionsMeasuringIn(area: NamedUnit): Record<DimensionKey, Convention | undefined> {
+    return {
+        '': { style: { kind: 'significantFigures' } },
+        // things that are counted come in whole numbers, unless they are counted in thousands
+        'person^1': { style: { kind: 'fixed', places: 0 } },
+        'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
+        'fatality^1': { style: { kind: 'fixed', places: 0 } },
+        'fatality^1 person^-1': {
+            style: { kind: 'fixed', places: 2 },
+            writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
+        },
+        // a density is not worth a third digit, and every one of them is read against the others
+        'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: area } },
+    }
+}
+
+const conventions: Record<'metric' | 'imperial', Record<DimensionKey, Convention | undefined>> = {
+    metric: conventionsMeasuringIn(kilometer),
+    imperial: conventionsMeasuringIn(mile),
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
 /** An abbreviated number is worth three figures, wherever they fall. */
 const abbreviatedStyle: NumberFormat = { kind: 'significantFigures' }
 
-function styleFor(key: DimensionKey, written: Written[]): NumberFormat {
+function styleFor(convention: Convention | undefined, written: Written[]): NumberFormat {
     if (written.some(({ unit }) => unit.abbreviation)) {
         return abbreviatedStyle
     }
-    return conventions[key]?.style ?? defaultStyle
+    return convention?.style ?? defaultStyle
 }
 
 /** Adjacent names are one run of text, which the browser shapes as a whole. */
@@ -226,9 +237,10 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
                 ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
                 : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
         case 'dimensionfull': {
-            const key = renderAsKey(unit.scales)
-            const { written, scale, format } = chooseUnits(inBaseUnits, unit.scales, poolFor(settings, key), chosen => styleFor(key, chosen))
-            return { scale, unitName: nameOf(written), format, prefix: conventions[key]?.prefix }
+            const convention = conventions[systemOf(settings)][renderAsKey(unit.scales)]
+            const pool = convention?.writeIn === undefined ? allUnits(settings) : Object.values(convention.writeIn)
+            const { written, scale, format } = chooseUnits(inBaseUnits, unit.scales, pool, chosen => styleFor(convention, chosen))
+            return { scale, unitName: nameOf(written), format, prefix: convention?.prefix }
         }
     }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -157,7 +157,7 @@ interface Convention {
     prefix?: string
 }
 
-function conventionsUsing(largeLength: NamedUnit): Record<DimensionKey, Convention | undefined> {
+function conventionsUsing(kmLike: NamedUnit): Record<DimensionKey, Convention | undefined> {
     return {
         '': { style: { kind: 'significantFigures' } },
         // things that are counted come in whole numbers, unless they are counted in thousands
@@ -169,7 +169,7 @@ function conventionsUsing(largeLength: NamedUnit): Record<DimensionKey, Conventi
             writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
         },
         // a density is not worth a third digit, and every one of them is read against the others
-        'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: largeLength } },
+        'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -157,7 +157,7 @@ interface Convention {
     prefix?: string
 }
 
-function conventionsMeasuringIn(area: NamedUnit): Record<DimensionKey, Convention | undefined> {
+function conventionsUsing(largeLength: NamedUnit): Record<DimensionKey, Convention | undefined> {
     return {
         '': { style: { kind: 'significantFigures' } },
         // things that are counted come in whole numbers, unless they are counted in thousands
@@ -169,13 +169,13 @@ function conventionsMeasuringIn(area: NamedUnit): Record<DimensionKey, Conventio
             writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
         },
         // a density is not worth a third digit, and every one of them is read against the others
-        'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: area } },
+        'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: largeLength } },
     }
 }
 
 const conventions: Record<'metric' | 'imperial', Record<DimensionKey, Convention | undefined>> = {
-    metric: conventionsMeasuringIn(kilometer),
-    imperial: conventionsMeasuringIn(mile),
+    metric: conventionsUsing(kilometer),
+    imperial: conventionsUsing(mile),
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -56,7 +56,7 @@ function decimalPlaces(value: number, { significantDigits, minDecimals, maxDecim
     return Math.min(Math.max(significantDigits - Math.ceil(Math.log10(Math.abs(value))), minDecimals ?? 0), most)
 }
 
-export function roundToDigits(value: number, rounding: Rounding): string {
+function roundToDigits(value: number, rounding: Rounding): string {
     return separateNumber(value.toFixed(decimalPlaces(value, rounding)))
 }
 

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -81,6 +81,7 @@ export const storedUnits = {
     distanceInKm: dimensionfull({ m: 1 }, 1e3),
     area: dimensionfull({ m: 2 }, 1e6),
     fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }),
+    density: dimensionfull({ person: 1, m: -2 }, 1e-6),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -94,6 +94,19 @@ for (const [value, expected] of [
     })
 }
 
+// A density is written per the area a reader measures in, and its people are never counted in
+// thousands however many of them there are
+for (const [value, imperial, expected] of [
+    [1234, false, '1\u202f234/\u00a0km2'],
+    [12345, false, '12\u202f345/\u00a0km2'],
+    [1234, true, '3\u202f196/\u00a0mi2'],
+    [12345, true, '31\u202f973/\u00a0mi2'],
+] as const) {
+    void test(`density renders ${value} in ${imperial ? 'imperial' : 'metric'} as ${expected}`, () => {
+        assert.equal(renderValue('density', value, imperial), expected)
+    })
+}
+
 // A rate is written per the number of people it is conventionally counted per, whatever its size
 for (const [value, expected] of [
     [1.2e-5, '1.20/\u00a0100k'],


### PR DESCRIPTION
Second of the three on rates, following #2270. Converts `density`.

```ts
density: dimensionfull({ person: 1, m: -2 }, 1e-6),
```

A density is people per km², or per mi² for a reader of miles, whatever the number would be per anything else — so it is a convention rather than a search. It is the first convention that differs between readers, so the table is now built per system of measurement:

```ts
const conventions: Record<'metric' | 'imperial', Record<DimensionKey, Convention | undefined>> = {
    metric: conventionsMeasuringIn(kilometer),
    imperial: conventionsMeasuringIn(mile),
}
```

Naming every base unit, which #2270 made the rule, is what keeps the numerator out of thousands here. A density of twelve thousand people per km² has twelve thousand people in it; had the convention pinned only the area and left people to the search, it would have read `12.3k` per km².

The last hand-written arm to use `roundToDigits` is gone with it, so that helper is now private to `text.ts`.

## Verification

The 1440-case sweep against main: **no differences**, in either system. `tsc`, lint, knip, 572 unit tests, including four asserting a density stays per km²/mi² and keeps its people whole.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
