### PR TITLE
Multiply, divide and raise units, and say what an expression is in

### DIFF
--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -1,0 +1,192 @@
+import { assert } from '../utils/defensive'
+import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
+
+import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
+
+/** `any` is that it could be in any unit; `none` is that no quantity is of it, as people plus an area. */
+export type AbstractInterpValue = (
+    { kind: 'any', constant?: number }
+    | { kind: 'none' }
+    | { kind: 'in', unit: StoredUnit, constant?: number }
+)
+
+export function constant(value: number): AbstractInterpValue {
+    return { kind: 'any', constant: value }
+}
+
+export function inUnit(unit: StoredUnit): AbstractInterpValue {
+    return { kind: 'in', unit }
+}
+
+/**
+ * Asked at the end rather than at every step: two temperatures added are neither one temperature
+ * nor none, but their mean is one again, and refusing the sum on the way past would lose that.
+ */
+export function unitToWriteIn(known: AbstractInterpValue): StoredUnit | undefined {
+    if (known.kind !== 'in') {
+        return undefined
+    }
+    const { unit } = known
+    if (!unit.unit.baseIsScalar && unit.unit.times !== 0 && unit.unit.times !== 1) {
+        return undefined
+    }
+    return unit
+}
+
+/** What an operand can be, once forward and backward have refused what came from nothing. */
+type KnownAIV = Exclude<AbstractInterpValue, { kind: 'none' }>
+
+function withTimes(unit: StoredUnit, times: number): AbstractInterpValue {
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
+}
+
+/** How an operator's slots are related, which is what both directions are read off. */
+type Form =
+    /** Every slot is the same unit, and the operands' coefficients combine into the result's. */
+    | { kind: 'sameUnit', combine: (left: number, right: number) => number, keepsUnit: boolean }
+    /** The operands' dimensions add, or subtract where the right is taken to the power -1. */
+    | { kind: 'product', rightPower: 1 | -1 }
+    /** The left raised to the right, which has to be a constant for anything to be said. */
+    | { kind: 'power' }
+    /** Nothing relates the slots, so nothing can be told from any of them. */
+    | { kind: 'opaque' }
+
+const comparison: Form = { kind: 'sameUnit', combine: () => 0, keepsUnit: false }
+
+const forms: Record<BinaryOperatorSymbol, Form> = {
+    '+': { kind: 'sameUnit', combine: (left, right) => left + right, keepsUnit: true },
+    '-': { kind: 'sameUnit', combine: (left, right) => left - right, keepsUnit: true },
+    // a comparison is between two of the same kind, and is itself of no kind at all
+    '==': comparison,
+    '!=': comparison,
+    '<': comparison,
+    '>': comparison,
+    '<=': comparison,
+    '>=': comparison,
+    '*': { kind: 'product', rightPower: 1 },
+    '/': { kind: 'product', rightPower: -1 },
+    '**': { kind: 'power' },
+    '&': { kind: 'opaque' },
+    '|': { kind: 'opaque' },
+}
+
+function addedForward(form: { combine: (left: number, right: number) => number }, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
+    // a side saying nothing is taken to be of the other's kind, since only alike things add, and a
+    // bare number added to a temperature is a number of degrees rather than a temperature
+    if (left.kind === 'any') {
+        return right.kind === 'any' ? { kind: 'any' } : withTimes(right.unit, form.combine(0, right.unit.unit.times))
+    }
+    if (right.kind === 'any') {
+        return withTimes(left.unit, form.combine(left.unit.unit.times, 0))
+    }
+    // nothing is both people and an area, so nothing is their sum
+    if (!sameDimensions(left.unit, right.unit)) {
+        return { kind: 'none' }
+    }
+    return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
+}
+
+function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
+    if (left.kind === 'any') {
+        if (right.kind === 'any' || left.constant === undefined) {
+            return { kind: 'any' }
+        }
+        // scaling a quantity scales how many of itself it is: half of two temperatures is one
+        if (rightPower === 1) {
+            return withTimes(right.unit, right.unit.unit.times * left.constant)
+        }
+        // where a number over a quantity is not that many of it, but one over it
+        const inverted = unitProduct(dimensionless, right.unit, -1)
+        return inverted === undefined ? { kind: 'none' } : { kind: 'in', unit: inverted }
+    }
+    if (right.kind === 'any') {
+        return right.constant === undefined
+            ? { kind: 'any' }
+            : withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
+    }
+    const product = unitProduct(left.unit, right.unit, rightPower)
+    return product === undefined ? { kind: 'none' } : { kind: 'in', unit: product }
+}
+
+export function forward(operator: BinaryOperatorSymbol, left: AbstractInterpValue, right: AbstractInterpValue): AbstractInterpValue {
+    // nothing computed from something no quantity is of is a quantity either
+    if (left.kind === 'none' || right.kind === 'none') {
+        return { kind: 'none' }
+    }
+    const form = forms[operator]
+    switch (form.kind) {
+        case 'opaque':
+            return { kind: 'any' }
+        case 'sameUnit':
+            return form.keepsUnit ? addedForward(form, left, right) : { kind: 'any' }
+        case 'product':
+            return productForward(form.rightPower, left, right)
+        case 'power': {
+            if (left.kind !== 'in' || right.kind !== 'any' || right.constant === undefined) {
+                return { kind: 'any' }
+            }
+            const raised = unitPower(left.unit, right.constant)
+            return raised === undefined ? { kind: 'none' } : { kind: 'in', unit: raised }
+        }
+    }
+}
+
+const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
+
+/** Solving an operator for one of its operands is running the operator that undoes it. */
+function undo(operator: keyof typeof inverses, result: AbstractInterpValue, known: AbstractInterpValue, side: 'left' | 'right'): AbstractInterpValue {
+    if (side === 'left') {
+        return forward(inverses[operator], result, known)
+    }
+    // the right of a sum or a product is found the same way; of a difference or a quotient, the
+    // operands change places, since the right of `a - b` is `a - result` rather than `result - a`
+    return operator === '+' || operator === '*'
+        ? forward(inverses[operator], result, known)
+        : forward(operator, known, result)
+}
+
+/** How the 0.1 of `commute_bike < 0.1` is read as ten percent. */
+export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpValue, known: AbstractInterpValue, side: 'left' | 'right'): AbstractInterpValue {
+    if (result.kind === 'none' || known.kind === 'none') {
+        return { kind: 'none' }
+    }
+    const form = forms[operator]
+    switch (form.kind) {
+        case 'opaque':
+        // a power is undone by a root, which is not one of these operators
+        case 'power':
+            return { kind: 'any' }
+        case 'sameUnit':
+            if (!form.keepsUnit) {
+                // a comparison says nothing of its own kind, but its operands are of each other's
+                return known
+            }
+            assert(operator === '+' || operator === '-', `${operator} keeps the unit of what it adds`)
+            return undo(operator, result, known, side)
+        case 'product':
+            assert(operator === '*' || operator === '/', `${operator} is a product`)
+            return undo(operator, result, known, side)
+    }
+}
+
+/** Each of these undoes itself: negating twice, or leaving alone twice, is what was there. */
+export function backwardUnary(operator: UnaryOperatorSymbol, result: AbstractInterpValue): AbstractInterpValue {
+    return forwardUnary(operator, result)
+}
+
+export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInterpValue): AbstractInterpValue {
+    if (operator === '!') {
+        return { kind: 'any' }
+    }
+    if (operator === '+' || operand.kind === 'none') {
+        return operand
+    }
+    // negating is taking it from nothing, so a level becomes minus one of itself, which a
+    // temperature has no reading for, while a difference of two is still a difference
+    const negated = operand.constant === undefined ? undefined : -operand.constant
+    if (operand.kind === 'any') {
+        return { kind: 'any', constant: negated }
+    }
+    const { unit } = operand
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times: -unit.unit.times } }, constant: negated }
+}

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -258,13 +258,12 @@ function product(written: Written[]): HumanReadableElement[] {
     ])
 }
 
-/** The names of the units chosen. The ones with no name of their own are left out. */
-function scalarUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit {
-    return { unit: { kind: 'scalar', dimensions, decoration: { kind: 'none' }, difference: false }, toBaseUnits }
+function computedUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit {
+    return { unit: { dimensions, decoration: { kind: 'none' }, times: 1, baseIsScalar: true }, toBaseUnits }
 }
 
 /** A quantity of no dimensions, such as one divided by another of its own kind. */
-export const dimensionless = scalarUnit([], 1)
+export const dimensionless = computedUnit([], 1)
 
 /** The same dimensions with each base unit counted once, and the ones that cancelled dropped. */
 function gathered(dimensions: Dimension[]): Dimension[] {
@@ -275,39 +274,35 @@ function gathered(dimensions: Dimension[]): Dimension[] {
     return [...totals].filter(([, power]) => power !== 0).map(([baseUnit, power]) => ({ baseUnit, power }))
 }
 
-/** A temperature is not a scaling of anything, so there is no arithmetic to do on one. */
-function scalarDimensions(stored: StoredUnit): Dimension[] | undefined {
-    return stored.unit.kind === 'scalar' ? stored.unit.dimensions : undefined
-}
-
 /** Whether two quantities measure the same kind of thing, so that one can be added to the other. */
 export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {
-    const [over, under] = [scalarDimensions(left), scalarDimensions(right)]
-    return over !== undefined && under !== undefined
-        && renderAsKey(gathered(over)) === renderAsKey(gathered(under))
+    return renderAsKey(gathered(left.unit.dimensions)) === renderAsKey(gathered(right.unit.dimensions))
 }
 
-/** The unit of a product, or of a quotient where the right one is taken to the power -1. */
+/**
+ * The unit of a product, or of a quotient where the right one is taken to the power -1. Neither
+ * can be measured from a zero of its own: how many temperatures a product of one is depends on
+ * what it was multiplied by, which is a coefficient rather than a unit.
+ */
 export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined {
-    const [over, under] = [scalarDimensions(left), scalarDimensions(right)]
-    if (over === undefined || under === undefined) {
+    if (!left.unit.baseIsScalar || !right.unit.baseIsScalar) {
         return undefined
     }
+    const [over, under] = [left.unit.dimensions, right.unit.dimensions]
     const dimensions = [...over, ...under.map(({ baseUnit, power }) => ({ baseUnit, power: power * rightPower }))]
     const toBaseUnits = rightPower === 1
         ? left.toBaseUnits * right.toBaseUnits
         : left.toBaseUnits / right.toBaseUnits
-    return scalarUnit(gathered(dimensions), toBaseUnits)
+    return computedUnit(gathered(dimensions), toBaseUnits)
 }
 
 /** The unit of a quantity raised to a power: a length squared is an area. */
 export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined {
-    const dimensions = scalarDimensions(stored)
-    if (dimensions === undefined) {
+    if (!stored.unit.baseIsScalar) {
         return undefined
     }
-    const raised = dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))
-    return scalarUnit(gathered(raised), Math.pow(stored.toBaseUnits, exponent))
+    const raised = stored.unit.dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))
+    return computedUnit(gathered(raised), Math.pow(stored.toBaseUnits, exponent))
 }
 
 export function nameOf(written: Written[]): HumanReadableElement[] {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -244,6 +244,57 @@ function product(written: Written[]): HumanReadableElement[] {
 }
 
 /** The names of the units chosen. The ones with no name of their own are left out. */
+function scalarUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit {
+    return { unit: { kind: 'scalar', dimensions, decoration: { kind: 'none' }, difference: false }, toBaseUnits }
+}
+
+/** A quantity of no dimensions, such as one divided by another of its own kind. */
+export const dimensionless = scalarUnit([], 1)
+
+/** The same dimensions with each base unit counted once, and the ones that cancelled dropped. */
+function gathered(dimensions: Dimension[]): Dimension[] {
+    const totals = new Map<BaseUnit, number>()
+    for (const { baseUnit, power } of dimensions) {
+        totals.set(baseUnit, (totals.get(baseUnit) ?? 0) + power)
+    }
+    return [...totals].filter(([, power]) => power !== 0).map(([baseUnit, power]) => ({ baseUnit, power }))
+}
+
+/** A temperature is not a scaling of anything, so there is no arithmetic to do on one. */
+function scalarDimensions(stored: StoredUnit): Dimension[] | undefined {
+    return stored.unit.kind === 'scalar' ? stored.unit.dimensions : undefined
+}
+
+/** Whether two quantities measure the same kind of thing, so that one can be added to the other. */
+export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {
+    const [over, under] = [scalarDimensions(left), scalarDimensions(right)]
+    return over !== undefined && under !== undefined
+        && renderAsKey(gathered(over)) === renderAsKey(gathered(under))
+}
+
+/** The unit of a product, or of a quotient where the right one is taken to the power -1. */
+export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined {
+    const [over, under] = [scalarDimensions(left), scalarDimensions(right)]
+    if (over === undefined || under === undefined) {
+        return undefined
+    }
+    const dimensions = [...over, ...under.map(({ baseUnit, power }) => ({ baseUnit, power: power * rightPower }))]
+    const toBaseUnits = rightPower === 1
+        ? left.toBaseUnits * right.toBaseUnits
+        : left.toBaseUnits / right.toBaseUnits
+    return scalarUnit(gathered(dimensions), toBaseUnits)
+}
+
+/** The unit of a quantity raised to a power: a length squared is an area. */
+export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined {
+    const dimensions = scalarDimensions(stored)
+    if (dimensions === undefined) {
+        return undefined
+    }
+    const raised = dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))
+    return scalarUnit(gathered(raised), Math.pow(stored.toBaseUnits, exponent))
+}
+
 export function nameOf(written: Written[]): HumanReadableElement[] {
     const named = written.filter(({ unit }) => unit.name !== '')
     const over = named.filter(({ power }) => power > 0)

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -1,0 +1,160 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { BinaryOperatorSymbol, infixOperators, unaryOperators } from '../src/urban-stats-script/operators'
+import { backward, backwardUnary, constant, forward, forwardUnary, inUnit, AbstractInterpValue, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
+import { StoredUnit } from '../src/utils/quantity'
+import { storedUnits } from '../src/utils/unit'
+
+/** What is known, as a string: the dimensions, how many of itself it is, and its scale. */
+function shape(known: AbstractInterpValue): string {
+    if (known.kind !== 'in') return known.kind === 'any' ? 'unknown' : 'inconsistent'
+    const written = [...known.unit.unit.dimensions]
+        .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+    return `${written === '' ? 'dimensionless' : written} times=${known.unit.unit.times} x${known.unit.toBaseUnits}`
+}
+
+const unknown: AbstractInterpValue = { kind: 'any' }
+const inconsistent: AbstractInterpValue = { kind: 'none' }
+const people = inUnit(storedUnits.population)
+const area = inUnit(storedUnits.area)
+const temperature = inUnit(storedUnits.temperature)
+const difference = (of: StoredUnit): AbstractInterpValue => inUnit({ ...of, unit: { ...of.unit, times: 0 } })
+
+void test('a product adds dimensions and a quotient subtracts them', () => {
+    assert.equal(shape(forward('*', people, area)), 'm^2 person^1 times=1 x1000000')
+    assert.equal(shape(forward('/', people, area)), 'm^-2 person^1 times=1 x0.000001')
+    assert.equal(shape(forward('/', people, people)), 'dimensionless times=1 x1')
+})
+
+void test('a bare number scales a quantity rather than being a quantity', () => {
+    assert.equal(shape(forward('*', people, constant(2))), 'person^1 times=2 x1')
+    assert.equal(shape(forward('*', constant(2), people)), 'person^1 times=2 x1')
+    // and a number over a quantity is one over it, not that many of it
+    assert.equal(shape(forward('/', constant(1), people)), 'person^-1 times=1 x1')
+})
+
+void test('only alike things add, and the sum is of their kind', () => {
+    assert.equal(shape(forward('+', people, people)), 'person^1 times=2 x1')
+    assert.equal(shape(forward('-', people, people)), 'person^1 times=0 x1')
+    // nothing is both people and an area, so nothing is their sum
+    assert.equal(shape(forward('+', people, area)), 'inconsistent')
+})
+
+void test('a side that says nothing is taken to be of the other side\'s kind', () => {
+    assert.equal(shape(forward('+', people, unknown)), 'person^1 times=1 x1')
+    assert.equal(shape(forward('+', unknown, people)), 'person^1 times=1 x1')
+    assert.equal(shape(forward('+', unknown, unknown)), 'unknown')
+})
+
+void test('a temperature is one of itself, and only stays a quantity while it is one or none', () => {
+    assert.equal(shape(temperature), 'F^1 times=1 x1')
+    // a difference of two temperatures is none of one, which is a quantity of degrees
+    assert.equal(shape(forward('-', temperature, temperature)), 'F^1 times=0 x1')
+    // their sum is two temperatures, which is carried along even though it is not one
+    assert.equal(shape(forward('+', temperature, temperature)), 'F^1 times=2 x1')
+    // because their mean is a temperature again
+    assert.equal(shape(forward('/', forward('+', temperature, temperature), constant(2))), 'F^1 times=1 x1')
+    // and a number of degrees added to one is a temperature
+    assert.equal(shape(forward('+', temperature, constant(2))), 'F^1 times=1 x1')
+})
+
+void test('two temperatures are not a temperature, and nothing writes them as one', () => {
+    assert.equal(unitToWriteIn(forward('+', temperature, temperature)), undefined)
+    assert.equal(unitToWriteIn(forward('*', temperature, constant(2))), undefined)
+    // where a mean of them, and a difference, are things to write
+    assert.notEqual(unitToWriteIn(forward('/', forward('+', temperature, temperature), constant(2))), undefined)
+    assert.notEqual(unitToWriteIn(forward('-', temperature, temperature)), undefined)
+    assert.notEqual(unitToWriteIn(people), undefined)
+})
+
+void test('a temperature cannot be multiplied by another quantity', () => {
+    // twice a temperature is two of them, which is carried, though it is not a temperature
+    assert.equal(shape(forward('*', temperature, constant(2))), 'F^1 times=2 x1')
+    // where there is no such quantity at all as a temperature times a population
+    assert.equal(shape(forward('*', temperature, people)), 'inconsistent')
+    assert.equal(shape(forward('**', temperature, constant(2))), 'inconsistent')
+    // a difference of two of them may be, since it is measured from nothing
+    assert.equal(shape(forward('*', difference(storedUnits.temperature), constant(2))), 'F^1 times=0 x1')
+})
+
+void test('a power needs its exponent to be a constant', () => {
+    assert.equal(shape(forward('**', inUnit(storedUnits.distanceInKm), constant(2))), 'm^2 times=1 x1000000')
+    assert.equal(shape(forward('**', inUnit(storedUnits.distanceInKm), people)), 'unknown')
+})
+
+void test('a comparison is of no kind, and its operands are of each other\'s', () => {
+    assert.equal(shape(forward('<', people, constant(2))), 'unknown')
+    assert.equal(shape(backward('<', unknown, people, 'right')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('==', unknown, area, 'left')), 'm^2 times=1 x1000000')
+})
+
+void test('an operand is found by undoing the operator', () => {
+    const perArea = forward('/', people, area)
+    assert.equal(shape(backward('/', perArea, area, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('/', perArea, people, 'right')), 'm^2 times=1 x1000000')
+    const total = forward('*', people, area)
+    assert.equal(shape(backward('*', total, area, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('*', total, people, 'right')), 'm^2 times=1 x1000000')
+})
+
+void test('a difference gives back the level it was taken from', () => {
+    const change = forward('-', people, people)
+    assert.equal(shape(backward('-', change, people, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('+', people, difference(storedUnits.population), 'left')), 'person^1 times=1 x1')
+})
+
+void test('every operator answers in both directions, whatever it is given', () => {
+    const inputs = [unknown, people, temperature, constant(2), constant(0)]
+    for (const operator of infixOperators satisfies readonly BinaryOperatorSymbol[]) {
+        for (const left of inputs) {
+            for (const right of inputs) {
+                assert.doesNotThrow(() => forward(operator, left, right))
+                assert.doesNotThrow(() => backward(operator, left, right, 'left'))
+                assert.doesNotThrow(() => backward(operator, left, right, 'right'))
+            }
+        }
+    }
+})
+
+void test('negating takes a quantity from nothing, which is not what it was', () => {
+    assert.equal(shape(forwardUnary('+', people)), 'person^1 times=1 x1')
+    assert.equal(shape(forwardUnary('-', people)), 'person^1 times=-1 x1')
+    // a difference of two is one however it is signed, so it stays one to write
+    assert.equal(shape(forwardUnary('-', difference(storedUnits.population))), 'person^1 times=0 x1')
+    assert.notEqual(unitToWriteIn(forwardUnary('-', difference(storedUnits.population))), undefined)
+    // where minus a temperature is no reading at all: -50F and -10C are not the same one
+    assert.equal(unitToWriteIn(forwardUnary('-', temperature)), undefined)
+    assert.equal(shape(forwardUnary('!', people)), 'unknown')
+})
+
+void test('a negated number is the negative of it, so that it scales the right way', () => {
+    assert.equal(shape(forward('*', people, forwardUnary('-', constant(2)))), 'person^1 times=-2 x1')
+    assert.equal(shape(forward('*', people, forwardUnary('+', constant(2)))), 'person^1 times=2 x1')
+})
+
+// Not knowing which unit something is in is a different thing from nothing being of any unit, and
+// the second is worth telling a script's author about where the first is not
+void test('what cannot be told apart from what cannot be', () => {
+    assert.equal(shape(unknown), 'unknown')
+    assert.equal(shape(inconsistent), 'inconsistent')
+    assert.equal(shape(forward('+', people, area)), 'inconsistent')
+    assert.equal(shape(forward('+', unknown, unknown)), 'unknown')
+    // and nothing computed from what cannot be is either
+    assert.equal(shape(forward('*', forward('+', people, area), constant(2))), 'inconsistent')
+    assert.equal(shape(backward('*', forward('+', people, area), people, 'left')), 'inconsistent')
+    // neither is written in anything, which is all the display asks
+    assert.equal(unitToWriteIn(unknown), undefined)
+    assert.equal(unitToWriteIn(inconsistent), undefined)
+})
+
+void test('a unary operator undoes itself, so the operand is found the same way', () => {
+    for (const operand of [unknown, people, temperature, constant(2), inconsistent]) {
+        for (const operator of unaryOperators) {
+            assert.equal(shape(backwardUnary(operator, forwardUnary(operator, operand))),
+                operator === '!' ? 'unknown' : shape(operand))
+        }
+    }
+})

--- a/react/unit/unit-arithmetic.test.ts
+++ b/react/unit/unit-arithmetic.test.ts
@@ -1,0 +1,60 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { Dimension, dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../src/utils/quantity'
+import { storedUnits } from '../src/utils/unit'
+
+/** The dimensions and scale of a unit, as a string, so that a test can say what it expects. */
+function shape(stored: StoredUnit | undefined): string {
+    if (stored === undefined) return 'none'
+    // arithmetic only ever produces a scalar, since that is the only thing it can take
+    assert.equal(stored.unit.kind, 'scalar')
+    const written = [...(stored.unit as { dimensions: Dimension[] }).dimensions]
+        .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+    return `${written === '' ? 'dimensionless' : written} x${stored.toBaseUnits}`
+}
+
+void test('a product adds the dimensions and multiplies what they are stored in', () => {
+    // people per km^2 times km^2 is people: 1e-6 * 1e6
+    assert.equal(shape(unitProduct(storedUnits.density, storedUnits.area, 1)), 'person^1 x1')
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.area, 1)), 'm^2 person^1 x1000000')
+})
+
+void test('a quotient subtracts them', () => {
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.area, -1)), 'm^-2 person^1 x0.000001')
+    assert.equal(shape(unitProduct(storedUnits.fatalities, storedUnits.population, -1)), 'fatality^1 person^-1 x1')
+})
+
+void test('dimensions that cancel are gone rather than left at nothing', () => {
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.population, -1)), 'dimensionless x1')
+    assert.equal(shape(unitProduct(storedUnits.distanceInKm, storedUnits.distanceInM, -1)), 'dimensionless x1000')
+})
+
+void test('a power raises the dimensions and the scale together', () => {
+    // a kilometer squared is a million square meters
+    assert.equal(shape(unitPower(storedUnits.distanceInKm, 2)), 'm^2 x1000000')
+    assert.equal(shape(unitPower(storedUnits.distanceInKm, -1)), 'm^-1 x0.001')
+    assert.equal(shape(unitPower(storedUnits.population, 0)), 'dimensionless x1')
+})
+
+void test('two quantities of the same kind can be told from two of different kinds', () => {
+    assert.ok(sameDimensions(storedUnits.distanceInKm, storedUnits.distanceInM))
+    assert.ok(sameDimensions(storedUnits.number, dimensionless))
+    assert.ok(!sameDimensions(storedUnits.population, storedUnits.fatalities))
+    assert.ok(!sameDimensions(storedUnits.area, storedUnits.distanceInM))
+})
+
+void test('a temperature is not a scaling of anything, so there is no arithmetic on one', () => {
+    assert.equal(shape(unitProduct(storedUnits.temperature, storedUnits.population, 1)), 'none')
+    assert.equal(shape(unitPower(storedUnits.temperature, 2)), 'none')
+    assert.ok(!sameDimensions(storedUnits.temperature, storedUnits.temperature))
+})
+
+void test('what a statistic is written in does not survive being computed with', () => {
+    const perArea = unitProduct(storedUnits.population, storedUnits.area, -1)
+    assert.equal(perArea?.unit.kind === 'scalar' ? perArea.unit.decoration.kind : undefined, 'none')
+    // where the density statistic itself keeps its km^2
+    assert.equal(storedUnits.density.unit.kind === 'scalar' ? storedUnits.density.unit.decoration.kind : undefined, 'writtenIn')
+})

--- a/react/unit/unit-arithmetic.test.ts
+++ b/react/unit/unit-arithmetic.test.ts
@@ -1,15 +1,13 @@
 import assert from 'assert/strict'
 import test from 'node:test'
 
-import { Dimension, dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../src/utils/quantity'
+import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
 /** The dimensions and scale of a unit, as a string, so that a test can say what it expects. */
 function shape(stored: StoredUnit | undefined): string {
     if (stored === undefined) return 'none'
-    // arithmetic only ever produces a scalar, since that is the only thing it can take
-    assert.equal(stored.unit.kind, 'scalar')
-    const written = [...(stored.unit as { dimensions: Dimension[] }).dimensions]
+    const written = [...stored.unit.dimensions]
         .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
         .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
         .join(' ')
@@ -46,15 +44,20 @@ void test('two quantities of the same kind can be told from two of different kin
     assert.ok(!sameDimensions(storedUnits.area, storedUnits.distanceInM))
 })
 
-void test('a temperature is not a scaling of anything, so there is no arithmetic on one', () => {
+void test('two temperatures are the same kind of thing, so one can be taken from the other', () => {
+    assert.ok(sameDimensions(storedUnits.temperature, storedUnits.temperature))
+    assert.ok(!sameDimensions(storedUnits.temperature, storedUnits.number))
+})
+
+void test('a quantity measured from its own zero cannot be multiplied or raised', () => {
+    // how many temperatures twice a temperature is depends on the two, not on the units
     assert.equal(shape(unitProduct(storedUnits.temperature, storedUnits.population, 1)), 'none')
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.temperature, -1)), 'none')
     assert.equal(shape(unitPower(storedUnits.temperature, 2)), 'none')
-    assert.ok(!sameDimensions(storedUnits.temperature, storedUnits.temperature))
 })
 
 void test('what a statistic is written in does not survive being computed with', () => {
-    const perArea = unitProduct(storedUnits.population, storedUnits.area, -1)
-    assert.equal(perArea?.unit.kind === 'scalar' ? perArea.unit.decoration.kind : undefined, 'none')
+    assert.equal(unitProduct(storedUnits.population, storedUnits.area, -1)?.unit.decoration.kind, 'none')
     // where the density statistic itself keeps its km^2
-    assert.equal(storedUnits.density.unit.kind === 'scalar' ? storedUnits.density.unit.decoration.kind : undefined, 'writtenIn')
+    assert.equal(storedUnits.density.unit.decoration.kind, 'writtenIn')
 })


### PR DESCRIPTION
Off main. The first two pieces of #2216, the second having been merged in here as #2299.

## Arithmetic on units

Inferring the unit of a computed quantity means saying what the unit of a product is, of a quotient, and of a quantity raised to a power. That is arithmetic on the dimensions, with what each is stored in carried along:

```ts
export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined
export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined
export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean
```

A kilometer squared is a million square meters, so the scale is raised with the dimensions, and dimensions that cancel are dropped rather than left at zero. Nothing computed keeps what its statistic was written in: a population over an area is people per square meter, to be written in whatever reads shortest, where the density *statistic* is per square kilometer because it says so.

Two temperatures are the same kind of thing, so one can be taken from the other. Twice a temperature is another matter — how many temperatures it is depends on the two of them rather than on their units — so a product or a power involving one is no quantity at all.

## What an expression is in, and what its operands must be

Inference needs both directions. Forwards gives the unit of a computed column; backwards reads the `0.1` of `commute_bike < 0.1` as ten percent, which is what the captions need.

```ts
export type AbstractInterpValue = (
    { kind: 'any', constant?: number }
    | { kind: 'none' }
    | { kind: 'in', unit: StoredUnit, constant?: number }
)
```

Not knowing which unit something is in is a different thing from nothing being of any unit, and only the second is worth telling a script's author about. Both are ordinary members of the domain, so every expression has an answer and no operation can fail — a test runs every operator over every kind of value in all three directions and asserts none of them throws.

Every operator is one of three shapes rather than a case of its own: the slots of a **sum** are all the same unit, the slots of a **product** have dimensions that add, and a **power** needs its exponent to be a constant. Solving for an operand is running the operator that undoes it —

```ts
const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
```

— so each direction is the other read backwards rather than a second set of rules to keep in step. The unary operators are their own inverses, and say so.

Constants are in the domain because coefficients need them. A bare number is dimensionless under *product* and takes the other side's unit under *same unit*, which is why `pop * 2` and `pop + 2` differ; and negating one negates it, so `pop * -2` scales by minus two.

Coefficients are checked where the quantity is written, not as it goes:

```
t1 - t2            times=0     a number of degrees
t1 + t2            times=2     carried, but nothing writes it
(t1 + t2) / 2      times=1     a temperature again
t + 2              times=1     a temperature, the 2 being degrees
-t                 times=-1    no reading: -50F and -10C are not the same one
```

Refusing the sum on the way past would have lost the mean, which is why `unitToWriteIn` asks at the end.

## Verification

`tsc`, lint, knip, 615 unit tests, twenty-four of them new. The 1440-case rendering sweep is unchanged: nothing here is reachable from a statistic yet.

Next is the walk over the AST, then the two entry points, then the captions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
