### PR TITLE
Keep the embed preview where you left it across a reload

### DIFF
--- a/react/cf-og-worker/README.md
+++ b/react/cf-og-worker/README.md
@@ -30,8 +30,9 @@ That serves the Worker on port 8787 (`OG_PORT`) against `http://localhost:$PORT`
 own port serves the whole site.
 
 `/embed-preview.html?target=<page url>` is a dev page showing the site on one side and the card a
-crawler would get on the other. It follows the frame's navigation, and it redraws when you edit the
-Worker, which restarts it — the site's own hot reload knows nothing about that.
+crawler would get on the other. It follows the frame's navigation, writing it back into `target` so
+a reload stays where you were, and it redraws when you edit the Worker, which restarts it — the
+site's own hot reload knows nothing about that.
 
 A card URL served against a local site takes `__tiles=<origin>`, which draws the basemap from that
 origin rather than openfreemap. The card screenshot tests point it at a snapshot of the tiles.

--- a/react/src/dev/EmbedPreviewPanel.tsx
+++ b/react/src/dev/EmbedPreviewPanel.tsx
@@ -1,6 +1,7 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react'
+import React, { ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { z } from 'zod'
 
+import { Navigator } from '../navigation/Navigator'
 import { useColors } from '../page_template/colors'
 
 /** What a crawler gets back for a page: the tags the Worker rewrote on the way through. */
@@ -54,6 +55,7 @@ async function fetchEmbed(workerOrigin: string, target: string): Promise<Status>
 
 export function EmbedPreviewPanel({ target, ogPort }: { target: string, ogPort: number }): ReactNode {
     const colors = useColors()
+    const navContext = useContext(Navigator.Context)
     const workerOrigin = `http://localhost:${ogPort}`
 
     const [path, setPath] = useState(target)
@@ -66,6 +68,12 @@ export function EmbedPreviewPanel({ target, ogPort }: { target: string, ogPort: 
     const frame = useRef<HTMLIFrameElement>(null)
     const seen = useRef(target)
     const isolate = useRef<string | undefined>(undefined)
+
+    // Keeps the page reloadable at whatever the frame is showing, rather than back at the default.
+    const record = useCallback((newPath: string): void => {
+        seen.current = newPath
+        navContext.unsafeUpdateCurrentDescriptor({ kind: 'embedPreview', target: newPath }, { history: 'replaceState' })
+    }, [navContext])
 
     /*
      * The site navigates with pushState, which fires no load event on the frame, so polling is the
@@ -86,12 +94,12 @@ export function EmbedPreviewPanel({ target, ogPort }: { target: string, ogPort: 
                 return // navigated off-origin
             }
             if (here !== seen.current) {
-                seen.current = here
+                record(here)
                 setPath(here)
             }
         }, 250)
         return () => { clearInterval(interval) }
-    }, [])
+    }, [record])
 
     /*
      * Editing the Worker restarts it, which the site's own hot reload never hears about. The restart
@@ -131,7 +139,7 @@ export function EmbedPreviewPanel({ target, ogPort }: { target: string, ogPort: 
                 onChange={(e) => { setPath(e.target.value) }}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter') {
-                        seen.current = path
+                        record(path)
                         setSrc(path)
                     }
                 }}

--- a/react/test/embed_preview.test.ts
+++ b/react/test/embed_preview.test.ts
@@ -44,6 +44,9 @@ test('embed-preview-follows-frame', async (t) => {
     await t.expect(card.innerText).contains('Population', { timeout: 30_000 })
     // The Worker draws no card for this page kind, so the site's static preview stands.
     await t.expect(card.find('img').getAttribute('src')).contains('/link-preview.png')
+    // The panel puts what it is showing in its own URL, so a reload does not go back to the start.
+    await safeReload(t)
+    await t.expect(pathInput.value).contains('/statistic.html', { timeout: 30_000 })
 })
 
 test('embed-preview-juxtastat', async (t) => {


### PR DESCRIPTION
Reloading `/embed-preview.html` dropped you back at the default article, which is annoying because reloading is what you do every time the site or the Worker rebuilds. The panel followed the frame's navigation in local state only; it now writes that location back into its own `target` param, which the page already accepted.

The write is a `replaceState`, not a push: the panel polls the frame four times a second, and an entry per navigation would bury the back button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)