### PR TITLE
Write rainfall per year, in the small length its reader measures in

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -3,8 +3,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
 import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
-import { separateNumber } from '../utils/text'
-import { convertPrecipitation, storedUnits, UnitType } from '../utils/unit'
+import { storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
     renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
@@ -118,19 +117,12 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'fatalitiesPerCapita':
         case 'density':
         case 'contaminantLevel':
+        case 'distancePerYear':
             return quantity(storedUnits[unitType])
         case 'time':
             return display(value => hoursAndMinutes(value))
         case 'minutes':
             return display(value => hoursAndMinutes(value / 60))
-        case 'distancePerYear':
-            return display((value, { useImperial }) => {
-                const converted = convertPrecipitation(value, useImperial)
-                return {
-                    number: separateNumber(converted.value.toFixed(1)),
-                    unit: atom(`${converted.unit}/yr`),
-                }
-            })
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -110,14 +110,7 @@ const people = scaling('person', '', 1, 0)
 const meter = scaling('m', 'm', 1, 0)
 const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
 const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
-const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, costScaledUnit)
-const timeUnits: NamedUnit[] = [
-    scaling('s', 's', 1, 0),
-    scaling('s', 'min', 60, costScaledUnit),
-    scaling('s', 'hr', 60 * 60, costScaledUnit),
-    scaling('s', 'days', 24 * 60 * 60, costScaledUnit),
-    year,
-]
+const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
 const microgram = scaling('g', 'μg', 1e-6, 0)
 
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
@@ -148,7 +141,6 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
         // fatalities are not abbreviated: there are never enough of them for it to save a digit
         scaling('fatality', '', 1, 0),
         ...lengthUnits[systemOf(settings)],
-        ...timeUnits,
     ]
 }
 
@@ -187,6 +179,8 @@ function conventionsUsing(kmLike: NamedUnit, cmLike: NamedUnit): Record<Dimensio
         'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
         // a concentration is scientific, and stays in the units science is written in
         'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
+        // rainfall is per year, however many digits per hour would save
+        'm^1 s^-1': { style: { kind: 'fixed', places: 1 }, writeIn: { m: cmLike, s: year } },
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -116,7 +116,7 @@ const microgram = scaling('g', 'μg', 1e-6, 0)
 
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
     metric: [
-        scaling('m', 'm', 1, 0),
+        meter,
         centimeter,
         kilometer,
     ],

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -110,7 +110,14 @@ const people = scaling('person', '', 1, 0)
 const meter = scaling('m', 'm', 1, 0)
 const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
 const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
-const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
+const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, costScaledUnit)
+const timeUnits: NamedUnit[] = [
+    scaling('s', 's', 1, 0),
+    scaling('s', 'min', 60, costScaledUnit),
+    scaling('s', 'hr', 60 * 60, costScaledUnit),
+    scaling('s', 'days', 24 * 60 * 60, costScaledUnit),
+    year,
+]
 const microgram = scaling('g', 'μg', 1e-6, 0)
 
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
@@ -141,6 +148,7 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
         // fatalities are not abbreviated: there are never enough of them for it to save a digit
         scaling('fatality', '', 1, 0),
         ...lengthUnits[systemOf(settings)],
+        ...timeUnits,
     ]
 }
 
@@ -179,8 +187,6 @@ function conventionsUsing(kmLike: NamedUnit, cmLike: NamedUnit): Record<Dimensio
         'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
         // a concentration is scientific, and stays in the units science is written in
         'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
-        // rainfall is per year, however many digits per hour would save
-        'm^1 s^-1': { style: { kind: 'fixed', places: 1 }, writeIn: { m: cmLike, s: year } },
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -11,7 +11,7 @@ type PartySystem = 'democratic' | 'left'
 /**
  * Base units, combined together via multiplication to form the units that correspond to the inBaseUnits value
  */
-export type BaseUnit = 'person' | 'usd' | 'fatality' | 'm' | 'g'
+export type BaseUnit = 'person' | 'usd' | 'fatality' | 'm' | 'g' | 's'
 
 export interface Dimension {
     baseUnit: BaseUnit
@@ -108,17 +108,20 @@ const kilometer = scaling('m', 'km', 1e3, costScaledUnit)
 const mile = scaling('m', 'mi', metersPerMile, costScaledUnit)
 const people = scaling('person', '', 1, 0)
 const meter = scaling('m', 'm', 1, 0)
+const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
+const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
+const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
 const microgram = scaling('g', 'μg', 1e-6, 0)
 
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
     metric: [
         scaling('m', 'm', 1, 0),
-        scaling('m', 'cm', 0.01, costScaledUnit),
+        centimeter,
         kilometer,
     ],
     imperial: [
         scaling('m', 'ft', metersPerFoot, 0),
-        scaling('m', 'in', metersPerInch, costScaledUnit),
+        inch,
         mile,
         // an acre is a unit of area in its own right, and the square of no length anybody writes
         { name: 'acres', dimensions: [{ baseUnit: 'm', power: 2 }], size: 4046.8564224, cost: costScaledUnit, abbreviation: false },
@@ -161,7 +164,7 @@ interface Convention {
     prefix?: string
 }
 
-function conventionsUsing(kmLike: NamedUnit): Record<DimensionKey, Convention | undefined> {
+function conventionsUsing(kmLike: NamedUnit, cmLike: NamedUnit): Record<DimensionKey, Convention | undefined> {
     return {
         '': { style: { kind: 'significantFigures' } },
         // things that are counted come in whole numbers, unless they are counted in thousands
@@ -176,12 +179,14 @@ function conventionsUsing(kmLike: NamedUnit): Record<DimensionKey, Convention | 
         'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
         // a concentration is scientific, and stays in the units science is written in
         'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
+        // rainfall is per year, however many digits per hour would save
+        'm^1 s^-1': { style: { kind: 'fixed', places: 1 }, writeIn: { m: cmLike, s: year } },
     }
 }
 
 const conventions: Record<'metric' | 'imperial', Record<DimensionKey, Convention | undefined>> = {
-    metric: conventionsUsing(kilometer),
-    imperial: conventionsUsing(mile),
+    metric: conventionsUsing(kilometer, centimeter),
+    imperial: conventionsUsing(mile, inch),
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -179,7 +179,6 @@ function conventionsUsing(kmLike: NamedUnit, cmLike: NamedUnit): Record<Dimensio
         'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
         // a concentration is scientific, and stays in the units science is written in
         'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
-        // rainfall is per year, however many digits per hour would save
         'm^1 s^-1': { style: { kind: 'fixed', places: 1 }, writeIn: { m: cmLike, s: year } },
     }
 }

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -83,6 +83,7 @@ export const storedUnits = {
     fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }),
     density: dimensionfull({ person: 1, m: -2 }, 1e-6),
     contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6),
+    distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60)),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -94,6 +94,18 @@ for (const [value, expected] of [
     })
 }
 
+// Rainfall is per year, and in the small length its reader measures in
+for (const [value, imperial, expected] of [
+    [1.2, false, '120.0cm/yr'],
+    [5.67, false, '567.0cm/yr'],
+    [5.67, true, '223.2in/yr'],
+    [12.3, true, '484.3in/yr'],
+] as const) {
+    void test(`distancePerYear renders ${value} in ${imperial ? 'imperial' : 'metric'} as ${expected}`, () => {
+        assert.equal(renderValue('distancePerYear', value, imperial), expected)
+    })
+}
+
 // The imperial units are their exact definitions, so a mile of kilometers reads as a round mile
 for (const [unitType, value, expected] of [
     ['distanceInKm', 1.609344, '1.00mi'],


### PR DESCRIPTION
Follows #2270, #2272 and #2277. Converts `distancePerYear`, the last quantity with an arm of its own outside durations.

```ts
distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60)),
// rainfall is per year, however many digits per hour would save
'm^1 s^-1': { style: { kind: 'fixed', places: 1 }, writeIn: { m: cmLike, s: year } },
```

Rainfall is per year whatever a smaller unit would save on digits, and it is read in centimeters, or inches for a reader of miles. The second is the length the conventions table now takes alongside the first — `conventionsUsing(kilometer, centimeter)` and `conventionsUsing(mile, inch)`.

The second joins the base units, with one unit in the pool and only through this convention, so nothing else can be written per year.

`convertPrecipitation` is no longer reached from `unit-display.tsx`; it stays for the monthly plots, which draw their own axes.

## Verification

The 1440-case sweep against main: **no differences**, in either system.

That is the case #2278 was split out for. Before the exact inch landed, the imperial values were out in their last digit at large rainfalls — the site had converted precipitation to inches with an exact `2.54` while deriving the inch elsewhere from `3.28084`.

`tsc`, lint, knip, 582 unit tests, four of them new for rainfall in both systems.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
