### PR TITLE
Carry a unit from where it is known to where it is written

### DIFF
--- a/react/cf-og-worker/src/data.ts
+++ b/react/cf-og-worker/src/data.ts
@@ -27,10 +27,11 @@ import { createRequestExecutor } from '../../src/urban-stats-script/execute-requ
 import { geometry } from '../../src/utils/geometry'
 import { HumanReadableName, reifyString } from '../../src/utils/human-readable-name'
 import { Feature } from '../../src/utils/protos'
+import { StoredUnit } from '../../src/utils/quantity'
 import { loadFeatureFromPossibleSymlink } from '../../src/utils/symlinks'
 import { displayType } from '../../src/utils/text'
 import { NormalizeProto } from '../../src/utils/types'
-import { UnitType } from '../../src/utils/unit'
+import { unitTypeToStoredUnit } from '../../src/utils/unit'
 
 import { Ring } from './map-layout'
 
@@ -155,7 +156,7 @@ export interface StatisticCard {
     heading: string
     /** What is ranked, without the condition, which the card states beside the geographies. */
     title: HumanReadableName
-    columns: { name: HumanReadableName, unit: UnitType | undefined }[]
+    columns: { name: HumanReadableName, unit: StoredUnit | undefined }[]
     /** Which column the rows are in the order of, and which way, as the page's header marks it. */
     sortColumn: number
     order: 'ascending' | 'descending'
@@ -246,7 +247,7 @@ export interface MapCard {
     insets: Inset[]
     basemap: Basemap
     /** The colourbar, absent on an RGB map, which has no single scale to show. */
-    ramp?: { colors: string[], ticks: number[], unit: UnitType | undefined }
+    ramp?: { colors: string[], ticks: number[], unit: StoredUnit | undefined }
     units: Units
 }
 
@@ -341,7 +342,13 @@ export async function mapCard(origin: string, pageData: Extract<PageData, { kind
         opacity: map.opacity,
         insets: map.insets,
         basemap: map.basemap,
-        ramp: visuals.ramp === undefined ? undefined : { ticks: visuals.ramp.ticks, colors: visuals.ramp.colors, unit: map.unit },
+        ramp: visuals.ramp === undefined
+            ? undefined
+            : {
+                    ticks: visuals.ramp.ticks,
+                    colors: visuals.ramp.colors,
+                    unit: map.unit === undefined ? undefined : unitTypeToStoredUnit(map.unit),
+                },
         units: settings.getMultiple(['use_imperial', 'temperature_unit']),
     }
 }

--- a/react/cf-og-worker/src/embed.tsx
+++ b/react/cf-og-worker/src/embed.tsx
@@ -16,7 +16,8 @@ import { Inset } from '../../src/urban-stats-script/constants/insets'
 import { mixWithBackground } from '../../src/utils/color'
 import { computeAspectRatioForInsets } from '../../src/utils/coordinates'
 import { HumanReadableName, reifyString } from '../../src/utils/human-readable-name'
-import { UnitType, classifyStatistic, unitTypeToStoredUnit } from '../../src/utils/unit'
+import { StoredUnit } from '../../src/utils/quantity'
+import { classifyStatistic, unitTypeToStoredUnit } from '../../src/utils/unit'
 import logoSvg from '../assets/logo.svg'
 
 import { basemap } from './basemap'
@@ -197,8 +198,8 @@ function humanReadable(name: HumanReadableName, fontSize: number): ReactNode[] {
     })
 }
 
-function formatValue(value: number, unit: UnitType, units: Units, fontSize: number): ReactNode[] {
-    const rendered = renderQuantity(value, unitTypeToStoredUnit(unit), { useImperial: units.use_imperial, temperatureUnit: units.temperature_unit })
+function formatValue(value: number, unit: StoredUnit, units: Units, fontSize: number): ReactNode[] {
+    const rendered = renderQuantity(value, unit, { useImperial: units.use_imperial, temperatureUnit: units.temperature_unit })
     // An array rather than a fragment, which satori does not have.
     return [
         keyed(styleBareTags(rendered.value, fontSize), 'value'),
@@ -220,7 +221,7 @@ function row(stat: ArticleCard['stats'][number], index: number, units: Units): R
             }}
         >
             <div style={{ flex: 1, fontSize: 24 }}>{stat.name}</div>
-            <div style={{ width: 170, fontSize: 26, justifyContent: 'flex-end', display: 'flex' }}>{formatValue(stat.value, classifyStatistic(stat.name), units, 26)}</div>
+            <div style={{ width: 170, fontSize: 26, justifyContent: 'flex-end', display: 'flex' }}>{formatValue(stat.value, unitTypeToStoredUnit(classifyStatistic(stat.name)), units, 26)}</div>
             <div style={{ width: 60, fontSize: 20, color: colors.muted, justifyContent: 'flex-end', display: 'flex' }}>
                 {`${stat.percentile}${percentileSuffix(stat.percentile)}`}
             </div>
@@ -337,7 +338,7 @@ async function insetImage(map: MapCard, inset: Inset, box: { width: number, heig
 }
 
 function colorbar(ramp: NonNullable<MapCard['ramp']>, label: string, units: Units): ReactElement {
-    const unit = ramp.unit ?? classifyStatistic(label)
+    const unit = ramp.unit ?? unitTypeToStoredUnit(classifyStatistic(label))
     return (
         <div style={{ display: 'flex', flexDirection: 'column', marginTop: 8 }}>
             <div style={{ display: 'flex' }}>
@@ -522,13 +523,13 @@ function rowHeight(stat: ComparisonCard['stats'][number], layout: TableLayout): 
     return rowPadding * 2 + Math.max(name, layout.valueSize) * lineHeight + 2
 }
 
-function cellValue(value: number, unit: UnitType, units: Units, fontSize: number): ReactNode[] {
+function cellValue(value: number, unit: StoredUnit, units: Units, fontSize: number): ReactNode[] {
     // A geography the statistic has no value for, which the site's tables leave blank.
     return Number.isNaN(value) ? ['—'] : formatValue(value, unit, units, fontSize)
 }
 
 function comparisonRow(stat: ComparisonCard['stats'][number], index: number, layout: TableLayout, units: Units): ReactElement {
-    const unit = classifyStatistic(stat.name)
+    const unit = unitTypeToStoredUnit(classifyStatistic(stat.name))
     return (
         <div
             key={stat.name}
@@ -820,7 +821,7 @@ export function statisticEmbedCard(statistic: StatisticCard, { width, height }: 
                                     justifyContent: 'flex-end',
                                 }}
                             >
-                                {cellValue(entry.values[index2], column.unit ?? classifyStatistic(reifyString(column.name)), statistic.units, valueSize)}
+                                {cellValue(entry.values[index2], column.unit ?? unitTypeToStoredUnit(classifyStatistic(reifyString(column.name))), statistic.units, valueSize)}
                             </div>
                         ))}
                     </div>

--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -1,15 +1,16 @@
 import React, { ReactNode } from 'react'
 
 import { useSetting } from '../page_template/settings'
-import { classifyStatistic, unitTypeToStoredUnit, UnitType } from '../utils/unit'
+import { StoredUnit } from '../utils/quantity'
+import { classifyStatistic, unitTypeToStoredUnit } from '../utils/unit'
 
 import { renderQuantity } from './unit-display'
 
-export function Statistic(props: { style?: React.CSSProperties, statname: string, value: number, isUnit: boolean, unit?: UnitType }): ReactNode {
+export function Statistic(props: { style?: React.CSSProperties, statname: string, value: number, isUnit: boolean, unit?: StoredUnit }): ReactNode {
     const [useImperial] = useSetting('use_imperial')
     const [temperatureUnit] = useSetting('temperature_unit')
 
-    const stored = unitTypeToStoredUnit(props.unit ?? classifyStatistic(props.statname))
+    const stored = props.unit ?? unitTypeToStoredUnit(classifyStatistic(props.statname))
     const { value, unit } = renderQuantity(props.value, stored, { useImperial, temperatureUnit })
 
     return (

--- a/react/src/components/load-article.ts
+++ b/react/src/components/load-article.ts
@@ -10,7 +10,7 @@ import { findAmbiguousSourcesAll, statParents, StatName, StatPath, statPathToOrd
 import { assert } from '../utils/defensive'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { Article, CongressionalRepresentativeTable, ICongressionalRepresentative, ICongressionalRepresentativePointer, IFirstOrLast, IMetadata } from '../utils/protos'
-import { UnitType } from '../utils/unit'
+import { StoredUnit } from '../utils/quantity'
 
 import { CountsByUT, forType } from './countsByArticleType'
 import { electionDisclaimerForRow, type Disclaimer } from './disclaimer-text'
@@ -111,7 +111,7 @@ const dataCreditExplanationPageByMetadataIndex = new Map<number, string>(
 interface StatisticCellRenderingInfoCommon {
     articleType: string
     statname: HumanReadableName
-    unit?: UnitType
+    unit?: StoredUnit
     statpath?: StatPath
 }
 

--- a/react/src/mapper/components/Colorbar.tsx
+++ b/react/src/mapper/components/Colorbar.tsx
@@ -6,7 +6,8 @@ import { Colors } from '../../page_template/color-themes'
 import { useColors } from '../../page_template/colors'
 import { ScaleInstance } from '../../urban-stats-script/constants/scale'
 import { HumanReadableName, reifyReact, reifyString } from '../../utils/human-readable-name'
-import { classifyStatistic, unitTypeToStoredUnit, UnitType } from '../../utils/unit'
+import { StoredUnit } from '../../utils/quantity'
+import { classifyStatistic, unitTypeToStoredUnit } from '../../utils/unit'
 import { rampColorer } from '../map-rendering'
 import { Keypoints } from '../ramps'
 import { Basemap } from '../settings/utils'
@@ -16,7 +17,7 @@ interface EmpiricalRamp {
     scale: ScaleInstance
     interpolations: number[]
     label: HumanReadableName
-    unit?: UnitType
+    unit?: StoredUnit
     hasValuesClampedToStart: boolean
     hasValuesClampedToEnd: boolean
 }
@@ -163,7 +164,7 @@ function RampColorbar({ ramp }: { ramp: EmpiricalRamp }): ReactNode {
 function MaybeInequality({ ramp, index }: { ramp: EmpiricalRamp, index: number }): ReactNode {
     const scaleAscending = ramp.scale.inverse(0) < ramp.scale.inverse(1)
     // Similarly to how we do it with <Statistic/> above
-    const unit = unitTypeToStoredUnit(ramp.unit ?? classifyStatistic(reifyString(ramp.label)))
+    const unit = ramp.unit ?? unitTypeToStoredUnit(classifyStatistic(reifyString(ramp.label)))
     const isFirst = index === 0
     const isLast = index === ramp.interpolations.length - 1
     let prefix: string | undefined

--- a/react/src/mapper/map-generator.tsx
+++ b/react/src/mapper/map-generator.tsx
@@ -32,6 +32,7 @@ import { computeAspectRatioForInsets } from '../utils/coordinates'
 import { makeDebugLogger } from '../utils/debug-logging'
 import { HumanReadableName } from '../utils/human-readable-name'
 import { ICoordinate } from '../utils/protos'
+import { unitTypeToStoredUnit } from '../utils/unit'
 import { useDebouncedResolve } from '../utils/useDebouncedResolve'
 
 import { Colorbar, RampToDisplay, styleFromBasemap } from './components/Colorbar'
@@ -548,7 +549,8 @@ async function loadMapResult({ mapResultMain, universe, geographyKind, cache, la
 function computeRampToDisplay(value: CommonMap, label: HumanReadableName, { scale, ticks }: { scale: ScaleInstance, ticks: number[] }): RampToDisplay & { type: 'ramp' } {
     const hasValuesClampedToStart = value.data.some(val => scale.forward(val) < 0)
     const hasValuesClampedToEnd = value.data.some(val => scale.forward(val) > 1)
-    return { type: 'ramp', value: { ramp: value.ramp, interpolations: ticks, scale, label, unit: value.unit, hasValuesClampedToStart, hasValuesClampedToEnd } }
+    const unit = value.unit === undefined ? undefined : unitTypeToStoredUnit(value.unit)
+    return { type: 'ramp', value: { ramp: value.ramp, interpolations: ticks, scale, label, unit, hasValuesClampedToStart, hasValuesClampedToEnd } }
 }
 
 export const transformContext = createContext({ selfDetermineHeight: false })

--- a/react/src/stat/types.ts
+++ b/react/src/stat/types.ts
@@ -3,7 +3,7 @@ import statnames from '../data/statistic_name_list'
 import { MapUSS } from '../mapper/settings/map-uss'
 import { Universe } from '../universe'
 import { HumanReadableName } from '../utils/human-readable-name'
-import { UnitType } from '../utils/unit'
+import { StoredUnit } from '../utils/quantity'
 
 export type Statistic = {
     universe: Universe
@@ -29,7 +29,7 @@ export interface StatSettings {
 
 export interface StatData {
     // One entry per column
-    table: { value: number[], populationPercentile: number[], ordinal: number[], name: HumanReadableName, unit?: UnitType }[]
+    table: { value: number[], populationPercentile: number[], ordinal: number[], name: HumanReadableName, unit?: StoredUnit }[]
     articleNames: string[]
     renderedStatname: HumanReadableName
     statcol?: StatCol

--- a/react/src/stat/utils.ts
+++ b/react/src/stat/utils.ts
@@ -12,6 +12,7 @@ import { unparse } from '../urban-stats-script/parser'
 import { TypeEnvironment } from '../urban-stats-script/types-values'
 import { assert } from '../utils/defensive'
 import { reifyString } from '../utils/human-readable-name'
+import { unitTypeToStoredUnit } from '../utils/unit'
 
 import { StatData, Statistic, StatSettings, View } from './types'
 
@@ -96,7 +97,7 @@ export function statDataFromTable({ table, stat, mapUSS, typeEnvironment, warn }
             populationPercentile: column.populationPercentiles,
             ordinal: computeOrdinals(column.values),
             name,
-            unit: column.unit,
+            unit: column.unit === undefined ? undefined : unitTypeToStoredUnit(column.unit),
         }
     })
 

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -27,8 +27,13 @@ export type System = 'metric' | 'imperial'
  * micrograms, not of grams. So a statistic declares the two together.
  */
 export interface WrittenIn {
-    units: (system: System) => Partial<Record<BaseUnit, NamedUnit>>
+    units: Record<System, Partial<Record<BaseUnit, NamedUnit>>>
     style: NumberFormat
+}
+
+/** For a quantity written the same way whichever units its reader measures in. */
+export function inEitherSystem(units: Partial<Record<BaseUnit, NamedUnit>>): Record<System, Partial<Record<BaseUnit, NamedUnit>>> {
+    return { metric: units, imperial: units }
 }
 
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party } | { kind: 'writtenIn', in: WrittenIn }
@@ -263,7 +268,7 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
     const convention = conventions[renderAsKey(unit.dimensions)]
     // a statistic written in units of its own leaves the search nothing to choose between
     const writtenIn = unit.decoration.kind === 'writtenIn' ? unit.decoration.in : undefined
-    const pool = writtenIn === undefined ? allUnits(settings) : Object.values(writtenIn.units(systemOf(settings)))
+    const pool = writtenIn === undefined ? allUnits(settings) : Object.values(writtenIn.units[systemOf(settings)])
     const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool,
         chosen => writtenIn?.style ?? styleFor(convention, chosen))
     // h:mm spends two units and names one, so which one it names is the format's to say

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,6 +1,6 @@
 import {
     BaseUnit, centimeter, Decoration, fatalities, Hue, hundredThousandPeople, inch, kilometer, meter, microgram, mile,
-    minute, Party, people, StoredUnit, WrittenIn, year,
+    inEitherSystem, minute, Party, people, StoredUnit, WrittenIn, year,
 } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
@@ -88,8 +88,8 @@ export const storedUnits = {
     partyChangeGreen: percentage(inParty('green'), true),
     partyChangePurple: percentage(inParty('purple'), true),
     temperature: { unit: { kind: 'temperature' }, toBaseUnits: 1 },
-    time: dimensionfull({ s: 1 }, 60 * 60, { units: () => ({ s: minute }), style: { kind: 'hoursMinutes' } }),
-    minutes: dimensionfull({ s: 1 }, 60, { units: () => ({ s: minute }), style: { kind: 'hoursMinutes' } }),
+    time: dimensionfull({ s: 1 }, 60 * 60, { units: inEitherSystem({ s: minute }), style: { kind: 'hoursMinutes' } }),
+    minutes: dimensionfull({ s: 1 }, 60, { units: inEitherSystem({ s: minute }), style: { kind: 'hoursMinutes' } }),
     number: dimensionfull({}),
     population: dimensionfull({ person: 1 }),
     fatalities: dimensionfull({ fatality: 1 }),
@@ -98,19 +98,19 @@ export const storedUnits = {
     distanceInKm: dimensionfull({ m: 1 }, 1e3),
     area: dimensionfull({ m: 2 }, 1e6),
     fatalitiesPerCapita: dimensionfull({ fatality: 1, person: -1 }, 1, {
-        units: () => ({ fatality: fatalities, person: hundredThousandPeople }),
+        units: inEitherSystem({ fatality: fatalities, person: hundredThousandPeople }),
         style: { kind: 'fixed', places: 2 },
     }),
     density: dimensionfull({ person: 1, m: -2 }, 1e-6, {
-        units: system => ({ person: people, m: system === 'metric' ? kilometer : mile }),
+        units: { metric: { person: people, m: kilometer }, imperial: { person: people, m: mile } },
         style: { kind: 'rounded', significantDigits: 2 },
     }),
     contaminantLevel: dimensionfull({ g: 1, m: -3 }, 1e-6, {
-        units: () => ({ g: microgram, m: meter }),
+        units: inEitherSystem({ g: microgram, m: meter }),
         style: { kind: 'fixed', places: 2 },
     }),
     distancePerYear: dimensionfull({ m: 1, s: -1 }, 1 / (365.25 * 24 * 60 * 60), {
-        units: system => ({ m: system === 'metric' ? centimeter : inch, s: year }),
+        units: { metric: { m: centimeter, s: year }, imperial: { m: inch, s: year } },
         style: { kind: 'fixed', places: 1 },
     }),
 } satisfies Record<UnitType, StoredUnit>


### PR DESCRIPTION
Off main, following #2295. The last of #2215, and what #2216 needs before it can resume.

#2295 gave the display a `StoredUnit`, but every caller still looked one up from a `UnitType` at the point of drawing. So a unit could only travel if it had a name, which is exactly what an inferred unit does not have. The carriers now hold the unit itself:

- `StatData.table[].unit`
- the colorbar's `EmpiricalRamp.unit`
- an article's `StatisticCellRenderingInfo.unit`
- the embed cards' statistic and map columns

and the conversion happens once, where a script or a statistic names the unit.

## A StoredUnit is plain data again

`WrittenIn.units` was a function of the system. It is a record of both now:

```ts
units: { metric: { person: people, m: kilometer }, imperial: { person: people, m: mile } },
units: inEitherSystem({ g: microgram, m: meter }),
```

Nothing serializes a `StoredUnit` today — the embed card's payload goes straight into satori in the same isolate — but USS values cross to a web worker by structured clone, and that is where inferred units are headed. A closure would not survive the trip, and would fail at runtime rather than in the type checker.

## What keeps a UnitType

Where a unit is *named* rather than written: the script constants, where `unit=Population` is what an author types, and `getUnit`'s prose for the documentation page. Those are names, and they should stay names.

## Verification

The 1440-case sweep against main: **no differences**. `tsc`, lint, knip, 585 unit tests.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
