### PR TITLE
Hand the display a unit rather than the name of one

### DIFF
--- a/react/cf-og-worker/src/embed.tsx
+++ b/react/cf-og-worker/src/embed.tsx
@@ -6,7 +6,7 @@
 import React, { ReactElement, ReactNode, cloneElement, isValidElement } from 'react'
 
 import { percentileSuffix } from '../../src/components/display-stats'
-import { getUnitDisplay } from '../../src/components/unit-display'
+import { renderQuantity } from '../../src/components/unit-display'
 import flagDimensions from '../../src/data/flag_dimensions'
 import { canonicalWidth } from '../../src/mapper/map-rendering'
 import { colorThemes } from '../../src/page_template/color-themes'
@@ -16,7 +16,7 @@ import { Inset } from '../../src/urban-stats-script/constants/insets'
 import { mixWithBackground } from '../../src/utils/color'
 import { computeAspectRatioForInsets } from '../../src/utils/coordinates'
 import { HumanReadableName, reifyString } from '../../src/utils/human-readable-name'
-import { UnitType, classifyStatistic } from '../../src/utils/unit'
+import { UnitType, classifyStatistic, unitTypeToStoredUnit } from '../../src/utils/unit'
 import logoSvg from '../assets/logo.svg'
 
 import { basemap } from './basemap'
@@ -198,7 +198,7 @@ function humanReadable(name: HumanReadableName, fontSize: number): ReactNode[] {
 }
 
 function formatValue(value: number, unit: UnitType, units: Units, fontSize: number): ReactNode[] {
-    const rendered = getUnitDisplay(unit).renderValue(value, units.use_imperial, units.temperature_unit)
+    const rendered = renderQuantity(value, unitTypeToStoredUnit(unit), { useImperial: units.use_imperial, temperatureUnit: units.temperature_unit })
     // An array rather than a fragment, which satori does not have.
     return [
         keyed(styleBareTags(rendered.value, fontSize), 'value'),

--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -1,17 +1,16 @@
 import React, { ReactNode } from 'react'
 
 import { useSetting } from '../page_template/settings'
-import { classifyStatistic, UnitType } from '../utils/unit'
+import { classifyStatistic, unitTypeToStoredUnit, UnitType } from '../utils/unit'
 
-import { getUnitDisplay } from './unit-display'
+import { renderQuantity } from './unit-display'
 
 export function Statistic(props: { style?: React.CSSProperties, statname: string, value: number, isUnit: boolean, unit?: UnitType }): ReactNode {
     const [useImperial] = useSetting('use_imperial')
     const [temperatureUnit] = useSetting('temperature_unit')
 
-    const statisticType = props.unit ?? classifyStatistic(props.statname)
-    const unitDisplay = getUnitDisplay(statisticType)
-    const { value, unit } = unitDisplay.renderValue(props.value, useImperial, temperatureUnit)
+    const stored = unitTypeToStoredUnit(props.unit ?? classifyStatistic(props.statname))
+    const { value, unit } = renderQuantity(props.value, stored, { useImperial, temperatureUnit })
 
     return (
         <span style={props.style}>

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -2,26 +2,26 @@ import React, { CSSProperties, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
 import { HumanReadableElement, reifyReact } from '../utils/human-readable-name'
-import { Hue, StoredUnit, writeQuantity } from '../utils/quantity'
-import { storedUnits, UnitType } from '../utils/unit'
+import { Hue, ReaderSettings, StoredUnit, Unit, writeQuantity } from '../utils/quantity'
+import { UnitType } from '../utils/unit'
 
-export interface UnitDisplay {
-    renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-        value: ReactNode
-        unit: ReactNode
-    }
+/** A quantity as it is displayed: the number and its unit, which sit in separate columns. */
+export interface DisplayedQuantity {
+    value: ReactNode
+    unit: ReactNode
 }
 
 /**
  * Whether a comparison against a quantity of this unit reads as its opposite, which it does below
  * zero for a lead, since a lead is written as a size rather than as a signed number.
  */
-function flipsInequality(unitType: UnitType, value: number): boolean {
-    return (unitType === 'democraticMargin' || unitType === 'leftMargin') && value <= 0
+function flipsInequality(unit: Unit, value: number): boolean {
+    return unit.kind === 'scalar' && unit.decoration.kind === 'percent'
+        && unit.decoration.party?.kind === 'lead' && value <= 0
 }
 
-export function renderInequality(value: number, unitType: UnitType, inequality: 'leq' | 'geq'): string {
-    const reads = flipsInequality(unitType, value) ? (inequality === 'leq' ? 'geq' : 'leq') : inequality
+export function renderInequality(value: number, stored: StoredUnit, inequality: 'leq' | 'geq'): string {
+    const reads = flipsInequality(stored.unit, value) ? (inequality === 'leq' ? 'geq' : 'leq') : inequality
     return reads === 'leq' ? '\u2264' /* ≤ */ : '\u2265' /* ≥ */
 }
 
@@ -36,51 +36,11 @@ function InParty({ value, hue }: { value: string, hue: Hue }): ReactNode {
     return <span style={spanStyle}>{value}</span>
 }
 
-function quantity(stored: StoredUnit): UnitDisplay {
+export function renderQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): DisplayedQuantity {
+    const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings)
     return {
-        renderValue: (value: number, useImperial?: boolean, temperatureUnit?: string) => {
-            const { renderedValue, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
-            return {
-                value: hue === undefined ? <span>{renderedValue}</span> : <InParty value={renderedValue} hue={hue} />,
-                unit: unitColumn(unitName),
-            }
-        },
-    }
-}
-
-export function getUnitDisplay(unitType: UnitType): UnitDisplay {
-    switch (unitType) {
-        case 'percentage':
-        case 'percentageChange':
-        case 'democraticMargin':
-        case 'leftMargin':
-        case 'partyPctBlue':
-        case 'partyPctRed':
-        case 'partyPctOrange':
-        case 'partyPctTeal':
-        case 'partyPctGreen':
-        case 'partyPctPurple':
-        case 'partyChangeBlue':
-        case 'partyChangeRed':
-        case 'partyChangeOrange':
-        case 'partyChangeTeal':
-        case 'partyChangeGreen':
-        case 'partyChangePurple':
-        case 'temperature':
-        case 'number':
-        case 'population':
-        case 'fatalities':
-        case 'usd':
-        case 'distanceInM':
-        case 'distanceInKm':
-        case 'area':
-        case 'fatalitiesPerCapita':
-        case 'density':
-        case 'contaminantLevel':
-        case 'distancePerYear':
-        case 'time':
-        case 'minutes':
-            return quantity(storedUnits[unitType])
+        value: hue === undefined ? <span>{renderedValue}</span> : <InParty value={renderedValue} hue={hue} />,
+        unit: unitColumn(unitName),
     }
 }
 

--- a/react/src/mapper/components/Colorbar.tsx
+++ b/react/src/mapper/components/Colorbar.tsx
@@ -6,7 +6,7 @@ import { Colors } from '../../page_template/color-themes'
 import { useColors } from '../../page_template/colors'
 import { ScaleInstance } from '../../urban-stats-script/constants/scale'
 import { HumanReadableName, reifyReact, reifyString } from '../../utils/human-readable-name'
-import { classifyStatistic, UnitType } from '../../utils/unit'
+import { classifyStatistic, unitTypeToStoredUnit, UnitType } from '../../utils/unit'
 import { rampColorer } from '../map-rendering'
 import { Keypoints } from '../ramps'
 import { Basemap } from '../settings/utils'
@@ -163,7 +163,7 @@ function RampColorbar({ ramp }: { ramp: EmpiricalRamp }): ReactNode {
 function MaybeInequality({ ramp, index }: { ramp: EmpiricalRamp, index: number }): ReactNode {
     const scaleAscending = ramp.scale.inverse(0) < ramp.scale.inverse(1)
     // Similarly to how we do it with <Statistic/> above
-    const unit = ramp.unit ?? classifyStatistic(reifyString(ramp.label))
+    const unit = unitTypeToStoredUnit(ramp.unit ?? classifyStatistic(reifyString(ramp.label)))
     const isFirst = index === 0
     const isLast = index === ramp.interpolations.length - 1
     let prefix: string | undefined

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -113,7 +113,11 @@ export const storedUnits = {
         units: system => ({ m: system === 'metric' ? centimeter : inch, s: year }),
         style: { kind: 'fixed', places: 1 },
     }),
-} satisfies Partial<Record<UnitType, StoredUnit>>
+} satisfies Record<UnitType, StoredUnit>
+
+export function unitTypeToStoredUnit(unitType: UnitType): StoredUnit {
+    return storedUnits[unitType]
+}
 /* eslint-enable no-restricted-syntax */
 
 function fahrenheitToCelsius(value: number): number {

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -3,10 +3,10 @@ import './util/localStorage'
 import assert from 'assert/strict'
 import test from 'node:test'
 
-import { getUnitDisplay, renderInequality } from '../src/components/unit-display'
+import { renderInequality, renderQuantity } from '../src/components/unit-display'
 import { reifyString } from '../src/utils/human-readable-name'
 import { Dimension, StoredUnit, writeQuantity } from '../src/utils/quantity'
-import { storedUnits, UnitType } from '../src/utils/unit'
+import { storedUnits, unitTypeToStoredUnit, UnitType } from '../src/utils/unit'
 
 // Flatten a React element tree into its text content.
 function textOf(node: unknown): string {
@@ -18,7 +18,7 @@ function textOf(node: unknown): string {
 }
 
 function renderValue(unitType: UnitType, value: number, useImperial = false, temperatureUnit = 'fahrenheit'): string {
-    const { value: valueEl, unit: unitEl } = getUnitDisplay(unitType).renderValue(value, useImperial, temperatureUnit)
+    const { value: valueEl, unit: unitEl } = renderQuantity(value, unitTypeToStoredUnit(unitType), { useImperial, temperatureUnit })
     return `${textOf(valueEl)}${textOf(unitEl)}`.trim()
 }
 
@@ -241,7 +241,7 @@ for (const [unitType, value, inequality, expected] of [
     ['leftMargin', -0.5, 'geq', '\u2264'],
 ] as const) {
     void test(`${unitType} renders a ${inequality} at ${value} as ${expected}`, () => {
-        assert.equal(renderInequality(value, unitType, inequality), expected)
+        assert.equal(renderInequality(value, unitTypeToStoredUnit(unitType), inequality), expected)
     })
 }
 


### PR DESCRIPTION
Off main. The last piece of #2215's framework, and what #2216 needs.

`getUnitDisplay` took a `UnitType` and looked the quantity up itself, so nothing could be displayed that was not one of the thirty named statistics. It is now:

```ts
export function renderQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}): DisplayedQuantity
```

and each caller looks its own unit up — `<Statistic>`, the colorbar, and the embed Worker. A quantity that no `UnitType` names, which is every quantity inference produces, can now be displayed.

`renderInequality` takes the unit too, and asks it whether it is a lead:

```ts
function flipsInequality(unit: Unit, value: number): boolean {
    return unit.kind === 'scalar' && unit.decoration.kind === 'percent'
        && unit.decoration.party?.kind === 'lead' && value <= 0
}
```

rather than checking two names against a list, which is how it has read since #2250 and which would have missed any lead that arrived without a name.

`storedUnits` is total over `UnitType` now that durations have joined it, so `unitTypeToStoredUnit` is an ordinary lookup rather than one that might fail. The `satisfies` clause enforces that.

## What this does not do

`UnitType` stays where a unit is *named* rather than displayed: the USS script layer, where `unit=Population` is a constant a script writes, and the carriers that pass a unit from a statistic to a table. Those still convert at the display boundary. Moving the conversion up to the source, so `StatData` and the colorbar's ramp carry a `StoredUnit` from the start, is a separate change and is what lets an inferred unit travel the whole way.

## Verification

The 1440-case sweep, through `renderQuantity` rather than `getUnitDisplay`: **no differences** against main. `tsc`, lint, knip, 585 unit tests.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
