### PR TITLE
Mint a fresh TOTP content key on retry instead of refetching a dead one

### DIFF
--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -33,35 +33,42 @@ function headersJSON(headers: Headers): string {
     return JSON.stringify(entries)
 }
 
-async function popTOTP(t: TestController): Promise<string> {
-    // https://script.google.com/u/2/home/projects/1CWDP4eezFo8fMhQb327VfSm3DnThl-8xg1fmg4cl9gHnK0NGB8XSz094/edit
-    // Apps Script runs the script at /exec, then 302s to a script.googleusercontent.com URL that
-    // serves the output. The hops are followed by hand so a failure says which one broke.
+// https://script.google.com/u/2/home/projects/1CWDP4eezFo8fMhQb327VfSm3DnThl-8xg1fmg4cl9gHnK0NGB8XSz094/edit
+// Apps Script runs the script at /exec, then 302s to a script.googleusercontent.com URL that
+// serves the output. The hops are followed by hand so a failure says which one broke.
+async function popTOTPSlot(): Promise<number | undefined> {
     const exec = await fetch('https://script.google.com/macros/s/AKfycbxLMtid0yZ_JiX5Ymm02FXfbRXYrpF1AE9nUaDM8P9dhP7uOWJpMRH8SpG5TbCQCRc/exec', { redirect: 'manual' })
     const location = exec.headers.get('location')
     if (location === null) {
         console.warn(`TOTP exec hop did not redirect: ${exec.status} ${exec.statusText}`)
         console.warn(`headers: ${headersJSON(exec.headers)}`)
         console.warn(`body: ${await exec.text()}`)
-        throw new Error('TOTP exec hop did not redirect')
+        return undefined
     }
-    // Re-running the exec hop would pop a new TOTP slot, so only this hop is retried.
-    let echo = await fetch(location, { redirect: 'manual' })
-    for (let attempt = 1; attempt <= 2 && !echo.ok; attempt++) {
-        console.warn(`TOTP echo hop ${echo.status} ${echo.statusText}, retry ${attempt}`)
-        await t.wait(1000)
-        echo = await fetch(location, { redirect: 'manual' })
-    }
+    const echo = await fetch(location, { redirect: 'manual' })
     const body = await echo.text()
-    let useAfter: number
     try {
-        ({ useAfter } = z.object({ useAfter: z.number() }).parse(JSON.parse(body)))
+        return z.object({ useAfter: z.number() }).parse(JSON.parse(body)).useAfter
     }
-    catch (error) {
+    catch {
         console.warn(`TOTP echo hop failed: ${echo.status} ${echo.statusText} for ${location}`)
         console.warn(`headers: ${headersJSON(echo.headers)}`)
         console.warn(`body: ${body}`)
-        throw error
+        return undefined
+    }
+}
+
+async function popTOTP(t: TestController): Promise<string> {
+    // A content key Google won't serve stays unservable, so a retry re-runs exec for a fresh one,
+    // spending a TOTP slot to do it.
+    let useAfter = await popTOTPSlot()
+    for (let attempt = 1; attempt <= 2 && useAfter === undefined; attempt++) {
+        console.warn(`TOTP retry ${attempt}`)
+        await t.wait(1000)
+        useAfter = await popTOTPSlot()
+    }
+    if (useAfter === undefined) {
+        throw new Error('TOTP endpoint failed')
     }
     const wait = useAfter - Date.now()
     if (wait > 0) {


### PR DESCRIPTION
`quiz_auth`'s TOTP endpoint fails by handing back a `user_content_key` that `script.googleusercontent.com` refuses to serve. #2224 retried that key on the echo hop, on the theory that the failure was transient. It isn't: a key the content server won't serve stays unservable, so the retry was always going to fail three times and then throw.

Two CI captures since #2224 landed settle it — 21 hop-two requests against 7 freshly minted keys, no 200 among them. The failures come in two shapes, sometimes alternating within one key's three attempts: a 404 carrying Drive's "Sorry, unable to open the file at this time" page, or a 302 with an empty body whose `location` points back at the deployment's own `/exec` URL. That second one is Google telling us in as many words to re-run the script.

So this retries the whole pop rather than half of it. Each attempt runs `/exec` again and gets a new key. The cost is one TOTP slot per retry, which pushes `useAfter` forward by about 30 seconds; that wait is already credited out of the test time limit by `creditTOTPWait`, so it spends wall-clock rather than budget.

Worth recording why this stopped being self-healing. `flaky` used to supply exactly this recovery for free by re-running `popTOTP` wholesale, which is how the August 12 outbreak mostly passed anyway. But its 30-second budget starts at the top of the Google sign-in loop, and clicking through accounts.google.com burns most of it before `fillTOTP` is reached, so by the time the TOTP call fails there's nothing left. All three failures in the run below logged `flaky timed out` without a single retry.

The underlying bug is Google's and is being reported separately. This only keeps CI green in the meantime.

Failing run: https://github.com/kavigupta/urbanstats/actions/runs/32458843848/job/96701908251
Earlier capture: https://github.com/kavigupta/urbanstats/actions/jobs/95852962727

🤖 Generated with [Claude Code](https://claude.com/claude-code)