### PR TITLE
Write a duration as the kind of quantity it is

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
-import { Hue, missingValue, StoredUnit, writeQuantity } from '../utils/quantity'
+import { Hue, StoredUnit, writeQuantity } from '../utils/quantity'
 import { storedUnits, UnitType } from '../utils/unit'
 
 export interface UnitDisplay {
@@ -25,48 +25,8 @@ export function renderInequality(value: number, unitType: UnitType, inequality: 
     return reads === 'leq' ? '\u2264' /* ≤ */ : '\u2265' /* ≥ */
 }
 
-interface ReaderSettings {
-    useImperial: boolean
-    temperatureUnit: string
-}
-
-interface Written {
-    number: string
-    unit: HumanReadableElement[]
-}
-
-const unitlessDisplay: HumanReadableElement[] = []
-
-function atom(value: string): HumanReadableElement[] {
-    return [{ type: 'atom', value }]
-}
-
 function unitColumn(name: HumanReadableElement[]): ReactNode {
     return <span>{name.length === 0 ? <>&nbsp;</> : reifyReact(name)}</span>
-}
-
-function display(write: (value: number, settings: ReaderSettings) => Written): UnitDisplay {
-    return {
-        renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-            if (!isFinite(value)) {
-                return { value: <span>{missingValue}</span>, unit: unitColumn(unitlessDisplay) }
-            }
-            const { number, unit } = write(value, { useImperial: useImperial ?? false, temperatureUnit: temperatureUnit ?? 'fahrenheit' })
-            return { value: <span>{number}</span>, unit: unitColumn(unit) }
-        },
-    }
-}
-
-/** Durations read as hours and minutes, or as minutes alone where there are no hours. */
-function hoursAndMinutes(hours: number): Written {
-    const totalMinutes = Math.round(Math.abs(hours) * 60)
-    const sign = hours < 0 && totalMinutes > 0 ? '-' : ''
-    const wholeHours = Math.floor(totalMinutes / 60)
-    const minutes = totalMinutes % 60
-    if (wholeHours === 0) {
-        return { number: `${sign}${minutes}`, unit: atom('min') }
-    }
-    return { number: `${sign}${wholeHours}:${minutes.toString().padStart(2, '0')}`, unit: atom('h') }
 }
 
 /** A quantity written in a party's color, set flush right so that a fourth digit overflows left. */
@@ -118,11 +78,9 @@ export function getUnitDisplay(unitType: UnitType): UnitDisplay {
         case 'density':
         case 'contaminantLevel':
         case 'distancePerYear':
-            return quantity(storedUnits[unitType])
         case 'time':
-            return display(value => hoursAndMinutes(value))
         case 'minutes':
-            return display(value => hoursAndMinutes(value / 60))
+            return quantity(storedUnits[unitType])
     }
 }
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -33,9 +33,13 @@ export interface WrittenIn {
 
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party } | { kind: 'writtenIn', in: WrittenIn }
 
-/** Temperature is not expressed in units that scale each other: 0°C is not 0°F. */
+/**
+ * Temperature is not expressed in units that scale each other: 0°C is not 0°F. A duration is not
+ * expressed in one unit at all: 1:30 is an hour and a half of it.
+ */
 export type Unit = (
     { kind: 'temperature' }
+    | { kind: 'duration' }
     | { kind: 'scalar', dimensions: Dimension[], decoration: Decoration, difference: boolean }
 )
 
@@ -50,7 +54,7 @@ export interface ReaderSettings {
     temperatureUnit?: string
 }
 
-export const missingValue = 'N/A'
+const missingValue = 'N/A'
 
 /** How a quantity is written: what to scale it by, what to call the result, and to how many places. */
 export interface Representation {
@@ -250,6 +254,11 @@ export function nameOf(written: Written[]): HumanReadableElement[] {
 }
 
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
+    if (unit.kind === 'duration') {
+        // it is named for the largest part of it that there is any of, as h:mm reads in hours
+        const anHourOrMore = Math.round(Math.abs(inBaseUnits) / 60) >= 60
+        return { unitName: atom(anHourOrMore ? 'h' : 'min'), scale: value => value / 60, format: { kind: 'hoursMinutes' } }
+    }
     if (unit.kind === 'temperature') {
         return settings.temperatureUnit === 'celsius'
             ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
@@ -274,7 +283,7 @@ function getParty(partySystem: PartySystem, value: number): { label: string, hue
 }
 
 function hueFor(unit: Unit): Hue | undefined {
-    if (unit.kind === 'temperature' || unit.decoration.kind !== 'percent') {
+    if (unit.kind !== 'scalar' || unit.decoration.kind !== 'percent') {
         return undefined
     }
     return unit.decoration.party?.kind === 'color' ? unit.decoration.party.hue : undefined

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -33,13 +33,9 @@ export interface WrittenIn {
 
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party } | { kind: 'writtenIn', in: WrittenIn }
 
-/**
- * Temperature is not expressed in units that scale each other: 0°C is not 0°F. A duration is
- * expressed in two at once: the 1 of 1:30 is hours and the 30 is minutes.
- */
+/** Temperature is not expressed in units that scale each other: 0°C is not 0°F. */
 export type Unit = (
     { kind: 'temperature' }
-    | { kind: 'duration' }
     | { kind: 'scalar', dimensions: Dimension[], decoration: Decoration, difference: boolean }
 )
 
@@ -128,6 +124,7 @@ export const fatalities = scaling('fatality', '', 1, 0)
 export const meter = scaling('m', 'm', 1, 0)
 export const centimeter = scaling('m', 'cm', 0.01, costScaledUnit)
 export const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
+export const minute = scaling('s', 'min', 60, costScaledUnit)
 export const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
 export const microgram = scaling('g', 'μg', 1e-6, costScaledUnit)
 
@@ -140,7 +137,7 @@ const massUnits: NamedUnit[] = [
 
 const timeUnits: NamedUnit[] = [
     scaling('s', 's', 1, 0),
-    scaling('s', 'min', 60, costScaledUnit),
+    minute,
     scaling('s', 'hr', 60 * 60, costScaledUnit),
     scaling('s', 'days', 24 * 60 * 60, costScaledUnit),
     year,
@@ -254,11 +251,6 @@ export function nameOf(written: Written[]): HumanReadableElement[] {
 }
 
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
-    if (unit.kind === 'duration') {
-        // it is named for the largest part of it that there is any of, as h:mm reads in hours
-        const anHourOrMore = Math.round(Math.abs(inBaseUnits) / 60) >= 60
-        return { unitName: atom(anHourOrMore ? 'h' : 'min'), scale: value => value / 60, format: { kind: 'hoursMinutes' } }
-    }
     if (unit.kind === 'temperature') {
         return settings.temperatureUnit === 'celsius'
             ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
@@ -274,7 +266,11 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
     const pool = writtenIn === undefined ? allUnits(settings) : Object.values(writtenIn.units(systemOf(settings)))
     const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool,
         chosen => writtenIn?.style ?? styleFor(convention, chosen))
-    return { scale, unitName: nameOf(written), format, prefix: convention?.prefix }
+    // h:mm spends two units and names one, so which one it names is the format's to say
+    const unitName = format.kind === 'hoursMinutes'
+        ? atom(Math.round(Math.abs(scale(inBaseUnits))) >= 60 ? 'h' : 'min')
+        : nameOf(written)
+    return { scale, unitName, format, prefix: convention?.prefix }
 }
 
 function getParty(partySystem: PartySystem, value: number): { label: string, hue: Hue } {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -1,7 +1,7 @@
 import { HueColors } from '../page_template/color-themes'
 
 import { atom, HumanReadableElement } from './human-readable-name'
-import { formatNumber, NumberFormat } from './text'
+import { formatNumber, hoursAndMinutes, NumberFormat } from './text'
 import { chooseUnits, Written } from './unit-search'
 
 export type Hue = keyof HueColors
@@ -268,7 +268,7 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
         chosen => writtenIn?.style ?? styleFor(convention, chosen))
     // h:mm spends two units and names one, so which one it names is the format's to say
     const unitName = format.kind === 'hoursMinutes'
-        ? atom(Math.round(Math.abs(scale(inBaseUnits))) >= 60 ? 'h' : 'min')
+        ? atom(hoursAndMinutes(scale(inBaseUnits)).unit)
         : nameOf(written)
     return { scale, unitName, format, prefix: convention?.prefix }
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -34,8 +34,8 @@ export interface WrittenIn {
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party } | { kind: 'writtenIn', in: WrittenIn }
 
 /**
- * Temperature is not expressed in units that scale each other: 0°C is not 0°F. A duration is not
- * expressed in one unit at all: 1:30 is an hour and a half of it.
+ * Temperature is not expressed in units that scale each other: 0°C is not 0°F. A duration is
+ * expressed in two at once: the 1 of 1:30 is hours and the 30 is minutes.
  */
 export type Unit = (
     { kind: 'temperature' }

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -65,6 +65,7 @@ export type NumberFormat = (
     { kind: 'fixed', places: number }
     | ({ kind: 'rounded' } & Rounding)
     | { kind: 'significantFigures' }
+    | { kind: 'hoursMinutes' }
 )
 
 export function formatNumber(value: number, format: NumberFormat): string {
@@ -75,6 +76,13 @@ export function formatNumber(value: number, format: NumberFormat): string {
             return roundToDigits(value, format)
         case 'significantFigures':
             return separateNumber(formatToSignificantFigures(value, 3))
+        case 'hoursMinutes': {
+            const totalMinutes = Math.round(Math.abs(value))
+            const sign = value < 0 && totalMinutes > 0 ? '-' : ''
+            const hours = Math.floor(totalMinutes / 60)
+            const minutes = totalMinutes % 60
+            return hours === 0 ? `${sign}${minutes}` : `${sign}${hours}:${minutes.toString().padStart(2, '0')}`
+        }
     }
 }
 

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -68,6 +68,17 @@ export type NumberFormat = (
     | { kind: 'hoursMinutes' }
 )
 
+/** A number of minutes as hours and minutes, or as minutes alone where there are no hours. */
+export function hoursAndMinutes(inMinutes: number): { written: string, unit: 'h' | 'min' } {
+    const totalMinutes = Math.round(Math.abs(inMinutes))
+    const sign = inMinutes < 0 && totalMinutes > 0 ? '-' : ''
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = totalMinutes % 60
+    return hours === 0
+        ? { written: `${sign}${minutes}`, unit: 'min' }
+        : { written: `${sign}${hours}:${minutes.toString().padStart(2, '0')}`, unit: 'h' }
+}
+
 export function formatNumber(value: number, format: NumberFormat): string {
     switch (format.kind) {
         case 'fixed':
@@ -76,13 +87,8 @@ export function formatNumber(value: number, format: NumberFormat): string {
             return roundToDigits(value, format)
         case 'significantFigures':
             return separateNumber(formatToSignificantFigures(value, 3))
-        case 'hoursMinutes': {
-            const totalMinutes = Math.round(Math.abs(value))
-            const sign = value < 0 && totalMinutes > 0 ? '-' : ''
-            const hours = Math.floor(totalMinutes / 60)
-            const minutes = totalMinutes % 60
-            return hours === 0 ? `${sign}${minutes}` : `${sign}${hours}:${minutes.toString().padStart(2, '0')}`
-        }
+        case 'hoursMinutes':
+            return hoursAndMinutes(value).written
     }
 }
 

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,6 +1,6 @@
 import {
     BaseUnit, centimeter, Decoration, fatalities, Hue, hundredThousandPeople, inch, kilometer, meter, microgram, mile,
-    Party, people, StoredUnit, WrittenIn, year,
+    minute, Party, people, StoredUnit, WrittenIn, year,
 } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
@@ -88,8 +88,8 @@ export const storedUnits = {
     partyChangeGreen: percentage(inParty('green'), true),
     partyChangePurple: percentage(inParty('purple'), true),
     temperature: { unit: { kind: 'temperature' }, toBaseUnits: 1 },
-    time: { unit: { kind: 'duration' }, toBaseUnits: 60 * 60 },
-    minutes: { unit: { kind: 'duration' }, toBaseUnits: 60 },
+    time: dimensionfull({ s: 1 }, 60 * 60, { units: () => ({ s: minute }), style: { kind: 'hoursMinutes' } }),
+    minutes: dimensionfull({ s: 1 }, 60, { units: () => ({ s: minute }), style: { kind: 'hoursMinutes' } }),
     number: dimensionfull({}),
     population: dimensionfull({ person: 1 }),
     fatalities: dimensionfull({ fatality: 1 }),

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -88,6 +88,8 @@ export const storedUnits = {
     partyChangeGreen: percentage(inParty('green'), true),
     partyChangePurple: percentage(inParty('purple'), true),
     temperature: { unit: { kind: 'temperature' }, toBaseUnits: 1 },
+    time: { unit: { kind: 'duration' }, toBaseUnits: 60 * 60 },
+    minutes: { unit: { kind: 'duration' }, toBaseUnits: 60 },
     number: dimensionfull({}),
     population: dimensionfull({ person: 1 }),
     fatalities: dimensionfull({ fatality: 1 }),


### PR DESCRIPTION
Off main. The last unit type with an arm of its own.

A duration is a quantity of time like any other, so it keeps its dimensions and goes through the search:

```ts
time: dimensionfull({ s: 1 }, 60 * 60, { units: () => ({ s: minute }), style: { kind: 'hoursMinutes' } }),
minutes: dimensionfull({ s: 1 }, 60, { units: () => ({ s: minute }), style: { kind: 'hoursMinutes' } }),
```

What is unusual is only how it is written. `h:mm` spends two units and names one, so the name cannot come from the chosen unit the way every other name does — it comes from the format:

```ts
// h:mm spends two units and names one, so which one it names is the format's to say
const unitName = format.kind === 'hoursMinutes'
    ? atom(hoursAndMinutes(scale(inBaseUnits)).unit)
    : nameOf(written)
```

One function in `text.ts` decides both the text and which of `h`/`min` names it, so the rounding that picks between them happens once.

Keeping the dimensions is what lets #2216 reach a duration at all: a time over a distance is a pace, and none of that follows if a duration sits outside the dimension system.

This keeps #2234's behaviour exactly: `34min`, `1:30h`, `1:40h` for 99.5 minutes, `-1:30h`, and `0min` for nothing.

## What goes with it

Every unit type is now written by `writeQuantity`, so the scaffolding the arms used goes: the `display` writer, its `ReaderSettings`, its `Written` type, its blank unit, and the local `atom`. `unit-display.tsx` is down to the two things it is for — putting a quantity in its two columns, and colouring a party's one.

`missingValue` becomes private to `quantity.ts`, since nothing outside writes an N/A any more.

## Verification

The 1440-case sweep against main: **no differences**. `tsc`, lint, knip, 585 unit tests, including the existing duration cases, which were written against #2234.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
