### PR TITLE
Measure what a comparison and a statistic card cost to render

### DIFF
--- a/react/cf-og-worker/src/data.ts
+++ b/react/cf-og-worker/src/data.ts
@@ -23,7 +23,7 @@ import { Inset } from '../../src/urban-stats-script/constants/insets'
 import { ClusterMap, CMap, CMapRGB, PMap } from '../../src/urban-stats-script/constants/map'
 import { Table } from '../../src/urban-stats-script/constants/table'
 import { deriveConditionLabel, deriveMapLabel } from '../../src/urban-stats-script/derive-human-readable-name'
-import { executeRequest } from '../../src/urban-stats-script/execute-request'
+import { createRequestExecutor } from '../../src/urban-stats-script/execute-request'
 import { geometry } from '../../src/utils/geometry'
 import { HumanReadableName, reifyString } from '../../src/utils/human-readable-name'
 import { Feature } from '../../src/utils/protos'
@@ -178,7 +178,9 @@ export async function statisticCard(origin: string, pageData: Extract<PageData, 
     const { stat, view } = pageData.settings
     const typeEnvironment = defaultTypeEnvironment(stat.universe)
     const mapUSS = mapUSSFromStat(stat)
-    const executed = await executeRequest({
+    // Its own executor: each card is a page of its own, so one kept across them would only hold
+    // the previous page's columns in the isolate.
+    const executed = await createRequestExecutor()({
         descriptor: {
             kind: 'statistics',
             geographyKind: stat.articleType as typeof validGeographies[number],
@@ -310,7 +312,7 @@ export async function mapCard(origin: string, pageData: Extract<PageData, { kind
         return undefined
     }
 
-    const executed = await executeRequest({ descriptor: { kind: 'mapper', geographyKind, universe }, stmts: computeUSS(script) })
+    const executed = await createRequestExecutor()({ descriptor: { kind: 'mapper', geographyKind, universe }, stmts: computeUSS(script) })
     const result = executed.resultingValue?.value as MapResult | undefined
     if (result === undefined) {
         return undefined

--- a/react/src/urban-stats-script/execute-request.ts
+++ b/react/src/urban-stats-script/execute-request.ts
@@ -16,17 +16,29 @@ import { noLocation } from './location'
 import { renderType, USSRawValue, USSValue } from './types-values'
 import { AssignmentsResult, USSExecutionRequest, USSExecutionResult } from './workerManager'
 
-let mapperCache: {
+interface LoadedGeography {
     universe: Universe
     geographyKind: typeof validGeographies[number]
     longnames: string[]
     dataCache: Map<string, number[]>
-} | undefined
+}
 
-export async function executeRequest(request: USSExecutionRequest): Promise<USSExecutionResult> {
+/** Replaced whenever a request asks for a geography other than the one already loaded. */
+interface ExecutorCache { loaded: LoadedGeography | undefined }
+
+/**
+ * The executor holds the names and columns of the geography it last ran over, so a request over
+ * that same geography loads nothing. Its lifetime is that cache's lifetime.
+ */
+export function createRequestExecutor(): (request: USSExecutionRequest) => Promise<USSExecutionResult> {
+    const cache: ExecutorCache = { loaded: undefined }
+    return request => executeRequest(request, cache)
+}
+
+async function executeRequest(request: USSExecutionRequest, cache: ExecutorCache): Promise<USSExecutionResult> {
     let context, getWarnings
     try {
-        ([context, getWarnings] = await contextForRequest(request))
+        ([context, getWarnings] = await contextForRequest(request, cache))
         const result = execute(request.stmts, context)
 
         switch (request.descriptor.kind) {
@@ -75,7 +87,7 @@ function assignments(context: Context | undefined): AssignmentsResult {
     return new Map(Array.from(context.constantEntries()).concat(Array.from(context.variableEntries())).map(([k, v]) => [k, { ...v, value: removeFunctions(v.value) }]))
 }
 
-async function contextForRequest(request: USSExecutionRequest): Promise<[Context, () => EditorError[]]> {
+async function contextForRequest(request: USSExecutionRequest, cache: ExecutorCache): Promise<[Context, () => EditorError[]]> {
     const effects: Effect[] = []
     const getWarnings = (): EditorError[] => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- just so if there's additonal types, we're safe
@@ -91,11 +103,11 @@ async function contextForRequest(request: USSExecutionRequest): Promise<[Context
             return [emptyContext(effects), getWarnings]
         case 'mapper':
         case 'statistics':
-            return [await mapperContextForRequest(request as USSExecutionRequest & { descriptor: { kind: 'mapper' } }, effects), getWarnings]
+            return [await mapperContextForRequest(request as USSExecutionRequest & { descriptor: { kind: 'mapper' } }, effects, cache), getWarnings]
     }
 }
 
-async function mapperContextForRequest(request: USSExecutionRequest & { descriptor: { kind: 'mapper' } }, effects: Effect[]): Promise<Context> {
+async function mapperContextForRequest(request: USSExecutionRequest & { descriptor: { kind: 'mapper' } }, effects: Effect[], cache: ExecutorCache): Promise<Context> {
     const geographyKind = request.descriptor.geographyKind
     const universe = request.descriptor.universe
     const dte = defaultTypeEnvironment(universe)
@@ -105,20 +117,17 @@ async function mapperContextForRequest(request: USSExecutionRequest & { descript
 
     // Load geography names and set up cache
     let longnames: string[]
+    let dataCache: Map<string, number[]>
 
-    if (mapperCache?.geographyKind === geographyKind && mapperCache.universe === universe) {
-        longnames = mapperCache.longnames
+    if (cache.loaded?.geographyKind === geographyKind && cache.loaded.universe === universe) {
+        ({ longnames, dataCache } = cache.loaded)
     }
     else {
         // Load geography names from index
         const indexData = await loadProtobuf(indexLink(universe, geographyKind), 'ArticleOrderingList')
         longnames = indexData.longnames
-        mapperCache = {
-            universe,
-            geographyKind,
-            longnames,
-            dataCache: new Map(),
-        }
+        dataCache = new Map()
+        cache.loaded = { universe, geographyKind, longnames, dataCache }
     }
 
     const annotateType = (name: string, val: USSRawValue): USSValue => {
@@ -132,7 +141,6 @@ async function mapperContextForRequest(request: USSExecutionRequest & { descript
     }
 
     const getVariable = async (name: string): Promise<USSValue | undefined> => {
-        assert(mapperCache !== undefined, 'mapperCache was initialized above and is never undefined after that')
         if (name === 'geoName') {
             return annotateType('geoName', longnames)
         }
@@ -152,7 +160,7 @@ async function mapperContextForRequest(request: USSExecutionRequest & { descript
         const index = variableInfo.index
 
         // Check cache first
-        const existing = mapperCache.dataCache.get(name)
+        const existing = dataCache.get(name)
         if (existing !== undefined) {
             return annotateType(name, existing)
         }
@@ -161,7 +169,7 @@ async function mapperContextForRequest(request: USSExecutionRequest & { descript
 
         const variableData = await loadOrderingDataProtobuf(universe, statpath, geographyKind)
         assert(Array.isArray(variableData.value), `Expected variable data for ${name} to be an array`)
-        mapperCache.dataCache.set(name, variableData.value)
+        dataCache.set(name, variableData.value)
         return annotateType(name, variableData.value)
     }
 

--- a/react/src/urban-stats-script/worker.ts
+++ b/react/src/urban-stats-script/worker.ts
@@ -1,5 +1,8 @@
-import { executeRequest } from './execute-request'
+import { createRequestExecutor } from './execute-request'
 import { USSExecutionRequest } from './workerManager'
+
+// One per worker, so a script rerun as it is edited keeps the geography it is over.
+const executeRequest = createRequestExecutor()
 
 onmessage = async (message: MessageEvent<{ request: USSExecutionRequest, id: number }>) => {
     if (!('request' in message.data)) {

--- a/react/test/embed_worker_resources.test.ts
+++ b/react/test/embed_worker_resources.test.ts
@@ -2,6 +2,10 @@ import { measuredPort, ogRenderCost, ogWorkerBundleCost, runOgWorkerForTest } fr
 import { urbanstatsFixture } from './test_utils'
 
 const article = '/article.html?longname=San Marino city, California, USA'
+// Two regions close enough to share a map, which is what makes this the expensive comparison.
+const comparison = '/comparison.html?longnames=["San Marino city, California, USA","Pasadena city, California, USA"]'
+const table = 'customNode(""); condition (population > 100000); table(columns=[column(values=density_pw_1km), column(values=population), column(values=area, name="Area")])'
+const statistic = `/statistic.html?uss=${encodeURIComponent(table)}&article_type=City&start=1&amount=20&order=descending&universe=USA`
 // The map the mapper opens on: the USA's states, over its five insets.
 const map = '/mapper.html'
 
@@ -46,8 +50,31 @@ test('embed-worker-map-render-cost', async (t) => {
     console.warn(`Embed Worker map render: ${cpuMs} ms CPU, ${subrequests} subrequests, ${originBytes} bytes from the site`)
     // Currently ~620, closer to three times an article's.
     await t.expect(cpuMs).lt(2_000)
-    // Currently 19, out of the 50 a free-plan request is allowed.
+    // Currently 25, out of the 50 a free-plan request is allowed.
     await t.expect(subrequests).lt(35)
-    // Currently ~12 MB, against an article's 0.7: shapes and tiles for the whole country.
+    // Currently ~13 MB, against an article's 0.7: shapes and tiles for the whole country.
     await t.expect(originBytes).lt(20_000_000)
+})
+
+// Both regions' shapes on one map, which is the comparison layout that draws a map at all.
+test('embed-worker-comparison-render-cost', async (t) => {
+    const { cpuMs, subrequests, originBytes } = await ogRenderCost(comparison)
+    console.warn(`Embed Worker comparison render: ${cpuMs} ms CPU, ${subrequests} subrequests, ${originBytes} bytes from the site`)
+    // Currently ~380: an article's, plus a second shape and the tiles the two of them span.
+    await t.expect(cpuMs).lt(1_500)
+    // Currently 14, out of the 50 a free-plan request is allowed.
+    await t.expect(subrequests).lt(25)
+    // Currently ~0.8 MB, which two regions' shapes and their tiles come to.
+    await t.expect(originBytes).lt(2_000_000)
+})
+
+test('embed-worker-statistic-render-cost', async (t) => {
+    const { cpuMs, subrequests, originBytes } = await ogRenderCost(statistic)
+    console.warn(`Embed Worker statistic render: ${cpuMs} ms CPU, ${subrequests} subrequests, ${originBytes} bytes from the site`)
+    // Currently ~400, most of it the interpreter's rather than the card's.
+    await t.expect(cpuMs).lt(2_000)
+    // Currently 16, out of the 50 a free-plan request is allowed.
+    await t.expect(subrequests).lt(30)
+    // Currently ~2 MB: every city's value for each of the columns, to rank 20 of them.
+    await t.expect(originBytes).lt(5_000_000)
 })


### PR DESCRIPTION
The embed Worker's resource test covered an article and a map, leaving the comparison and statistic cards unwatched. Both are now measured the same way: CPU, subrequests, and bytes from the site, with bounds set well above today's numbers so they catch a change in kind rather than drift.

Measuring the statistic card turned up that the interpreter's geography cache was module-level, so a second card for the same geography kind fetched nothing and reported 1 subrequest and 9 KB against a realistic 16 and 2 MB. That cache exists for a script being rerun as it is edited, which is not what a Worker serving unrelated pages does, so `executeRequest` became `createRequestExecutor()` and holds the cache in its closure: the site's script worker makes one and keeps it, the embed Worker makes one per card. The alternative was to keep the cache and have the test evict it between renders, which measures the right thing by a more fragile route and leaves the Worker holding a geography's columns in the isolate for nothing.

The map card's measured cost rises to 25 subrequests and 12.9 MB as a result, which is what a map for a page the isolate has not seen was always paying.

Measured locally: article 212 ms / 9 / 0.7 MB, comparison 378 ms / 14 / 0.8 MB, statistic 423 ms / 16 / 2.1 MB, map 683 ms / 25 / 12.9 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)