### PR TITLE
Give a quantity its dimensions, a decoration and whether it is a difference

### DIFF
--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -18,7 +18,6 @@ export interface Dimension {
     power: number
 }
 
-// Abstract interpretation of a quantity as a unit.
 export type Party = { kind: 'color', hue: Hue } | { kind: 'lead', system: PartySystem }
 
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -19,16 +19,11 @@ export interface Dimension {
 }
 
 // Abstract interpretation of a quantity as a unit.
-/** Whose color a quantity is drawn in, either fixed or read off which way the quantity leans. */
 export type Party = { kind: 'color', hue: Hue } | { kind: 'lead', system: PartySystem }
 
-/** What a quantity is dressed in, over and above the dimensions it has. */
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party }
 
-/**
- * A temperature is the one quantity that is not a scaling of anything: Fahrenheit to Celsius has
- * an offset, so no unit off a ladder can express it.
- */
+/** Temperature is not expressed in units that scale each other: 0°C is not 0°F. */
 export type Unit = (
     { kind: 'temperature' }
     | { kind: 'scalar', dimensions: Dimension[], decoration: Decoration, difference: boolean }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -19,12 +19,19 @@ export interface Dimension {
 }
 
 // Abstract interpretation of a quantity as a unit.
+/** Whose color a quantity is drawn in, either fixed or read off which way the quantity leans. */
+export type Party = { kind: 'color', hue: Hue } | { kind: 'lead', system: PartySystem }
+
+/** What a quantity is dressed in, over and above the dimensions it has. */
+export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party }
+
+/**
+ * A temperature is the one quantity that is not a scaling of anything: Fahrenheit to Celsius has
+ * an offset, so no unit off a ladder can express it.
+ */
 export type Unit = (
-    { kind: 'raw-percentage', partyColor?: Hue }
-    | { kind: 'delta-percentage', partyColor?: Hue }
-    | { kind: 'lead-percentage', partySystem: PartySystem }
-    | { kind: 'temperature-F' }
-    | { kind: 'dimensionfull', scales: Dimension[] }
+    { kind: 'temperature' }
+    | { kind: 'scalar', dimensions: Dimension[], decoration: Decoration, difference: boolean }
 )
 
 export interface StoredUnit {
@@ -232,23 +239,19 @@ export function nameOf(written: Written[]): HumanReadableElement[] {
 }
 
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
-    switch (unit.kind) {
-        case 'raw-percentage':
-        case 'delta-percentage':
-            return percent
-        case 'lead-percentage':
-            return margin
-        case 'temperature-F':
-            return settings.temperatureUnit === 'celsius'
-                ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
-                : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
-        case 'dimensionfull': {
-            const convention = conventions[systemOf(settings)][renderAsKey(unit.scales)]
-            const pool = convention?.writeIn === undefined ? allUnits(settings) : Object.values(convention.writeIn)
-            const { written, scale, format } = chooseUnits(inBaseUnits, unit.scales, pool, chosen => styleFor(convention, chosen))
-            return { scale, unitName: nameOf(written), format, prefix: convention?.prefix }
-        }
+    if (unit.kind === 'temperature') {
+        return settings.temperatureUnit === 'celsius'
+            ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
+            : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
     }
+    if (unit.decoration.kind === 'percent') {
+        // a lead is given more digits the closer it is, since that is what is being read off it
+        return unit.decoration.party?.kind === 'lead' ? margin : percent
+    }
+    const convention = conventions[systemOf(settings)][renderAsKey(unit.dimensions)]
+    const pool = convention?.writeIn === undefined ? allUnits(settings) : Object.values(convention.writeIn)
+    const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool, chosen => styleFor(convention, chosen))
+    return { scale, unitName: nameOf(written), format, prefix: convention?.prefix }
 }
 
 function getParty(partySystem: PartySystem, value: number): { label: string, hue: Hue } {
@@ -257,15 +260,10 @@ function getParty(partySystem: PartySystem, value: number): { label: string, hue
 }
 
 function hueFor(unit: Unit): Hue | undefined {
-    switch (unit.kind) {
-        case 'raw-percentage':
-        case 'delta-percentage':
-            return unit.partyColor
-        case 'lead-percentage':
-        case 'temperature-F':
-        case 'dimensionfull':
-            return undefined
+    if (unit.kind === 'temperature' || unit.decoration.kind !== 'percent') {
+        return undefined
     }
+    return unit.decoration.party?.kind === 'color' ? unit.decoration.party.hue : undefined
 }
 
 export interface WrittenQuantity {
@@ -282,12 +280,15 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     const { unit } = stored
     let inBaseUnits = value * stored.toBaseUnits
     const representation = representationFor(inBaseUnits, unit, settings)
+    const leads = unit.kind === 'scalar' && unit.decoration.kind === 'percent' && unit.decoration.party?.kind === 'lead'
+        ? unit.decoration.party.system
+        : undefined
     let party = undefined
-    if (unit.kind === 'lead-percentage') {
-        party = getParty(unit.partySystem, inBaseUnits)
+    if (leads !== undefined) {
+        party = getParty(leads, inBaseUnits)
         inBaseUnits = Math.abs(inBaseUnits)
     }
-    const explicitSign = unit.kind === 'delta-percentage' && inBaseUnits >= 0 ? '+' : ''
+    const explicitSign = unit.kind === 'scalar' && unit.difference && inBaseUnits >= 0 ? '+' : ''
     const written = formatNumber(representation.scale(inBaseUnits), representation.format)
     return {
         renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${representation.prefix ?? ''}${written}`,

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -59,7 +59,6 @@ function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 
     }
 }
 
-/** A share of a vote, or a change in one, which is a fraction written as a percentage. */
 function percentage(party: Party | undefined, difference = false): StoredUnit {
     return { unit: { kind: 'scalar', dimensions: [], decoration: { kind: 'percent', party }, difference }, toBaseUnits: 1 }
 }

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,4 +1,4 @@
-import { BaseUnit, StoredUnit } from './quantity'
+import { BaseUnit, Hue, Party, StoredUnit } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
@@ -49,30 +49,42 @@ function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
 function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 1): StoredUnit {
     const entries = Object.entries(scales) as [BaseUnit, number][]
     return {
-        unit: { kind: 'dimensionfull', scales: entries.map(([baseUnit, power]) => ({ baseUnit, power })) },
+        unit: {
+            kind: 'scalar',
+            dimensions: entries.map(([baseUnit, power]) => ({ baseUnit, power })),
+            decoration: { kind: 'none' },
+            difference: false,
+        },
         toBaseUnits,
     }
 }
 
+/** A share of a vote, or a change in one, which is a fraction written as a percentage. */
+function percentage(party: Party | undefined, difference = false): StoredUnit {
+    return { unit: { kind: 'scalar', dimensions: [], decoration: { kind: 'percent', party }, difference }, toBaseUnits: 1 }
+}
+
+const inParty = (hue: Hue): Party => ({ kind: 'color', hue })
+
 /* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
 export const storedUnits = {
-    percentage: { unit: { kind: 'raw-percentage' }, toBaseUnits: 1 },
-    percentageChange: { unit: { kind: 'delta-percentage' }, toBaseUnits: 1 },
-    democraticMargin: { unit: { kind: 'lead-percentage', partySystem: 'democratic' }, toBaseUnits: 1 },
-    leftMargin: { unit: { kind: 'lead-percentage', partySystem: 'left' }, toBaseUnits: 1 },
-    partyPctBlue: { unit: { kind: 'raw-percentage', partyColor: 'blue' }, toBaseUnits: 1 },
-    partyPctRed: { unit: { kind: 'raw-percentage', partyColor: 'red' }, toBaseUnits: 1 },
-    partyPctOrange: { unit: { kind: 'raw-percentage', partyColor: 'orange' }, toBaseUnits: 1 },
-    partyPctTeal: { unit: { kind: 'raw-percentage', partyColor: 'cyan' }, toBaseUnits: 1 },
-    partyPctGreen: { unit: { kind: 'raw-percentage', partyColor: 'green' }, toBaseUnits: 1 },
-    partyPctPurple: { unit: { kind: 'raw-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
-    partyChangeBlue: { unit: { kind: 'delta-percentage', partyColor: 'blue' }, toBaseUnits: 1 },
-    partyChangeRed: { unit: { kind: 'delta-percentage', partyColor: 'red' }, toBaseUnits: 1 },
-    partyChangeOrange: { unit: { kind: 'delta-percentage', partyColor: 'orange' }, toBaseUnits: 1 },
-    partyChangeTeal: { unit: { kind: 'delta-percentage', partyColor: 'cyan' }, toBaseUnits: 1 },
-    partyChangeGreen: { unit: { kind: 'delta-percentage', partyColor: 'green' }, toBaseUnits: 1 },
-    partyChangePurple: { unit: { kind: 'delta-percentage', partyColor: 'purple' }, toBaseUnits: 1 },
-    temperature: { unit: { kind: 'temperature-F' }, toBaseUnits: 1 },
+    percentage: percentage(undefined),
+    percentageChange: percentage(undefined, true),
+    democraticMargin: percentage({ kind: 'lead', system: 'democratic' }),
+    leftMargin: percentage({ kind: 'lead', system: 'left' }),
+    partyPctBlue: percentage(inParty('blue')),
+    partyPctRed: percentage(inParty('red')),
+    partyPctOrange: percentage(inParty('orange')),
+    partyPctTeal: percentage(inParty('cyan')),
+    partyPctGreen: percentage(inParty('green')),
+    partyPctPurple: percentage(inParty('purple')),
+    partyChangeBlue: percentage(inParty('blue'), true),
+    partyChangeRed: percentage(inParty('red'), true),
+    partyChangeOrange: percentage(inParty('orange'), true),
+    partyChangeTeal: percentage(inParty('cyan'), true),
+    partyChangeGreen: percentage(inParty('green'), true),
+    partyChangePurple: percentage(inParty('purple'), true),
+    temperature: { unit: { kind: 'temperature' }, toBaseUnits: 1 },
     number: dimensionfull({}),
     population: dimensionfull({ person: 1 }),
     fatalities: dimensionfull({ fatality: 1 }),


### PR DESCRIPTION
Off main, and ahead of #2279 in the queue.

`Unit` was five kinds that were really two things:

```ts
export type Unit = (
    { kind: 'temperature' }
    | { kind: 'scalar', dimensions: Dimension[], decoration: Decoration, difference: boolean }
)

export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party }
export type Party = { kind: 'color', hue: Hue } | { kind: 'lead', system: PartySystem }
```

A temperature stays its own kind because it is the one quantity that is not a scaling of anything — Fahrenheit to Celsius has an offset, and no unit off a ladder can express that. Everything else is a scalar with dimensions, whatever it is dressed in, and whether it is a change rather than a level.

`difference` is where the duplication was. A percentage change differs from a percentage, and each party's change from that party's share, by a plus sign and nothing else — seven kinds carrying one bit. It is also the version that survives #2216: the difference of two columns is a difference whatever they were measuring, whereas `delta-percentage` only knew about fractions.

`Party` splits the two things the old `partyColor`/`partySystem` pair conflated: a share is always drawn in its party's color, while a margin reads its party off which way it leans, and colors and labels itself accordingly.

The declarations get shorter for it:

```ts
partyPctBlue: percentage(inParty('blue')),
partyChangeBlue: percentage(inParty('blue'), true),
democraticMargin: percentage({ kind: 'lead', system: 'democratic' }),
temperature: { unit: { kind: 'temperature' }, toBaseUnits: 1 },
```

Conventions stay keyed by dimensions here. Moving them onto the decoration — so a statistic keeps its units while a quantity derived from one floats — is the next step, and is what `decoration` is there to hold.

## Verification

The 1440-case sweep against main: **no differences**. `tsc`, lint, knip, 578 unit tests.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
