### PR TITLE
Let a statistic carry the units it is written in

### DIFF
--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -20,7 +20,18 @@ export interface Dimension {
 
 export type Party = { kind: 'color', hue: Hue } | { kind: 'lead', system: PartySystem }
 
-export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party }
+export type System = 'metric' | 'imperial'
+
+/**
+ * What a statistic is written in, whatever the search would otherwise choose, and to how many
+ * places. The places come with the units: fixing them is a decision about a unit already chosen.
+ */
+export interface WrittenIn {
+    units: (system: System) => Partial<Record<BaseUnit, NamedUnit>>
+    style: NumberFormat
+}
+
+export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party } | { kind: 'writtenIn', in: WrittenIn }
 
 /** Temperature is not expressed in units that scale each other: 0°C is not 0°F. */
 export type Unit = (
@@ -112,7 +123,22 @@ const meter = scaling('m', 'm', 1, 0)
 const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
 const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
 const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
-const microgram = scaling('g', 'μg', 1e-6, 0)
+const microgram = scaling('g', 'μg', 1e-6, costScaledUnit)
+
+const massUnits: NamedUnit[] = [
+    scaling('g', 'g', 1, 0),
+    microgram,
+    scaling('g', 'mg', 1e-3, costScaledUnit),
+    scaling('g', 'kg', 1e3, costScaledUnit),
+]
+
+const timeUnits: NamedUnit[] = [
+    scaling('s', 's', 1, 0),
+    scaling('s', 'min', 60, costScaledUnit),
+    scaling('s', 'hr', 60 * 60, costScaledUnit),
+    scaling('s', 'days', 24 * 60 * 60, costScaledUnit),
+    year,
+]
 
 const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
     metric: [
@@ -142,6 +168,8 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
         // fatalities are not abbreviated: there are never enough of them for it to save a digit
         scaling('fatality', '', 1, 0),
         ...lengthUnits[systemOf(settings)],
+        ...massUnits,
+        ...timeUnits,
     ]
 }
 
@@ -160,33 +188,39 @@ function renderAsKey(scales: Dimension[]): DimensionKey {
  */
 interface Convention {
     style?: NumberFormat
-    /** Every base unit the quantity has, or there is no way left to write it in. */
-    writeIn?: Partial<Record<BaseUnit, NamedUnit>>
     prefix?: string
 }
 
-function conventionsUsing(kmLike: NamedUnit, cmLike: NamedUnit): Record<DimensionKey, Convention | undefined> {
-    return {
-        '': { style: { kind: 'significantFigures' } },
-        // things that are counted come in whole numbers, unless they are counted in thousands
-        'person^1': { style: { kind: 'fixed', places: 0 } },
-        'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
-        'fatality^1': { style: { kind: 'fixed', places: 0 } },
-        'fatality^1 person^-1': {
-            style: { kind: 'fixed', places: 2 },
-            writeIn: { fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) },
-        },
-        // a density is not worth a third digit, and every one of them is read against the others
-        'm^-2 person^1': { style: { kind: 'rounded', significantDigits: 2 }, writeIn: { person: people, m: kmLike } },
-        // a concentration is scientific, and stays in the units science is written in
-        'g^1 m^-3': { style: { kind: 'fixed', places: 2 }, writeIn: { g: microgram, m: meter } },
-        'm^1 s^-1': { style: { kind: 'fixed', places: 1 }, writeIn: { m: cmLike, s: year } },
-    }
+/** What quantities of these dimensions are written like, however they arose. */
+const conventions: Record<DimensionKey, Convention | undefined> = {
+    '': { style: { kind: 'significantFigures' } },
+    // things that are counted come in whole numbers, unless they are counted in thousands
+    'person^1': { style: { kind: 'fixed', places: 0 } },
+    'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
+    'fatality^1': { style: { kind: 'fixed', places: 0 } },
 }
 
-const conventions: Record<'metric' | 'imperial', Record<DimensionKey, Convention | undefined>> = {
-    metric: conventionsUsing(kilometer, centimeter),
-    imperial: conventionsUsing(mile, inch),
+/** A death rate is per a hundred thousand people however many digits per person would save. */
+export const perHundredThousand: WrittenIn = {
+    units: () => ({ fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) }),
+    style: { kind: 'fixed', places: 2 },
+}
+
+/** A density is not worth a third digit, and every one of them is read against the others. */
+export const perArea: WrittenIn = {
+    units: system => ({ person: people, m: system === 'metric' ? kilometer : mile }),
+    style: { kind: 'rounded', significantDigits: 2 },
+}
+
+/** A concentration is scientific, and stays in the units science is written in. */
+export const perCubicMeter: WrittenIn = {
+    units: () => ({ g: microgram, m: meter }),
+    style: { kind: 'fixed', places: 2 },
+}
+
+export const perYear: WrittenIn = {
+    units: system => ({ m: system === 'metric' ? centimeter : inch, s: year }),
+    style: { kind: 'fixed', places: 1 },
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
@@ -246,9 +280,12 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
         // a lead is given more digits the closer it is, since that is what is being read off it
         return unit.decoration.party?.kind === 'lead' ? margin : percent
     }
-    const convention = conventions[systemOf(settings)][renderAsKey(unit.dimensions)]
-    const pool = convention?.writeIn === undefined ? allUnits(settings) : Object.values(convention.writeIn)
-    const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool, chosen => styleFor(convention, chosen))
+    const convention = conventions[renderAsKey(unit.dimensions)]
+    // a statistic written in units of its own leaves the search nothing to choose between
+    const writtenIn = unit.decoration.kind === 'writtenIn' ? unit.decoration.in : undefined
+    const pool = writtenIn === undefined ? allUnits(settings) : Object.values(writtenIn.units(systemOf(settings)))
+    const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool,
+        chosen => writtenIn?.style ?? styleFor(convention, chosen))
     return { scale, unitName: nameOf(written), format, prefix: convention?.prefix }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -23,8 +23,8 @@ export type Party = { kind: 'color', hue: Hue } | { kind: 'lead', system: PartyS
 export type System = 'metric' | 'imperial'
 
 /**
- * What a statistic is written in, whatever the search would otherwise choose, and to how many
- * places. The places come with the units: fixing them is a decision about a unit already chosen.
+ * A fixed number of places only means something once the unit is known: two decimals of
+ * micrograms, not of grams. So a statistic declares the two together.
  */
 export interface WrittenIn {
     units: (system: System) => Partial<Record<BaseUnit, NamedUnit>>
@@ -116,14 +116,16 @@ function systemOf(settings: ReaderSettings): 'metric' | 'imperial' {
     return settings.useImperial === true ? 'imperial' : 'metric'
 }
 
-const kilometer = scaling('m', 'km', 1e3, costScaledUnit)
-const mile = scaling('m', 'mi', metersPerMile, costScaledUnit)
-const people = scaling('person', '', 1, 0)
-const meter = scaling('m', 'm', 1, 0)
-const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
-const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
-const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
-const microgram = scaling('g', 'μg', 1e-6, costScaledUnit)
+export const kilometer = scaling('m', 'km', 1e3, costScaledUnit)
+export const mile = scaling('m', 'mi', metersPerMile, costScaledUnit)
+export const people = scaling('person', '', 1, 0)
+export const hundredThousandPeople = scaling('person', '100k', 1e5, 0)
+export const fatalities = scaling('fatality', '', 1, 0)
+export const meter = scaling('m', 'm', 1, 0)
+export const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
+export const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
+export const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
+export const microgram = scaling('g', 'μg', 1e-6, costScaledUnit)
 
 const massUnits: NamedUnit[] = [
     scaling('g', 'g', 1, 0),
@@ -198,29 +200,6 @@ const conventions: Record<DimensionKey, Convention | undefined> = {
     'person^1': { style: { kind: 'fixed', places: 0 } },
     'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
     'fatality^1': { style: { kind: 'fixed', places: 0 } },
-}
-
-/** A death rate is per a hundred thousand people however many digits per person would save. */
-export const perHundredThousand: WrittenIn = {
-    units: () => ({ fatality: scaling('fatality', '', 1, 0), person: scaling('person', '100k', 1e5, 0) }),
-    style: { kind: 'fixed', places: 2 },
-}
-
-/** A density is not worth a third digit, and every one of them is read against the others. */
-export const perArea: WrittenIn = {
-    units: system => ({ person: people, m: system === 'metric' ? kilometer : mile }),
-    style: { kind: 'rounded', significantDigits: 2 },
-}
-
-/** A concentration is scientific, and stays in the units science is written in. */
-export const perCubicMeter: WrittenIn = {
-    units: () => ({ g: microgram, m: meter }),
-    style: { kind: 'fixed', places: 2 },
-}
-
-export const perYear: WrittenIn = {
-    units: system => ({ m: system === 'metric' ? centimeter : inch, s: year }),
-    style: { kind: 'fixed', places: 1 },
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,4 +1,7 @@
-import { BaseUnit, Decoration, Hue, Party, perArea, perCubicMeter, perHundredThousand, perYear, StoredUnit, WrittenIn } from './quantity'
+import {
+    BaseUnit, centimeter, Decoration, fatalities, Hue, hundredThousandPeople, inch, kilometer, meter, microgram, mile,
+    Party, people, StoredUnit, WrittenIn, year,
+} from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
@@ -92,10 +95,22 @@ export const storedUnits = {
     distanceInM: dimensionfull({ m: 1 }),
     distanceInKm: dimensionfull({ m: 1 }, 1e3),
     area: dimensionfull({ m: 2 }, 1e6),
-    fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }, 1, perHundredThousand),
-    density: dimensionfull({ person: 1, m: -2 }, 1e-6, perArea),
-    contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6, perCubicMeter),
-    distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60), perYear),
+    fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }, 1, {
+        units: () => ({ fatality: fatalities, person: hundredThousandPeople }),
+        style: { kind: 'fixed', places: 2 },
+    }),
+    density: dimensionfull({ person: 1, m: -2 }, 1e-6, {
+        units: system => ({ person: people, m: system === 'metric' ? kilometer : mile }),
+        style: { kind: 'rounded', significantDigits: 2 },
+    }),
+    contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6, {
+        units: () => ({ g: microgram, m: meter }),
+        style: { kind: 'fixed', places: 2 },
+    }),
+    distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60), {
+        units: system => ({ m: system === 'metric' ? centimeter : inch, s: year }),
+        style: { kind: 'fixed', places: 1 },
+    }),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,4 +1,4 @@
-import { BaseUnit, Hue, Party, StoredUnit } from './quantity'
+import { BaseUnit, Decoration, Hue, Party, perArea, perCubicMeter, perHundredThousand, perYear, StoredUnit, WrittenIn } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
     | 'area' | 'distanceInKm' | 'distanceInM' | 'democraticMargin' | 'temperature' | 'time' | 'distancePerYear'
@@ -46,13 +46,14 @@ function checkAllIncluded(unitType: UnitType): (typeof allUnitTypes)[number] {
     return unitType
 }
 
-function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 1): StoredUnit {
+function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 1, writtenIn?: WrittenIn): StoredUnit {
     const entries = Object.entries(scales) as [BaseUnit, number][]
+    const decoration: Decoration = writtenIn === undefined ? { kind: 'none' } : { kind: 'writtenIn', in: writtenIn }
     return {
         unit: {
             kind: 'scalar',
             dimensions: entries.map(([baseUnit, power]) => ({ baseUnit, power })),
-            decoration: { kind: 'none' },
+            decoration,
             difference: false,
         },
         toBaseUnits,
@@ -91,10 +92,10 @@ export const storedUnits = {
     distanceInM: dimensionfull({ m: 1 }),
     distanceInKm: dimensionfull({ m: 1 }, 1e3),
     area: dimensionfull({ m: 2 }, 1e6),
-    fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }),
-    density: dimensionfull({ person: 1, m: -2 }, 1e-6),
-    contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6),
-    distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60)),
+    fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }, 1, perHundredThousand),
+    density: dimensionfull({ person: 1, m: -2 }, 1e-6, perArea),
+    contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6, perCubicMeter),
+    distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60), perYear),
 } satisfies Partial<Record<UnitType, StoredUnit>>
 /* eslint-enable no-restricted-syntax */
 

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -4,7 +4,8 @@ import assert from 'assert/strict'
 import test from 'node:test'
 
 import { getUnitDisplay, renderInequality } from '../src/components/unit-display'
-import { writeQuantity } from '../src/utils/quantity'
+import { reifyString } from '../src/utils/human-readable-name'
+import { Dimension, StoredUnit, writeQuantity } from '../src/utils/quantity'
 import { storedUnits, UnitType } from '../src/utils/unit'
 
 // Flatten a React element tree into its text content.
@@ -303,5 +304,25 @@ for (const [unitType, value, expected] of [
 ] as const) {
     void test(`${unitType} renders ${value} in imperial as ${expected}`, () => {
         assert.equal(renderValue(unitType, value, true), expected)
+    })
+}
+
+// A statistic is written in the units it is declared in; a quantity that merely has the same
+// dimensions, as one derived from it would, is written in whichever units read shortest
+for (const [unitType, dimensions, toBaseUnits, value, asStatistic, asDerived] of [
+    ['contaminantLevel', [{ baseUnit: 'g', power: 1 }, { baseUnit: 'm', power: -3 }], 1e-6, 8.2, '8.20μg/m^{3}', '8.20μg/m^{3}'],
+    ['distancePerYear', [{ baseUnit: 'm', power: 1 }, { baseUnit: 's', power: -1 }], 1 / (365.25 * 24 * 60 * 60), 1.2, '120.0cm/yr', '1.20m/yr'],
+    ['density', [{ baseUnit: 'person', power: 1 }, { baseUnit: 'm', power: -2 }], 1e-6, 1234, '1\u202f234/\u00a0km^{2}', '0.001/\u00a0m^{2}'],
+] as ['contaminantLevel' | 'distancePerYear' | 'density', Dimension[], number, number, string, string][]) {
+    const write = (stored: StoredUnit): string => {
+        const written = writeQuantity(value, stored)
+        return `${written.renderedValue}${reifyString(written.unitName)}`
+    }
+    void test(`${unitType} keeps its units, where the same dimensions on their own do not`, () => {
+        assert.equal(write(storedUnits[unitType]), asStatistic)
+        assert.equal(write({
+            unit: { kind: 'scalar', dimensions, decoration: { kind: 'none' }, difference: false },
+            toBaseUnits,
+        }), asDerived)
     })
 }


### PR DESCRIPTION
Off main. This is the change #2281's `decoration` field was added to hold.

What a pollution reading is written in is a fact about that column, not about everything with the dimensions of a concentration. So a statistic says it where it says everything else about itself:

```ts
density: dimensionfull({ person: 1, m: -2 }, 1e-6, {
    units: system => ({ person: people, m: system === 'metric' ? kilometer : mile }),
    style: { kind: 'rounded', significantDigits: 2 },
}),
contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6, {
    units: () => ({ g: microgram, m: meter }),
    style: { kind: 'fixed', places: 2 },
}),
```

and a quantity that merely has the same dimensions — as one derived in a script would — is written in whichever units read shortest:

```
pollution (statistic)          8.20 μg/m³
  same dimensions, derived     8.20 μg/m³
rainfall (statistic)           120.0 cm/yr
  same dimensions, derived     1.20 m/yr
density (statistic)            1 234 /km²
  same dimensions, derived     0.001 /m²
```

The dimension-keyed table keeps what is genuinely dimensional: a count of people is whole however it arose, a dollar figure takes a `$`, and a dimensionless number gets three figures. Those a derived quantity should inherit.

## Two things this turned up

**The places have to travel with the units.** A `fixed` style is exempt from the penalty for rounding a quantity away — that exemption is what keeps a fraction of a person reading `0` — so a floating concentration that kept `fixed 2` from the dimension table renders every realistic reading as `0.00 g/m³`. Fixing decimal places is a decision about a unit already chosen, so `WrittenIn` carries both.

**The pool has to cover every base unit.** It is now what an undecorated quantity falls back on, and grams and seconds had no units outside the conventions that named them — the microgram and the year existed only there. A derived concentration hit `every quantity has at least one way of being written` rather than floating. Mass and time ladders are in the pool now, which cannot affect the statistics, since their pool is replaced outright.

## Verification

The 1440-case sweep against main: **no differences**. `tsc`, lint, knip, 585 unit tests, three of them new: each of the three decorated statistics against a bare quantity of the same dimensions.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
