### PR TITLE
Write a pollution reading in micrograms per cubic meter

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -42,10 +42,6 @@ function atom(value: string): HumanReadableElement[] {
     return [{ type: 'atom', value }]
 }
 
-function raised(name: string, power: string): HumanReadableElement[] {
-    return [{ type: 'atom', value: name }, { type: 'superscript', value: atom(power) }]
-}
-
 function unitColumn(name: HumanReadableElement[]): ReactNode {
     return <span>{name.length === 0 ? <>&nbsp;</> : reifyReact(name)}</span>
 }
@@ -121,6 +117,7 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'area':
         case 'fatalitiesPerCapita':
         case 'density':
+        case 'contaminantLevel':
             return quantity(storedUnits[unitType])
         case 'time':
             return display(value => hoursAndMinutes(value))
@@ -134,11 +131,6 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
                     unit: atom(`${converted.unit}/yr`),
                 }
             })
-        case 'contaminantLevel':
-            return display(value => ({
-                number: separateNumber(value.toFixed(2)),
-                unit: raised('μg/m', '3'),
-            }))
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -11,7 +11,7 @@ type PartySystem = 'democratic' | 'left'
 /**
  * Base units, combined together via multiplication to form the units that correspond to the inBaseUnits value
  */
-export type BaseUnit = 'person' | 'usd' | 'fatality' | 'm'
+export type BaseUnit = 'person' | 'usd' | 'fatality' | 'm' | 'g'
 
 export interface Dimension {
     baseUnit: BaseUnit
@@ -105,6 +105,8 @@ function systemOf(settings: ReaderSettings): 'metric' | 'imperial' {
 const kilometer = scaling('m', 'km', 1e3, costScaledUnit)
 const mile = scaling('m', 'mi', metersPerMile, costScaledUnit)
 const people = scaling('person', '', 1, 0)
+const meter = scaling('m', 'm', 1, 0)
+const microgram = scaling('g', 'μg', 1e-6, 0)
 
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
     metric: [
@@ -170,6 +172,8 @@ function conventionsUsing(kmLike: NamedUnit): Record<DimensionKey, Convention | 
         },
         // a density is not worth a third digit, and every one of them is read against the others
         'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
+        // a concentration is scientific, and stays in the units science is written in
+        'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
     }
 }
 

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -82,6 +82,7 @@ export const storedUnits = {
     area: dimensionfull({ m: 2 }, 1e6),
     fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }),
     density: dimensionfull({ person: 1, m: -2 }, 1e-6),
+    contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 


### PR DESCRIPTION
Third of the ones on rates, following #2270 and #2272. Converts `contaminantLevel`.

```ts
contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6),
```

Micrograms per cubic meter is what science writes a concentration in, and a reader of miles reads it the same way, so it is a convention in both systems and nothing is searched for:

```ts
// a concentration is scientific, and stays in the units science is written in
'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
```

The gram joins the base units to hold the numerator. It has one unit in the pool, the microgram, and only through this convention — nothing else is measured in grams, so nothing else can reach for it.

The name comes out of `nameOf` rather than being written by hand: `μg` over `m` cubed, with the solidus set tight because there is a numerator in front of it, and the adjacent atoms merged into the single run `μg/m` followed by a superscript — which is exactly the markup the arm produced.

`raised`, the last hand-written superscript helper in `unit-display.tsx`, goes with it.

## Verification

The 1440-case sweep against main: **no differences**. `tsc`, lint, knip, 576 unit tests.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
