### PR TITLE
Measure a temperature from its own zero, and a difference of two from nothing

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -16,8 +16,7 @@ export interface DisplayedQuantity {
  * zero for a lead, since a lead is written as a size rather than as a signed number.
  */
 function flipsInequality(unit: Unit, value: number): boolean {
-    return unit.kind === 'scalar' && unit.decoration.kind === 'percent'
-        && unit.decoration.party?.kind === 'lead' && value <= 0
+    return unit.decoration.kind === 'percent' && unit.decoration.party?.kind === 'lead' && value <= 0
 }
 
 export function renderInequality(value: number, stored: StoredUnit, inequality: 'leq' | 'geq'): string {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -11,7 +11,7 @@ type PartySystem = 'democratic' | 'left'
 /**
  * Base units, combined together via multiplication to form the units that correspond to the inBaseUnits value
  */
-export type BaseUnit = 'person' | 'usd' | 'fatality' | 'm' | 'g' | 's'
+export type BaseUnit = 'person' | 'usd' | 'fatality' | 'm' | 'g' | 's' | 'F'
 
 export interface Dimension {
     baseUnit: BaseUnit
@@ -38,11 +38,19 @@ export function inEitherSystem(units: Partial<Record<BaseUnit, NamedUnit>>): Rec
 
 export type Decoration = { kind: 'none' } | { kind: 'percent', party?: Party } | { kind: 'writtenIn', in: WrittenIn }
 
-/** Temperature is not expressed in units that scale each other: 0°C is not 0°F. */
-export type Unit = (
-    { kind: 'temperature' }
-    | { kind: 'scalar', dimensions: Dimension[], decoration: Decoration, difference: boolean }
-)
+export interface Unit {
+    dimensions: Dimension[]
+    decoration: Decoration
+    /**
+     * The coefficients of the quantities that were added to make this one: a level is 1, a
+     * difference of two is 0, and the mean of two is 1 again. Where the base has no zero of its
+     * own only those two are quantities at all; where it has one, all that is read off this is
+     * whether it is zero, which is what a leading + is written for.
+     */
+    times: number
+    /** Whether zero of it is nothing, which is false of a temperature: 0°C is not 0°F. */
+    baseIsScalar: boolean
+}
 
 export interface StoredUnit {
     unit: Unit
@@ -93,6 +101,8 @@ export interface NamedUnit {
     dimensions: Dimension[]
     /** E.g., for an acre, 4046.86 */
     size: number
+    /** Where its zero sits, in base units, for a base that has no zero of its own */
+    offset?: number
     /* How much should we discourage using this, in units of cost (digits) */
     cost: number
     /** Whether it shortens the number rather than measuring in something else, as k and m do */
@@ -132,6 +142,8 @@ export const inch = scaling('m', 'in', metersPerInch, costScaledUnit)
 export const minute = scaling('s', 'min', 60, costScaledUnit)
 export const year = scaling('s', 'yr', 365.25 * 24 * 60 * 60, 0)
 export const microgram = scaling('g', 'μg', 1e-6, costScaledUnit)
+const fahrenheit: NamedUnit = { name: '°F', dimensions: [{ baseUnit: 'F', power: 1 }], size: 1, cost: 0, abbreviation: false }
+const celsius: NamedUnit = { name: '°C', dimensions: [{ baseUnit: 'F', power: 1 }], size: 9 / 5, offset: 32, cost: 0, abbreviation: false }
 
 const massUnits: NamedUnit[] = [
     scaling('g', 'g', 1, 0),
@@ -178,6 +190,8 @@ function allUnits(settings: ReaderSettings): NamedUnit[] {
         ...lengthUnits[systemOf(settings)],
         ...massUnits,
         ...timeUnits,
+        // the one a reader reads temperatures in, so there is nothing for the search to weigh
+        settings.temperatureUnit === 'celsius' ? celsius : fahrenheit,
     ]
 }
 
@@ -206,6 +220,7 @@ const conventions: Record<DimensionKey, Convention | undefined> = {
     'person^1': { style: { kind: 'fixed', places: 0 } },
     'usd^1': { style: { kind: 'fixed', places: 0 }, prefix: '$' },
     'fatality^1': { style: { kind: 'fixed', places: 0 } },
+    'F^1': { style: { kind: 'fixed', places: 1 } },
 }
 
 const defaultStyle: NumberFormat = { kind: 'rounded', significantDigits: 3 }
@@ -255,12 +270,15 @@ export function nameOf(written: Written[]): HumanReadableElement[] {
     return merged([...product(over), ...atom(over.length === 0 ? '/\u00a0' : '/'), ...product(under)])
 }
 
+/**
+ * Where the zero of the units a quantity is written in sits. A quantity measured from that zero is
+ * written from it; a difference of two is not, since the zero cancels between them.
+ */
+function offsetOf(written: Written[], times: number): number {
+    return times === 1 ? written.reduce((total, { unit, power }) => total + (unit.offset ?? 0) * power, 0) : 0
+}
+
 function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings): Representation {
-    if (unit.kind === 'temperature') {
-        return settings.temperatureUnit === 'celsius'
-            ? { unitName: atom('°C'), scale: value => (value - 32) * (5 / 9), format: { kind: 'fixed', places: 1 } }
-            : { unitName: atom('°F'), scale: value => value, format: { kind: 'fixed', places: 1 } }
-    }
     if (unit.decoration.kind === 'percent') {
         // a lead is given more digits the closer it is, since that is what is being read off it
         return unit.decoration.party?.kind === 'lead' ? margin : percent
@@ -271,11 +289,12 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSett
     const pool = writtenIn === undefined ? allUnits(settings) : Object.values(writtenIn.units[systemOf(settings)])
     const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool,
         chosen => writtenIn?.style ?? styleFor(convention, chosen))
+    const zero = offsetOf(written, unit.times)
     // h:mm spends two units and names one, so which one it names is the format's to say
     const unitName = format.kind === 'hoursMinutes'
         ? atom(hoursAndMinutes(scale(inBaseUnits)).unit)
         : nameOf(written)
-    return { scale, unitName, format, prefix: convention?.prefix }
+    return { scale: value => scale(value - zero), unitName, format, prefix: convention?.prefix }
 }
 
 function getParty(partySystem: PartySystem, value: number): { label: string, hue: Hue } {
@@ -284,7 +303,7 @@ function getParty(partySystem: PartySystem, value: number): { label: string, hue
 }
 
 function hueFor(unit: Unit): Hue | undefined {
-    if (unit.kind !== 'scalar' || unit.decoration.kind !== 'percent') {
+    if (unit.decoration.kind !== 'percent') {
         return undefined
     }
     return unit.decoration.party?.kind === 'color' ? unit.decoration.party.hue : undefined
@@ -304,7 +323,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
     const { unit } = stored
     let inBaseUnits = value * stored.toBaseUnits
     const representation = representationFor(inBaseUnits, unit, settings)
-    const leads = unit.kind === 'scalar' && unit.decoration.kind === 'percent' && unit.decoration.party?.kind === 'lead'
+    const leads = unit.decoration.kind === 'percent' && unit.decoration.party?.kind === 'lead'
         ? unit.decoration.party.system
         : undefined
     let party = undefined
@@ -312,7 +331,7 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
         party = getParty(leads, inBaseUnits)
         inBaseUnits = Math.abs(inBaseUnits)
     }
-    const explicitSign = unit.kind === 'scalar' && unit.difference && inBaseUnits >= 0 ? '+' : ''
+    const explicitSign = unit.times === 0 && inBaseUnits >= 0 ? '+' : ''
     const written = formatNumber(representation.scale(inBaseUnits), representation.format)
     return {
         renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${representation.prefix ?? ''}${written}`,

--- a/react/src/utils/unit.ts
+++ b/react/src/utils/unit.ts
@@ -1,6 +1,6 @@
 import {
     BaseUnit, centimeter, Decoration, fatalities, Hue, hundredThousandPeople, inch, kilometer, meter, microgram, mile,
-    inEitherSystem, minute, Party, people, StoredUnit, WrittenIn, year,
+    inEitherSystem, minute, Party, people, StoredUnit, Unit, WrittenIn, year,
 } from './quantity'
 
 export type UnitType = 'percentage' | 'percentageChange' | 'fatalities' | 'fatalitiesPerCapita' | 'density' | 'population'
@@ -54,17 +54,18 @@ function dimensionfull(scales: Partial<Record<BaseUnit, number>>, toBaseUnits = 
     const decoration: Decoration = writtenIn === undefined ? { kind: 'none' } : { kind: 'writtenIn', in: writtenIn }
     return {
         unit: {
-            kind: 'scalar',
             dimensions: entries.map(([baseUnit, power]) => ({ baseUnit, power })),
             decoration,
-            difference: false,
+            times: 1,
+            baseIsScalar: true,
         },
         toBaseUnits,
     }
 }
 
 function percentage(party: Party | undefined, difference = false): StoredUnit {
-    return { unit: { kind: 'scalar', dimensions: [], decoration: { kind: 'percent', party }, difference }, toBaseUnits: 1 }
+    const unit: Unit = { dimensions: [], decoration: { kind: 'percent', party }, times: difference ? 0 : 1, baseIsScalar: true }
+    return { unit, toBaseUnits: 1 }
 }
 
 const inParty = (hue: Hue): Party => ({ kind: 'color', hue })
@@ -87,7 +88,11 @@ export const storedUnits = {
     partyChangeTeal: percentage(inParty('cyan'), true),
     partyChangeGreen: percentage(inParty('green'), true),
     partyChangePurple: percentage(inParty('purple'), true),
-    temperature: { unit: { kind: 'temperature' }, toBaseUnits: 1 },
+    // a temperature is measured from a zero that is not nothing, so it is not a scaling of anything
+    temperature: {
+        unit: { dimensions: [{ baseUnit: 'F', power: 1 }], decoration: { kind: 'none' }, times: 1, baseIsScalar: false },
+        toBaseUnits: 1,
+    },
     time: dimensionfull({ s: 1 }, 60 * 60, { units: inEitherSystem({ s: minute }), style: { kind: 'hoursMinutes' } }),
     minutes: dimensionfull({ s: 1 }, 60, { units: inEitherSystem({ s: minute }), style: { kind: 'hoursMinutes' } }),
     number: dimensionfull({}),

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -321,8 +321,26 @@ for (const [unitType, dimensions, toBaseUnits, value, asStatistic, asDerived] of
     void test(`${unitType} keeps its units, where the same dimensions on their own do not`, () => {
         assert.equal(write(storedUnits[unitType]), asStatistic)
         assert.equal(write({
-            unit: { kind: 'scalar', dimensions, decoration: { kind: 'none' }, difference: false },
+            unit: { dimensions, decoration: { kind: 'none' }, times: 1, baseIsScalar: true },
             toBaseUnits,
         }), asDerived)
+    })
+}
+
+// A temperature is measured from a zero that is not nothing, so a difference of two is not
+// measured from it: nine Fahrenheit degrees between two readings is five Celsius degrees
+for (const [times, value, temperatureUnit, expected] of [
+    [1, 50, 'fahrenheit', '50.0°F'],
+    [1, 50, 'celsius', '10.0°C'],
+    [0, 50, 'fahrenheit', '+50.0°F'],
+    [0, 50, 'celsius', '+27.8°C'],
+    [0, 9, 'celsius', '+5.0°C'],
+    [0, -9, 'celsius', '-5.0°C'],
+] as const) {
+    void test(`${times === 1 ? 'a temperature' : 'a difference'} of ${value}F reads as ${expected}`, () => {
+        const temperature = unitTypeToStoredUnit('temperature')
+        const stored: StoredUnit = { ...temperature, unit: { ...temperature.unit, times } }
+        const written = writeQuantity(value, stored, { temperatureUnit })
+        assert.equal(`${written.renderedValue}${reifyString(written.unitName)}`, expected)
     })
 }


### PR DESCRIPTION
Off main, ahead of #2297 and the rest of #2216.

A temperature was a kind of its own because 0°C is not 0°F. What that actually says is that it is measured from a zero which is not nothing — and that is a property a quantity can have rather than a kind it has to be. A unit says where its zero sits, and a quantity says how many of itself were added to make it:

```ts
export interface Unit {
    dimensions: Dimension[]
    decoration: Decoration
    /**
     * The coefficients of the quantities that were added to make this one: a level is 1, a
     * difference of two is 0, and the mean of two is 1 again. [...]
     */
    times: number
    /** Whether zero of it is nothing, which is false of a temperature: 0°C is not 0°F. */
    baseIsScalar: boolean
}
```

A level is measured from that zero; a difference of two is not, since the zero cancels between them. So `Unit` is one shape rather than two, and temperature joins the dimension system as `F^1` with Celsius as a unit of size 9/5 and offset 32.

`difference` becomes `times`, of which it was the zero-or-not: `false` is one, `true` is none. For anything whose zero *is* nothing, that is all `times` is read for — it decides the leading `+`.

## What this makes possible

A difference of two temperatures, which the old code could not express at all — it applied `(v − 32) × 5/9` to everything, so it would render a nine-degree gap as `−12.8 °C`:

```
                                   reader of °F     reader of °C
a temperature of 50F               50.0°F           10.0°C
a difference of 50F between two    +50.0°F          +27.8°C
a difference of 9F between two     +9.0°F           +5.0°C
```

Nine Fahrenheit degrees is five Celsius degrees, which is the point.

It also unblocks `(t1 + t2) / 2` reading as a temperature once inference lands: the coefficients sum to one, so the mean of two temperatures is a temperature, where their sum is not a quantity at all.

## Verification

The 1440-case sweep against main: **no differences**. Temperature now goes through the same search and offset arithmetic as everything else, so I stressed it separately: every tenth of a degree from −100 to 250, in both settings, **7,002 renderings identical to main**.

`tsc`, lint, knip, 591 unit tests, six of them new for the level-versus-difference distinction.

#2297 wants a small follow-up after this: its `sameDimensions` test says a temperature is not the same kind of thing as a temperature, which this makes untrue, and its arithmetic can stop refusing one.

No screenshots should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
