### PR TITLE
Pin a histogram tooltip on a tap, not on every touch that lands on the chart

### DIFF
--- a/react/src/components/plots-general.tsx
+++ b/react/src/components/plots-general.tsx
@@ -212,6 +212,10 @@ export function seriesTip(
     )
 }
 
+// what separates a tap on a point from a scroll or a long press that happens to start on the plot
+const tapDuration = 500
+const tapMovement = 10
+
 // The tooltips the user has clicked on, identified by their position in the tip mark's data.
 // Indices rather than the data themselves because the data is rebuilt from scratch whenever the
 // plot re-renders, and it means the same points stay pinned across a transpose or a settings change.
@@ -696,12 +700,8 @@ export function PlotComponent(props: {
         const recordPointedTip = (): void => {
             pointedTip.current = pointedTipIndex(plot)
         }
-        const handlePointerDown = (event: PointerEvent): void => {
-            // Plot has a click-to-stick tooltip of its own (mouse only), which would double up with
-            // the pinned ones we draw; suppressing it here (before the event reaches the plot)
-            // leaves us in sole charge of what a click does
-            event.stopPropagation()
-            const dismissed = dismissButtonTipIndex(event.target)
+        const act = (target: EventTarget | null): void => {
+            const dismissed = dismissButtonTipIndex(target)
             if (dismissed !== null) {
                 dismiss(dismissed)
                 return
@@ -711,8 +711,39 @@ export function PlotComponent(props: {
                 setPinnedTips(current => withTipToggled(current, pointed))
             }
         }
+        // where and when a touch began, so that the lift can tell a tap from a scroll
+        let touchStart: { time: number, x: number, y: number } | null = null
+        const handlePointerDown = (event: PointerEvent): void => {
+            // Plot has a click-to-stick tooltip of its own (mouse only), which would double up with
+            // the pinned ones we draw; suppressing it here (before the event reaches the plot)
+            // leaves us in sole charge of what a click does
+            event.stopPropagation()
+            if (event.pointerType === 'touch') {
+                touchStart = { time: event.timeStamp, x: event.clientX, y: event.clientY }
+                return
+            }
+            act(event.target)
+        }
+        // A touch that starts on the plot is most often the start of a scroll down the page, which
+        // would otherwise pin a tooltip on the way past (kavigupta/urbanstats#2239). So a touch acts
+        // when it lifts, and only if it stayed still and lifted soon enough to have been a tap.
+        const handlePointerUp = (event: PointerEvent): void => {
+            const start = touchStart
+            touchStart = null
+            if (start === null || event.pointerType !== 'touch') {
+                return
+            }
+            if (event.timeStamp - start.time > tapDuration) {
+                return
+            }
+            if (Math.hypot(event.clientX - start.x, event.clientY - start.y) > tapMovement) {
+                return
+            }
+            act(event.target)
+        }
         plot.addEventListener('input', recordPointedTip)
         container.addEventListener('pointerdown', handlePointerDown, true)
+        container.addEventListener('pointerup', handlePointerUp, true)
         const frame = requestAnimationFrame(() => {
             attachDismissButtons(plot, transpose, dismiss)
         })
@@ -721,6 +752,7 @@ export function PlotComponent(props: {
             cancelAnimationFrame(frame)
             plot.removeEventListener('input', recordPointedTip)
             container.removeEventListener('pointerdown', handlePointerDown, true)
+            container.removeEventListener('pointerup', handlePointerUp, true)
         }
     }, [transpose, plotConfig])
 
@@ -742,6 +774,11 @@ export function PlotComponent(props: {
                         height: transpose ? `calc(100% - ${transposeTopMargin})` : undefined,
                         position: transpose ? 'relative' : undefined,
                         top: transpose ? transposeTopMargin : undefined,
+                        // a drag scrubs the tooltip along the x-axis, so the page is left only the
+                        // other axis to scroll with -- given both, it takes the touch away at the
+                        // first vertical drift. A transposed plot scrubs the way the page scrolls,
+                        // so it has no axis to spare.
+                        touchAction: transpose ? undefined : 'pan-y',
                     }
                 }
             >

--- a/react/test/histogram_x1.test.ts
+++ b/react/test/histogram_x1.test.ts
@@ -56,6 +56,50 @@ test('histogram-pinned-tooltip', async (t) => {
     await t.expect(pinnedTip.exists).notOk('the dismiss button unpins the tooltip')
 })
 
+// TestCafe drives a mouse, so a finger has to be dispatched by hand. Both ends of the gesture are
+// sent from the same client-side call, so that a tap here is as quick as a real one.
+const touchPlot = ClientFunction((offsetX: number, offsetY: number, dx: number, dy: number, hold: number) => {
+    const panel = document.getElementsByClassName('histogram-svg-panel')[0]
+    const rect = panel.getBoundingClientRect()
+    const send = (type: string, x: number, y: number): void => {
+        panel.dispatchEvent(new PointerEvent(type, {
+            pointerType: 'touch',
+            pointerId: 2,
+            isPrimary: true,
+            bubbles: true,
+            clientX: rect.left + x,
+            clientY: rect.top + y,
+        }))
+    }
+    send('pointerdown', offsetX, offsetY)
+    return new Promise<void>((resolve) => {
+        setTimeout(() => {
+            send('pointerup', offsetX + dx, offsetY + dy)
+            resolve()
+        }, hold)
+    })
+})
+
+// A touch that lands on the chart is usually the start of a scroll down the page, so a touch pins
+// only once it lifts, and only if it was a tap.
+test('histogram-pinned-tooltip-touch', async (t) => {
+    await t.resizeWindow(1400, 800)
+    await t.click(Selector('.expand-toggle'))
+    // stands in for the pointerenter that precedes a real touch, which is what tells the plot which
+    // point is being touched
+    await t.hover(Selector('.histogram-svg-panel'), { offsetX: 500, offsetY: 200 })
+
+    await touchPlot(500, 200, 0, -40, 0)
+    await t.expect(pinnedTip.exists).notOk('a touch that drags off, as a scroll does, pins nothing')
+    await touchPlot(500, 200, 0, 0, 700)
+    await t.expect(pinnedTip.exists).notOk('a touch held down pins nothing')
+    await touchPlot(500, 200, 0, 0, 0)
+    await t.expect(pinnedTip.exists).ok('a tap pins the touched tooltip')
+
+    await t.expect(Selector('.histogram-svg-panel').getStyleProperty('touch-action')).eql(
+        'pan-y', 'a drag across the plot moves the tooltip rather than scrolling the page')
+})
+
 // pins are per-plot component state, so several graphs on a page each keep their own set, and each
 // graph carries only its own into the image it exports
 test('histogram-pinned-tooltip-multiple-graphs', async (t) => {


### PR DESCRIPTION
Fixes #2239.

Scrolling an article with a finger that happens to start on a histogram pinned a tooltip on the way past, so a scroll down the page left a trail of them. Pinning ran off `pointerdown`, which a scroll and a tap look identical in. A touch is now acted on when it lifts, and only if it stayed within 10px and lifted within 500ms — a scroll gets a `pointercancel` rather than a `pointerup`, so it is filtered out by both routes. Mouse and pen still act on the way down, where there is no gesture to disambiguate, so nothing about the desktop behaviour moves.

The second half is why dragging along the chart felt so fragile on a phone. With `touch-action` left at its default the browser may claim the touch for a vertical page scroll the moment the finger drifts off the horizontal, and once it does it cancels the touch and the tooltip stops tracking. Asking for `pan-y` on the panel makes the browser decide the axis once, at the start of the gesture, and a drag that begins horizontally then stays the plot's for the rest of the gesture. Vertical drags still scroll the page, so the chart does not trap the finger.

Transposed plots keep the default. There the tooltip scrubs along the vertical axis, which is the axis the page scrolls, so the only way to make dragging work would be `pan-x` — and that would swallow every scroll gesture starting on a chart that takes up much of a phone screen. Dragging to scrub still does not work in that layout; tapping to pin does.

`histogram-pinned-tooltip-touch` dispatches synthetic touch pointer events, since TestCafe only drives a mouse: a drag pins nothing, a held press pins nothing, a tap pins. It fails on all three counts without the change. The `touch-action` half is enforced by the browser's compositor rather than by anything a synthetic event exercises, so the test only asserts the computed property; the gesture itself wants a check on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)