### PR TITLE
Fix the three e2e failures that actually turned main red

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -210,6 +210,14 @@ jobs:
         with:
           name: changed_screenshots-${{ steps.artifact-name.outputs.name }}
           path: react/changed_screenshots
+      # Both TestCafe's take-on-fail shots and the ones `flaky` takes per attempt land here, and
+      # a run that passes deletes them, so this only ever carries pictures of something going wrong.
+      - uses: actions/upload-artifact@v4
+        if: "!cancelled()"
+        with:
+          name: error_screenshots-${{ steps.artifact-name.outputs.name }}
+          path: react/screenshots/**/*.error.png
+          if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
         if: "!cancelled()"
         with:

--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -33,6 +33,20 @@ function headersJSON(headers: Headers): string {
     return JSON.stringify(entries)
 }
 
+// eslint-disable-next-line no-restricted-syntax -- Reporting on Google's pages, which have no page descriptor
+const pageURL = ClientFunction(() => window.location.href)
+
+// Google's interstitials look much alike in the error screenshot; the URL is what tells them apart.
+async function expectOrWarn(t: TestController, selector: Selector, what: string): Promise<void> {
+    try {
+        await t.expect(selector.exists).ok()
+    }
+    catch (error) {
+        console.warn(`${what}, at ${await pageURL()}`)
+        throw error
+    }
+}
+
 async function popTOTP(t: TestController): Promise<string> {
     // https://script.google.com/u/2/home/projects/1CWDP4eezFo8fMhQb327VfSm3DnThl-8xg1fmg4cl9gHnK0NGB8XSz094/edit
     // Apps Script runs the script at /exec, then 302s to a script.googleusercontent.com URL that
@@ -115,7 +129,7 @@ async function googleSignIn(t: TestController): Promise<void> {
                 await fillTOTP(t)
             }
             else {
-                await t.expect(Selector('h1').withExactText('Urban Stats').exists).ok()
+                await expectOrWarn(t, Selector('h1').withExactText('Urban Stats'), 'Google sign in reached an unhandled page')
                 break
             }
         }
@@ -181,7 +195,7 @@ async function signInPopup(t: TestController, enableDrive: boolean): Promise<voi
         await t.click(continueButton)
     }
     // Waiting on the outcome first, since waitForLoading needs the callback page to have replaced Google's
-    await t.expect(Selector('h1').withText(/Signed In!|Sign In Failed/).exists).ok()
+    await expectOrWarn(t, Selector('h1').withText(/Signed In!|Sign In Failed/), 'Sign in popup ended on neither Signed In! nor Sign In Failed')
     await waitForLoading()
 }
 

--- a/react/test/quiz_test_template.ts
+++ b/react/test/quiz_test_template.ts
@@ -10,7 +10,9 @@ import { target, safeReload, screencap, safeClearLocalStorage, waitForDownload, 
 
 export async function runQuery(t: TestController, query: string): Promise<string> {
     // dump given query to a string
-    const commandLine = `sqlite3 ../urbanstats-persistent-data/db.sqlite3 "${query}"`
+    // The CLI's default busy timeout is zero, so without this it gives up the instant the quiz
+    // server happens to be holding the write lock.
+    const commandLine = `sqlite3 -cmd ".timeout 10000" ../urbanstats-persistent-data/db.sqlite3 "${query}"`
     await t.wait(500)
     const result = await promisify(exec)(commandLine)
     return result.stdout

--- a/react/test/random.test.ts
+++ b/react/test/random.test.ts
@@ -18,6 +18,8 @@ async function assertNoSpecials(t: TestController): Promise<void> {
 }
 
 async function assertCorrect(t: TestController): Promise<void> {
+    // The redirect isn't done until the article it picked has loaded, which can outlast the assertion timeout
+    await waitForLoading()
     await assertIsArticle(t)
     await assertNoSetUniverse(t)
     await assertNoSpecials(t)


### PR DESCRIPTION
Three of the last forty `check` runs on main went red. Two were `random.test.ts` and one was a sqlite3 lock, so this fixes both, plus two changes that make the next failure diagnosable. Across the sixteen most recent main runs (1,440 test executions) there were nine retry-or-fail events; `random` accounts for four of them, more than any other test.

`random.test.ts` asserted the location with nothing but TestCafe's 5s `assertionTimeout` behind it. Its redirect isn't finished until the article it sampled has loaded, and `random` pulls sixty distinct uncached articles through the jsdelivr proxy per run, so a slow fetch reads as a failed assertion. Every observed failure took exactly 5s longer than a passing repeat. `waitForLoading` resolves on error as well as on success, so a genuine failure now reports as a failure rather than as a timeout.

The sqlite3 CLI defaults to a zero busy timeout, so `runQuery` gave up the instant the quiz server happened to hold the write lock, behind only a hopeful `t.wait(500)`. That is what took `quiz_x0_desktop`'s retry down in run 32177452624, after an unrelated flaky screenshot diff had already spent its first attempt.

The other two changes buy information rather than passes. Error screenshots were being written and then discarded, because `react/screenshots` isn't among the artifacts the e2e job uploads — this covers both TestCafe's take-on-fail shots and the ones `flaky` takes per attempt, and since a passing file deletes them, the artifact only ever carries pictures of something going wrong. Separately, the two `quiz_auth` assertions that Google's sign-in flow actually trips now report the page URL, which is what distinguishes Google's otherwise identical-looking interstitials and is the one thing a screenshot can't show.

Two things deliberately left out. The artifact-upload `ECONNRESET` that failed run 31984213833 with all ninety tests passing is rare enough not to be worth guarding against; rerun by hand. And the `ci_proxy` retry chain looked broken — three jsdelivr attempts and the raw.githubusercontent fallback completing within 1.4ms of each other, ending in `request body has already been read` — but it isn't. Rebuilding the chain against local upstreams showed it retrying correctly on 500, connection reset, and connection refused. That cascade is an abandoned request: it lands 0.53s after the preceding test passed, when the browser cancelled the previous page's in-flight shape fetch. Nothing was waiting for the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)