### PR TITLE
Say what an expression is in, and what its operands must be

### DIFF
--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -17,32 +17,23 @@ export function inUnit(unit: StoredUnit): Known {
     return { kind: 'in', unit }
 }
 
-function unitOf(known: Known): StoredUnit | undefined {
-    return known.kind === 'in' ? known.unit : undefined
-}
-
-function quantity(unit: StoredUnit | undefined): Known {
-    return unit === undefined ? { kind: 'none' } : { kind: 'in', unit }
-}
-
 /**
  * Asked at the end rather than at every step: two temperatures added are neither one temperature
  * nor none, but their mean is one again, and refusing the sum on the way past would lose that.
  */
 export function unitToWriteIn(known: Known): StoredUnit | undefined {
-    const unit = unitOf(known)
-    if (unit === undefined || (!unit.unit.baseIsScalar && unit.unit.times !== 0 && unit.unit.times !== 1)) {
+    if (known.kind !== 'in') {
+        return undefined
+    }
+    const { unit } = known
+    if (!unit.unit.baseIsScalar && unit.unit.times !== 0 && unit.unit.times !== 1) {
         return undefined
     }
     return unit
 }
 
 function withTimes(unit: StoredUnit, times: number): Known {
-    return quantity({ ...unit, unit: { ...unit.unit, times } })
-}
-
-function asFactor(known: Known): number | undefined {
-    return known.kind === 'any' ? known.constant : undefined
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
 }
 
 /** How an operator's slots are related, which is what both directions are read off. */
@@ -76,37 +67,42 @@ const forms: Record<BinaryOperatorSymbol, Form> = {
 }
 
 function addedForward(form: { combine: (left: number, right: number) => number }, left: Known, right: Known): Known {
-    const [over, under] = [unitOf(left), unitOf(right)]
-    // one side saying nothing is taken to be of the other's kind, since only alike things add
-    const unit = over ?? under
-    if (unit === undefined) {
-        return { kind: 'any' }
+    if (left.kind === 'in' && right.kind === 'in') {
+        // nothing is both people and an area, so nothing is their sum
+        if (!sameDimensions(left.unit, right.unit)) {
+            return { kind: 'none' }
+        }
+        return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
     }
-    if (over !== undefined && under !== undefined && !sameDimensions(over, under)) {
-        // nothing is both, so nothing is their sum
-        return { kind: 'none' }
-    }
+    // one side saying nothing is taken to be of the other's kind, since only alike things add, and
     // a bare number added to a temperature is a number of degrees rather than a temperature
-    return withTimes(unit, form.combine(over?.unit.times ?? 0, under?.unit.times ?? 0))
+    if (left.kind === 'in') {
+        return withTimes(left.unit, form.combine(left.unit.unit.times, 0))
+    }
+    if (right.kind === 'in') {
+        return withTimes(right.unit, form.combine(0, right.unit.unit.times))
+    }
+    return { kind: 'any' }
 }
 
 function productForward(rightPower: 1 | -1, left: Known, right: Known): Known {
-    const [over, under] = [unitOf(left), unitOf(right)]
-    const [byLeft, byRight] = [asFactor(left), asFactor(right)]
-    if (byRight !== undefined && over !== undefined) {
+    if (left.kind === 'in' && right.kind === 'any' && right.constant !== undefined) {
         // scaling a quantity scales how many of itself it is: half of two temperatures is one
-        return withTimes(over, over.unit.times * (rightPower === 1 ? byRight : 1 / byRight))
+        return withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
     }
-    if (byLeft !== undefined && under !== undefined) {
-        return rightPower === 1
-            ? withTimes(under, under.unit.times * byLeft)
-            // a number over a quantity is not that many of it, but one over it
-            : quantity(unitProduct(dimensionless, under, -1))
+    if (right.kind === 'in' && left.kind === 'any' && left.constant !== undefined) {
+        if (rightPower === 1) {
+            return withTimes(right.unit, right.unit.unit.times * left.constant)
+        }
+        // a number over a quantity is not that many of it, but one over it
+        const inverted = unitProduct(dimensionless, right.unit, -1)
+        return inverted === undefined ? { kind: 'none' } : { kind: 'in', unit: inverted }
     }
-    if (over === undefined || under === undefined) {
+    if (left.kind !== 'in' || right.kind !== 'in') {
         return { kind: 'any' }
     }
-    return quantity(unitProduct(over, under, rightPower))
+    const product = unitProduct(left.unit, right.unit, rightPower)
+    return product === undefined ? { kind: 'none' } : { kind: 'in', unit: product }
 }
 
 export function forward(operator: BinaryOperatorSymbol, left: Known, right: Known): Known {
@@ -123,8 +119,11 @@ export function forward(operator: BinaryOperatorSymbol, left: Known, right: Know
         case 'product':
             return productForward(form.rightPower, left, right)
         case 'power': {
-            const [base, exponent] = [unitOf(left), asFactor(right)]
-            return exponent === undefined || base === undefined ? { kind: 'any' } : quantity(unitPower(base, exponent))
+            if (left.kind !== 'in' || right.kind !== 'any' || right.constant === undefined) {
+                return { kind: 'any' }
+            }
+            const raised = unitPower(left.unit, right.constant)
+            return raised === undefined ? { kind: 'none' } : { kind: 'in', unit: raised }
         }
     }
 }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -1,0 +1,171 @@
+import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
+
+import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
+
+/**
+ * What is known about a value: the unit it is in, where that can be told, and the value itself,
+ * where it is a constant. Knowing nothing is an ordinary member of this rather than a failure to
+ * be one, so every expression has one and no operation on them can fail.
+ */
+export interface Known {
+    unit?: StoredUnit
+    constant?: number
+}
+
+export const unknown: Known = {}
+
+/** A number written in the script, which is in whatever unit the operator on it says it is. */
+export function constant(value: number): Known {
+    return { constant: value }
+}
+
+export function inUnit(unit: StoredUnit): Known {
+    return { unit }
+}
+
+function quantity(unit: StoredUnit | undefined): Known {
+    return unit === undefined ? unknown : { unit }
+}
+
+/**
+ * The unit to write a value in, which a quantity measured from a zero of its own has only while it
+ * is one of itself or none of it. Two temperatures added together are neither -- but their mean is
+ * one again, so this is asked at the end rather than of every step along the way.
+ */
+export function unitToWriteIn(known: Known): StoredUnit | undefined {
+    const { unit } = known
+    if (unit === undefined || (!unit.unit.baseIsScalar && unit.unit.times !== 0 && unit.unit.times !== 1)) {
+        return undefined
+    }
+    return unit
+}
+
+function withTimes(unit: StoredUnit, times: number): Known {
+    return quantity({ ...unit, unit: { ...unit.unit, times } })
+}
+
+/** A constant with no unit of its own, which is what a bare number is when it scales something. */
+function asFactor(known: Known): number | undefined {
+    return known.unit === undefined ? known.constant : undefined
+}
+
+/**
+ * The shapes an operator takes. Each says how its slots are related; the directions are read off
+ * that relation rather than written out one at a time.
+ */
+type Form =
+    /** Every slot is the same unit, and the operands' coefficients combine into the result's. */
+    | { kind: 'sameUnit', combine: (left: number, right: number) => number, keepsUnit: boolean }
+    /** The operands' dimensions add, or subtract where the right is taken to the power -1. */
+    | { kind: 'product', rightPower: 1 | -1 }
+    /** The left raised to the right, which has to be a constant for anything to be said. */
+    | { kind: 'power' }
+    /** Nothing relates the slots, so nothing can be told from any of them. */
+    | { kind: 'opaque' }
+
+const comparison: Form = { kind: 'sameUnit', combine: () => 0, keepsUnit: false }
+
+const forms: Record<BinaryOperatorSymbol, Form> = {
+    '+': { kind: 'sameUnit', combine: (left, right) => left + right, keepsUnit: true },
+    '-': { kind: 'sameUnit', combine: (left, right) => left - right, keepsUnit: true },
+    // a comparison is between two of the same kind, and is itself of no kind at all
+    '==': comparison,
+    '!=': comparison,
+    '<': comparison,
+    '>': comparison,
+    '<=': comparison,
+    '>=': comparison,
+    '*': { kind: 'product', rightPower: 1 },
+    '/': { kind: 'product', rightPower: -1 },
+    '**': { kind: 'power' },
+    '&': { kind: 'opaque' },
+    '|': { kind: 'opaque' },
+}
+
+function addedForward(form: { combine: (left: number, right: number) => number }, left: Known, right: Known): Known {
+    // one side saying nothing is taken to be of the other's kind, since only alike things add
+    const unit = left.unit ?? right.unit
+    if (unit === undefined) {
+        return unknown
+    }
+    if (left.unit !== undefined && right.unit !== undefined && !sameDimensions(left.unit, right.unit)) {
+        return unknown
+    }
+    // a bare number added to a temperature is a number of degrees rather than a temperature
+    return withTimes(unit, form.combine(left.unit?.unit.times ?? 0, right.unit?.unit.times ?? 0))
+}
+
+function productForward(rightPower: 1 | -1, left: Known, right: Known): Known {
+    const [byLeft, byRight] = [asFactor(left), asFactor(right)]
+    if (byRight !== undefined && left.unit !== undefined) {
+        // scaling a quantity scales how many of itself it is: half of two temperatures is one
+        return withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? byRight : 1 / byRight))
+    }
+    if (byLeft !== undefined && right.unit !== undefined) {
+        return rightPower === 1
+            ? withTimes(right.unit, right.unit.unit.times * byLeft)
+            // a number over a quantity is not that many of it, but one over it
+            : quantity(unitProduct(dimensionless, right.unit, -1))
+    }
+    if (left.unit === undefined || right.unit === undefined) {
+        return unknown
+    }
+    return quantity(unitProduct(left.unit, right.unit, rightPower))
+}
+
+/** What is known about `left operator right`, from what is known about each of them. */
+export function forward(operator: BinaryOperatorSymbol, left: Known, right: Known): Known {
+    const form = forms[operator]
+    switch (form.kind) {
+        case 'opaque':
+            return unknown
+        case 'sameUnit':
+            return form.keepsUnit ? addedForward(form, left, right) : unknown
+        case 'product':
+            return productForward(form.rightPower, left, right)
+        case 'power': {
+            const exponent = asFactor(right)
+            return exponent === undefined || left.unit === undefined
+                ? unknown
+                : quantity(unitPower(left.unit, exponent))
+        }
+    }
+}
+
+const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
+
+/** Solving an operator for one of its operands is running the operator that undoes it. */
+function undo(operator: keyof typeof inverses, result: Known, known: Known, side: 'left' | 'right'): Known {
+    if (side === 'left') {
+        return forward(inverses[operator], result, known)
+    }
+    // the right of a sum or a product is found the same way; of a difference or a quotient, the
+    // operands change places, since the right of `a - b` is `a - result` rather than `result - a`
+    return operator === '+' || operator === '*'
+        ? forward(inverses[operator], result, known)
+        : forward(operator, known, result)
+}
+
+/**
+ * What is known about the other operand of `left operator right`, from the result and one of them.
+ * This is how a bare number written against a quantity is read in that quantity's unit.
+ */
+export function backward(operator: BinaryOperatorSymbol, result: Known, known: Known, side: 'left' | 'right'): Known {
+    const form = forms[operator]
+    switch (form.kind) {
+        case 'opaque':
+        // a power is undone by a root, which is not one of these operators
+        case 'power':
+            return unknown
+        case 'sameUnit':
+            // a comparison says nothing of its own kind, but its operands are of each other's
+            return form.keepsUnit ? undo(operator as '+' | '-', result, known, side) : quantity(known.unit)
+        case 'product':
+            return undo(operator as '*' | '/', result, known, side)
+    }
+}
+
+/** What is known about `operator operand`. Negating a quantity leaves it the quantity it was. */
+export function forwardUnary(operator: UnaryOperatorSymbol, operand: Known): Known {
+    return operator === '!' ? unknown : operand
+}

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -178,10 +178,10 @@ export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInt
     }
     // negating is taking it from nothing, so a level becomes minus one of itself, which a
     // temperature has no reading for, while a difference of two is still a difference
-    const constant = operand.constant === undefined ? undefined : -operand.constant
+    const negated = operand.constant === undefined ? undefined : -operand.constant
     if (operand.kind === 'any') {
-        return { kind: 'any', constant }
+        return { kind: 'any', constant: negated }
     }
     const { unit } = operand
-    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times: -unit.unit.times } }, constant }
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times: -unit.unit.times } }, constant: negated }
 }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -2,24 +2,13 @@ import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } fro
 
 import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 
-/**
- * What is known about a value. Every expression has one of these and no operation on them can
- * fail, so the two ways of knowing no unit are told apart: one is that it could be in any of them,
- * the other that no quantity is of it at all, which is what adding people to an area asks for.
- */
+/** `any` is that it could be in any unit; `none` is that no quantity is of it, as people plus an area. */
 export type Known = (
     { kind: 'any', constant?: number }
     | { kind: 'none' }
     | { kind: 'in', unit: StoredUnit, constant?: number }
 )
 
-/** It could be in any unit; nothing here says which. */
-export const unknown: Known = { kind: 'any' }
-
-/** No quantity is of it, because what it was computed from did not agree. */
-export const inconsistent: Known = { kind: 'none' }
-
-/** A number written in the script, which is in whatever unit the operator on it says it is. */
 export function constant(value: number): Known {
     return { kind: 'any', constant: value }
 }
@@ -33,13 +22,12 @@ function unitOf(known: Known): StoredUnit | undefined {
 }
 
 function quantity(unit: StoredUnit | undefined): Known {
-    return unit === undefined ? inconsistent : { kind: 'in', unit }
+    return unit === undefined ? { kind: 'none' } : { kind: 'in', unit }
 }
 
 /**
- * The unit to write a value in, which a quantity measured from a zero of its own has only while it
- * is one of itself or none of it. Two temperatures added together are neither -- but their mean is
- * one again, so this is asked at the end rather than of every step along the way.
+ * Asked at the end rather than at every step: two temperatures added are neither one temperature
+ * nor none, but their mean is one again, and refusing the sum on the way past would lose that.
  */
 export function unitToWriteIn(known: Known): StoredUnit | undefined {
     const unit = unitOf(known)
@@ -53,15 +41,11 @@ function withTimes(unit: StoredUnit, times: number): Known {
     return quantity({ ...unit, unit: { ...unit.unit, times } })
 }
 
-/** A constant with no unit of its own, which is what a bare number is when it scales something. */
 function asFactor(known: Known): number | undefined {
     return known.kind === 'any' ? known.constant : undefined
 }
 
-/**
- * The shapes an operator takes. Each says how its slots are related; the directions are read off
- * that relation rather than written out one at a time.
- */
+/** How an operator's slots are related, which is what both directions are read off. */
 type Form =
     /** Every slot is the same unit, and the operands' coefficients combine into the result's. */
     | { kind: 'sameUnit', combine: (left: number, right: number) => number, keepsUnit: boolean }
@@ -96,11 +80,11 @@ function addedForward(form: { combine: (left: number, right: number) => number }
     // one side saying nothing is taken to be of the other's kind, since only alike things add
     const unit = over ?? under
     if (unit === undefined) {
-        return unknown
+        return { kind: 'any' }
     }
     if (over !== undefined && under !== undefined && !sameDimensions(over, under)) {
         // nothing is both, so nothing is their sum
-        return inconsistent
+        return { kind: 'none' }
     }
     // a bare number added to a temperature is a number of degrees rather than a temperature
     return withTimes(unit, form.combine(over?.unit.times ?? 0, under?.unit.times ?? 0))
@@ -120,28 +104,27 @@ function productForward(rightPower: 1 | -1, left: Known, right: Known): Known {
             : quantity(unitProduct(dimensionless, under, -1))
     }
     if (over === undefined || under === undefined) {
-        return unknown
+        return { kind: 'any' }
     }
     return quantity(unitProduct(over, under, rightPower))
 }
 
-/** What is known about `left operator right`, from what is known about each of them. */
 export function forward(operator: BinaryOperatorSymbol, left: Known, right: Known): Known {
     // nothing computed from something no quantity is of is a quantity either
     if (left.kind === 'none' || right.kind === 'none') {
-        return inconsistent
+        return { kind: 'none' }
     }
     const form = forms[operator]
     switch (form.kind) {
         case 'opaque':
-            return unknown
+            return { kind: 'any' }
         case 'sameUnit':
-            return form.keepsUnit ? addedForward(form, left, right) : unknown
+            return form.keepsUnit ? addedForward(form, left, right) : { kind: 'any' }
         case 'product':
             return productForward(form.rightPower, left, right)
         case 'power': {
             const [base, exponent] = [unitOf(left), asFactor(right)]
-            return exponent === undefined || base === undefined ? unknown : quantity(unitPower(base, exponent))
+            return exponent === undefined || base === undefined ? { kind: 'any' } : quantity(unitPower(base, exponent))
         }
     }
 }
@@ -160,20 +143,17 @@ function undo(operator: keyof typeof inverses, result: Known, known: Known, side
         : forward(operator, known, result)
 }
 
-/**
- * What is known about the other operand of `left operator right`, from the result and one of them.
- * This is how a bare number written against a quantity is read in that quantity's unit.
- */
+/** How the 0.1 of `commute_bike < 0.1` is read as ten percent. */
 export function backward(operator: BinaryOperatorSymbol, result: Known, known: Known, side: 'left' | 'right'): Known {
     if (result.kind === 'none' || known.kind === 'none') {
-        return inconsistent
+        return { kind: 'none' }
     }
     const form = forms[operator]
     switch (form.kind) {
         case 'opaque':
         // a power is undone by a root, which is not one of these operators
         case 'power':
-            return unknown
+            return { kind: 'any' }
         case 'sameUnit':
             // a comparison says nothing of its own kind, but its operands are of each other's
             return form.keepsUnit ? undo(operator as '+' | '-', result, known, side) : known
@@ -182,7 +162,6 @@ export function backward(operator: BinaryOperatorSymbol, result: Known, known: K
     }
 }
 
-/** What is known about `operator operand`. Negating a quantity leaves it the quantity it was. */
 export function forwardUnary(operator: UnaryOperatorSymbol, operand: Known): Known {
-    return operator === '!' ? unknown : operand
+    return operator === '!' ? { kind: 'any' } : operand
 }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -32,6 +32,9 @@ export function unitToWriteIn(known: Known): StoredUnit | undefined {
     return unit
 }
 
+/** What an operand can be, once forward and backward have refused what came from nothing. */
+type Possible = Exclude<Known, { kind: 'none' }>
+
 function withTimes(unit: StoredUnit, times: number): Known {
     return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
 }
@@ -66,40 +69,39 @@ const forms: Record<BinaryOperatorSymbol, Form> = {
     '|': { kind: 'opaque' },
 }
 
-function addedForward(form: { combine: (left: number, right: number) => number }, left: Known, right: Known): Known {
-    if (left.kind === 'in' && right.kind === 'in') {
-        // nothing is both people and an area, so nothing is their sum
-        if (!sameDimensions(left.unit, right.unit)) {
-            return { kind: 'none' }
-        }
-        return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
+function addedForward(form: { combine: (left: number, right: number) => number }, left: Possible, right: Possible): Known {
+    // a side saying nothing is taken to be of the other's kind, since only alike things add, and a
+    // bare number added to a temperature is a number of degrees rather than a temperature
+    if (left.kind === 'any') {
+        return right.kind === 'any' ? { kind: 'any' } : withTimes(right.unit, form.combine(0, right.unit.unit.times))
     }
-    // one side saying nothing is taken to be of the other's kind, since only alike things add, and
-    // a bare number added to a temperature is a number of degrees rather than a temperature
-    if (left.kind === 'in') {
+    if (right.kind === 'any') {
         return withTimes(left.unit, form.combine(left.unit.unit.times, 0))
     }
-    if (right.kind === 'in') {
-        return withTimes(right.unit, form.combine(0, right.unit.unit.times))
+    // nothing is both people and an area, so nothing is their sum
+    if (!sameDimensions(left.unit, right.unit)) {
+        return { kind: 'none' }
     }
-    return { kind: 'any' }
+    return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
 }
 
-function productForward(rightPower: 1 | -1, left: Known, right: Known): Known {
-    if (left.kind === 'in' && right.kind === 'any' && right.constant !== undefined) {
+function productForward(rightPower: 1 | -1, left: Possible, right: Possible): Known {
+    if (left.kind === 'any') {
+        if (right.kind === 'any' || left.constant === undefined) {
+            return { kind: 'any' }
+        }
         // scaling a quantity scales how many of itself it is: half of two temperatures is one
-        return withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
-    }
-    if (right.kind === 'in' && left.kind === 'any' && left.constant !== undefined) {
         if (rightPower === 1) {
             return withTimes(right.unit, right.unit.unit.times * left.constant)
         }
-        // a number over a quantity is not that many of it, but one over it
+        // where a number over a quantity is not that many of it, but one over it
         const inverted = unitProduct(dimensionless, right.unit, -1)
         return inverted === undefined ? { kind: 'none' } : { kind: 'in', unit: inverted }
     }
-    if (left.kind !== 'in' || right.kind !== 'in') {
-        return { kind: 'any' }
+    if (right.kind === 'any') {
+        return right.constant === undefined
+            ? { kind: 'any' }
+            : withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
     }
     const product = unitProduct(left.unit, right.unit, rightPower)
     return product === undefined ? { kind: 'none' } : { kind: 'in', unit: product }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -169,6 +169,11 @@ export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpV
     }
 }
 
+/** Each of these undoes itself: negating twice, or leaving alone twice, is what was there. */
+export function backwardUnary(operator: UnaryOperatorSymbol, result: AbstractInterpValue): AbstractInterpValue {
+    return forwardUnary(operator, result)
+}
+
 export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInterpValue): AbstractInterpValue {
     if (operator === '!') {
         return { kind: 'any' }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -1,3 +1,4 @@
+import { assert } from '../utils/defensive'
 import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
 
 import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
@@ -156,10 +157,15 @@ export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpV
         case 'power':
             return { kind: 'any' }
         case 'sameUnit':
-            // a comparison says nothing of its own kind, but its operands are of each other's
-            return form.keepsUnit ? undo(operator as '+' | '-', result, known, side) : known
+            if (!form.keepsUnit) {
+                // a comparison says nothing of its own kind, but its operands are of each other's
+                return known
+            }
+            assert(operator === '+' || operator === '-', `${operator} keeps the unit of what it adds`)
+            return undo(operator, result, known, side)
         case 'product':
-            return undo(operator as '*' | '/', result, known, side)
+            assert(operator === '*' || operator === '/', `${operator} is a product`)
+            return undo(operator, result, known, side)
     }
 }
 

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -3,17 +3,17 @@ import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } fro
 import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 
 /** `any` is that it could be in any unit; `none` is that no quantity is of it, as people plus an area. */
-export type Known = (
+export type AbstractInterpValue = (
     { kind: 'any', constant?: number }
     | { kind: 'none' }
     | { kind: 'in', unit: StoredUnit, constant?: number }
 )
 
-export function constant(value: number): Known {
+export function constant(value: number): AbstractInterpValue {
     return { kind: 'any', constant: value }
 }
 
-export function inUnit(unit: StoredUnit): Known {
+export function inUnit(unit: StoredUnit): AbstractInterpValue {
     return { kind: 'in', unit }
 }
 
@@ -21,7 +21,7 @@ export function inUnit(unit: StoredUnit): Known {
  * Asked at the end rather than at every step: two temperatures added are neither one temperature
  * nor none, but their mean is one again, and refusing the sum on the way past would lose that.
  */
-export function unitToWriteIn(known: Known): StoredUnit | undefined {
+export function unitToWriteIn(known: AbstractInterpValue): StoredUnit | undefined {
     if (known.kind !== 'in') {
         return undefined
     }
@@ -33,9 +33,9 @@ export function unitToWriteIn(known: Known): StoredUnit | undefined {
 }
 
 /** What an operand can be, once forward and backward have refused what came from nothing. */
-type Possible = Exclude<Known, { kind: 'none' }>
+type KnownAIV = Exclude<AbstractInterpValue, { kind: 'none' }>
 
-function withTimes(unit: StoredUnit, times: number): Known {
+function withTimes(unit: StoredUnit, times: number): AbstractInterpValue {
     return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
 }
 
@@ -69,7 +69,7 @@ const forms: Record<BinaryOperatorSymbol, Form> = {
     '|': { kind: 'opaque' },
 }
 
-function addedForward(form: { combine: (left: number, right: number) => number }, left: Possible, right: Possible): Known {
+function addedForward(form: { combine: (left: number, right: number) => number }, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
     // a side saying nothing is taken to be of the other's kind, since only alike things add, and a
     // bare number added to a temperature is a number of degrees rather than a temperature
     if (left.kind === 'any') {
@@ -85,7 +85,7 @@ function addedForward(form: { combine: (left: number, right: number) => number }
     return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
 }
 
-function productForward(rightPower: 1 | -1, left: Possible, right: Possible): Known {
+function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
     if (left.kind === 'any') {
         if (right.kind === 'any' || left.constant === undefined) {
             return { kind: 'any' }
@@ -107,7 +107,7 @@ function productForward(rightPower: 1 | -1, left: Possible, right: Possible): Kn
     return product === undefined ? { kind: 'none' } : { kind: 'in', unit: product }
 }
 
-export function forward(operator: BinaryOperatorSymbol, left: Known, right: Known): Known {
+export function forward(operator: BinaryOperatorSymbol, left: AbstractInterpValue, right: AbstractInterpValue): AbstractInterpValue {
     // nothing computed from something no quantity is of is a quantity either
     if (left.kind === 'none' || right.kind === 'none') {
         return { kind: 'none' }
@@ -133,7 +133,7 @@ export function forward(operator: BinaryOperatorSymbol, left: Known, right: Know
 const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
 
 /** Solving an operator for one of its operands is running the operator that undoes it. */
-function undo(operator: keyof typeof inverses, result: Known, known: Known, side: 'left' | 'right'): Known {
+function undo(operator: keyof typeof inverses, result: AbstractInterpValue, known: AbstractInterpValue, side: 'left' | 'right'): AbstractInterpValue {
     if (side === 'left') {
         return forward(inverses[operator], result, known)
     }
@@ -145,7 +145,7 @@ function undo(operator: keyof typeof inverses, result: Known, known: Known, side
 }
 
 /** How the 0.1 of `commute_bike < 0.1` is read as ten percent. */
-export function backward(operator: BinaryOperatorSymbol, result: Known, known: Known, side: 'left' | 'right'): Known {
+export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpValue, known: AbstractInterpValue, side: 'left' | 'right'): AbstractInterpValue {
     if (result.kind === 'none' || known.kind === 'none') {
         return { kind: 'none' }
     }
@@ -163,6 +163,6 @@ export function backward(operator: BinaryOperatorSymbol, result: Known, known: K
     }
 }
 
-export function forwardUnary(operator: UnaryOperatorSymbol, operand: Known): Known {
+export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInterpValue): AbstractInterpValue {
     return operator === '!' ? { kind: 'any' } : operand
 }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -8,7 +8,8 @@ import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
  * the other that no quantity is of it at all, which is what adding people to an area asks for.
  */
 export type Known = (
-    { kind: 'any' | 'none', constant?: number }
+    { kind: 'any', constant?: number }
+    | { kind: 'none' }
     | { kind: 'in', unit: StoredUnit, constant?: number }
 )
 

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -3,28 +3,36 @@ import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } fro
 import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 
 /**
- * What is known about a value: the unit it is in, where that can be told, and the value itself,
- * where it is a constant. Knowing nothing is an ordinary member of this rather than a failure to
- * be one, so every expression has one and no operation on them can fail.
+ * What is known about a value. Every expression has one of these and no operation on them can
+ * fail, so the two ways of knowing no unit are told apart: one is that it could be in any of them,
+ * the other that no quantity is of it at all, which is what adding people to an area asks for.
  */
-export interface Known {
-    unit?: StoredUnit
-    constant?: number
-}
+export type Known = (
+    { kind: 'any' | 'none', constant?: number }
+    | { kind: 'in', unit: StoredUnit, constant?: number }
+)
 
-export const unknown: Known = {}
+/** It could be in any unit; nothing here says which. */
+export const unknown: Known = { kind: 'any' }
+
+/** No quantity is of it, because what it was computed from did not agree. */
+export const inconsistent: Known = { kind: 'none' }
 
 /** A number written in the script, which is in whatever unit the operator on it says it is. */
 export function constant(value: number): Known {
-    return { constant: value }
+    return { kind: 'any', constant: value }
 }
 
 export function inUnit(unit: StoredUnit): Known {
-    return { unit }
+    return { kind: 'in', unit }
+}
+
+function unitOf(known: Known): StoredUnit | undefined {
+    return known.kind === 'in' ? known.unit : undefined
 }
 
 function quantity(unit: StoredUnit | undefined): Known {
-    return unit === undefined ? unknown : { unit }
+    return unit === undefined ? inconsistent : { kind: 'in', unit }
 }
 
 /**
@@ -33,7 +41,7 @@ function quantity(unit: StoredUnit | undefined): Known {
  * one again, so this is asked at the end rather than of every step along the way.
  */
 export function unitToWriteIn(known: Known): StoredUnit | undefined {
-    const { unit } = known
+    const unit = unitOf(known)
     if (unit === undefined || (!unit.unit.baseIsScalar && unit.unit.times !== 0 && unit.unit.times !== 1)) {
         return undefined
     }
@@ -46,7 +54,7 @@ function withTimes(unit: StoredUnit, times: number): Known {
 
 /** A constant with no unit of its own, which is what a bare number is when it scales something. */
 function asFactor(known: Known): number | undefined {
-    return known.unit === undefined ? known.constant : undefined
+    return known.kind === 'any' ? known.constant : undefined
 }
 
 /**
@@ -83,38 +91,45 @@ const forms: Record<BinaryOperatorSymbol, Form> = {
 }
 
 function addedForward(form: { combine: (left: number, right: number) => number }, left: Known, right: Known): Known {
+    const [over, under] = [unitOf(left), unitOf(right)]
     // one side saying nothing is taken to be of the other's kind, since only alike things add
-    const unit = left.unit ?? right.unit
+    const unit = over ?? under
     if (unit === undefined) {
         return unknown
     }
-    if (left.unit !== undefined && right.unit !== undefined && !sameDimensions(left.unit, right.unit)) {
-        return unknown
+    if (over !== undefined && under !== undefined && !sameDimensions(over, under)) {
+        // nothing is both, so nothing is their sum
+        return inconsistent
     }
     // a bare number added to a temperature is a number of degrees rather than a temperature
-    return withTimes(unit, form.combine(left.unit?.unit.times ?? 0, right.unit?.unit.times ?? 0))
+    return withTimes(unit, form.combine(over?.unit.times ?? 0, under?.unit.times ?? 0))
 }
 
 function productForward(rightPower: 1 | -1, left: Known, right: Known): Known {
+    const [over, under] = [unitOf(left), unitOf(right)]
     const [byLeft, byRight] = [asFactor(left), asFactor(right)]
-    if (byRight !== undefined && left.unit !== undefined) {
+    if (byRight !== undefined && over !== undefined) {
         // scaling a quantity scales how many of itself it is: half of two temperatures is one
-        return withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? byRight : 1 / byRight))
+        return withTimes(over, over.unit.times * (rightPower === 1 ? byRight : 1 / byRight))
     }
-    if (byLeft !== undefined && right.unit !== undefined) {
+    if (byLeft !== undefined && under !== undefined) {
         return rightPower === 1
-            ? withTimes(right.unit, right.unit.unit.times * byLeft)
+            ? withTimes(under, under.unit.times * byLeft)
             // a number over a quantity is not that many of it, but one over it
-            : quantity(unitProduct(dimensionless, right.unit, -1))
+            : quantity(unitProduct(dimensionless, under, -1))
     }
-    if (left.unit === undefined || right.unit === undefined) {
+    if (over === undefined || under === undefined) {
         return unknown
     }
-    return quantity(unitProduct(left.unit, right.unit, rightPower))
+    return quantity(unitProduct(over, under, rightPower))
 }
 
 /** What is known about `left operator right`, from what is known about each of them. */
 export function forward(operator: BinaryOperatorSymbol, left: Known, right: Known): Known {
+    // nothing computed from something no quantity is of is a quantity either
+    if (left.kind === 'none' || right.kind === 'none') {
+        return inconsistent
+    }
     const form = forms[operator]
     switch (form.kind) {
         case 'opaque':
@@ -124,10 +139,8 @@ export function forward(operator: BinaryOperatorSymbol, left: Known, right: Know
         case 'product':
             return productForward(form.rightPower, left, right)
         case 'power': {
-            const exponent = asFactor(right)
-            return exponent === undefined || left.unit === undefined
-                ? unknown
-                : quantity(unitPower(left.unit, exponent))
+            const [base, exponent] = [unitOf(left), asFactor(right)]
+            return exponent === undefined || base === undefined ? unknown : quantity(unitPower(base, exponent))
         }
     }
 }
@@ -151,6 +164,9 @@ function undo(operator: keyof typeof inverses, result: Known, known: Known, side
  * This is how a bare number written against a quantity is read in that quantity's unit.
  */
 export function backward(operator: BinaryOperatorSymbol, result: Known, known: Known, side: 'left' | 'right'): Known {
+    if (result.kind === 'none' || known.kind === 'none') {
+        return inconsistent
+    }
     const form = forms[operator]
     switch (form.kind) {
         case 'opaque':
@@ -159,7 +175,7 @@ export function backward(operator: BinaryOperatorSymbol, result: Known, known: K
             return unknown
         case 'sameUnit':
             // a comparison says nothing of its own kind, but its operands are of each other's
-            return form.keepsUnit ? undo(operator as '+' | '-', result, known, side) : quantity(known.unit)
+            return form.keepsUnit ? undo(operator as '+' | '-', result, known, side) : known
         case 'product':
             return undo(operator as '*' | '/', result, known, side)
     }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -170,5 +170,18 @@ export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpV
 }
 
 export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInterpValue): AbstractInterpValue {
-    return operator === '!' ? { kind: 'any' } : operand
+    if (operator === '!') {
+        return { kind: 'any' }
+    }
+    if (operator === '+' || operand.kind === 'none') {
+        return operand
+    }
+    // negating is taking it from nothing, so a level becomes minus one of itself, which a
+    // temperature has no reading for, while a difference of two is still a difference
+    const constant = operand.constant === undefined ? undefined : -operand.constant
+    if (operand.kind === 'any') {
+        return { kind: 'any', constant }
+    }
+    const { unit } = operand
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times: -unit.unit.times } }, constant }
 }

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -1,0 +1,119 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { BinaryOperatorSymbol, infixOperators } from '../src/urban-stats-script/operators'
+import { backward, constant, forward, forwardUnary, inUnit, Known, unitToWriteIn, unknown } from '../src/urban-stats-script/unit-algebra'
+import { StoredUnit } from '../src/utils/quantity'
+import { storedUnits } from '../src/utils/unit'
+
+/** What is known, as a string: the dimensions, how many of itself it is, and its scale. */
+function shape(known: Known): string {
+    if (known.unit === undefined) return 'unknown'
+    const written = [...known.unit.unit.dimensions]
+        .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+    return `${written === '' ? 'dimensionless' : written} times=${known.unit.unit.times} x${known.unit.toBaseUnits}`
+}
+
+const people = inUnit(storedUnits.population)
+const area = inUnit(storedUnits.area)
+const temperature = inUnit(storedUnits.temperature)
+const difference = (of: StoredUnit): Known => inUnit({ ...of, unit: { ...of.unit, times: 0 } })
+
+void test('a product adds dimensions and a quotient subtracts them', () => {
+    assert.equal(shape(forward('*', people, area)), 'm^2 person^1 times=1 x1000000')
+    assert.equal(shape(forward('/', people, area)), 'm^-2 person^1 times=1 x0.000001')
+    assert.equal(shape(forward('/', people, people)), 'dimensionless times=1 x1')
+})
+
+void test('a bare number scales a quantity rather than being a quantity', () => {
+    assert.equal(shape(forward('*', people, constant(2))), 'person^1 times=2 x1')
+    assert.equal(shape(forward('*', constant(2), people)), 'person^1 times=2 x1')
+    // and a number over a quantity is one over it, not that many of it
+    assert.equal(shape(forward('/', constant(1), people)), 'person^-1 times=1 x1')
+})
+
+void test('only alike things add, and the sum is of their kind', () => {
+    assert.equal(shape(forward('+', people, people)), 'person^1 times=2 x1')
+    assert.equal(shape(forward('-', people, people)), 'person^1 times=0 x1')
+    assert.equal(shape(forward('+', people, area)), 'unknown')
+})
+
+void test('a side that says nothing is taken to be of the other side\'s kind', () => {
+    assert.equal(shape(forward('+', people, unknown)), 'person^1 times=1 x1')
+    assert.equal(shape(forward('+', unknown, people)), 'person^1 times=1 x1')
+    assert.equal(shape(forward('+', unknown, unknown)), 'unknown')
+})
+
+void test('a temperature is one of itself, and only stays a quantity while it is one or none', () => {
+    assert.equal(shape(temperature), 'F^1 times=1 x1')
+    // a difference of two temperatures is none of one, which is a quantity of degrees
+    assert.equal(shape(forward('-', temperature, temperature)), 'F^1 times=0 x1')
+    // their sum is two temperatures, which is carried along even though it is not one
+    assert.equal(shape(forward('+', temperature, temperature)), 'F^1 times=2 x1')
+    // because their mean is a temperature again
+    assert.equal(shape(forward('/', forward('+', temperature, temperature), constant(2))), 'F^1 times=1 x1')
+    // and a number of degrees added to one is a temperature
+    assert.equal(shape(forward('+', temperature, constant(2))), 'F^1 times=1 x1')
+})
+
+void test('two temperatures are not a temperature, and nothing writes them as one', () => {
+    assert.equal(unitToWriteIn(forward('+', temperature, temperature)), undefined)
+    assert.equal(unitToWriteIn(forward('*', temperature, constant(2))), undefined)
+    // where a mean of them, and a difference, are things to write
+    assert.notEqual(unitToWriteIn(forward('/', forward('+', temperature, temperature), constant(2))), undefined)
+    assert.notEqual(unitToWriteIn(forward('-', temperature, temperature)), undefined)
+    assert.notEqual(unitToWriteIn(people), undefined)
+})
+
+void test('a temperature cannot be multiplied by another quantity', () => {
+    assert.equal(shape(forward('*', temperature, people)), 'unknown')
+    assert.equal(shape(forward('**', temperature, constant(2))), 'unknown')
+    // a difference of two of them may be, since it is measured from nothing
+    assert.equal(shape(forward('*', difference(storedUnits.temperature), constant(2))), 'F^1 times=0 x1')
+})
+
+void test('a power needs its exponent to be a constant', () => {
+    assert.equal(shape(forward('**', inUnit(storedUnits.distanceInKm), constant(2))), 'm^2 times=1 x1000000')
+    assert.equal(shape(forward('**', inUnit(storedUnits.distanceInKm), people)), 'unknown')
+})
+
+void test('a comparison is of no kind, and its operands are of each other\'s', () => {
+    assert.equal(shape(forward('<', people, constant(2))), 'unknown')
+    assert.equal(shape(backward('<', unknown, people, 'right')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('==', unknown, area, 'left')), 'm^2 times=1 x1000000')
+})
+
+void test('an operand is found by undoing the operator', () => {
+    const perArea = forward('/', people, area)
+    assert.equal(shape(backward('/', perArea, area, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('/', perArea, people, 'right')), 'm^2 times=1 x1000000')
+    const total = forward('*', people, area)
+    assert.equal(shape(backward('*', total, area, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('*', total, people, 'right')), 'm^2 times=1 x1000000')
+})
+
+void test('a difference gives back the level it was taken from', () => {
+    const change = forward('-', people, people)
+    assert.equal(shape(backward('-', change, people, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('+', people, difference(storedUnits.population), 'left')), 'person^1 times=1 x1')
+})
+
+void test('every operator answers in both directions, whatever it is given', () => {
+    const inputs = [unknown, people, temperature, constant(2), constant(0)]
+    for (const operator of infixOperators satisfies readonly BinaryOperatorSymbol[]) {
+        for (const left of inputs) {
+            for (const right of inputs) {
+                assert.doesNotThrow(() => forward(operator, left, right))
+                assert.doesNotThrow(() => backward(operator, left, right, 'left'))
+                assert.doesNotThrow(() => backward(operator, left, right, 'right'))
+            }
+        }
+    }
+})
+
+void test('negating a quantity leaves it what it was, and not-ing it says nothing', () => {
+    assert.equal(shape(forwardUnary('-', people)), 'person^1 times=1 x1')
+    assert.equal(shape(forwardUnary('!', people)), 'unknown')
+})

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -2,12 +2,12 @@ import assert from 'assert/strict'
 import test from 'node:test'
 
 import { BinaryOperatorSymbol, infixOperators } from '../src/urban-stats-script/operators'
-import { backward, constant, forward, forwardUnary, inUnit, Known, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
+import { backward, constant, forward, forwardUnary, inUnit, AbstractInterpValue, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
 import { StoredUnit } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
 /** What is known, as a string: the dimensions, how many of itself it is, and its scale. */
-function shape(known: Known): string {
+function shape(known: AbstractInterpValue): string {
     if (known.kind !== 'in') return known.kind === 'any' ? 'unknown' : 'inconsistent'
     const written = [...known.unit.unit.dimensions]
         .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
@@ -16,12 +16,12 @@ function shape(known: Known): string {
     return `${written === '' ? 'dimensionless' : written} times=${known.unit.unit.times} x${known.unit.toBaseUnits}`
 }
 
-const unknown: Known = { kind: 'any' }
-const inconsistent: Known = { kind: 'none' }
+const unknown: AbstractInterpValue = { kind: 'any' }
+const inconsistent: AbstractInterpValue = { kind: 'none' }
 const people = inUnit(storedUnits.population)
 const area = inUnit(storedUnits.area)
 const temperature = inUnit(storedUnits.temperature)
-const difference = (of: StoredUnit): Known => inUnit({ ...of, unit: { ...of.unit, times: 0 } })
+const difference = (of: StoredUnit): AbstractInterpValue => inUnit({ ...of, unit: { ...of.unit, times: 0 } })
 
 void test('a product adds dimensions and a quotient subtracts them', () => {
     assert.equal(shape(forward('*', people, area)), 'm^2 person^1 times=1 x1000000')

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -119,9 +119,20 @@ void test('every operator answers in both directions, whatever it is given', () 
     }
 })
 
-void test('negating a quantity leaves it what it was, and not-ing it says nothing', () => {
-    assert.equal(shape(forwardUnary('-', people)), 'person^1 times=1 x1')
+void test('negating takes a quantity from nothing, which is not what it was', () => {
+    assert.equal(shape(forwardUnary('+', people)), 'person^1 times=1 x1')
+    assert.equal(shape(forwardUnary('-', people)), 'person^1 times=-1 x1')
+    // a difference of two is one however it is signed, so it stays one to write
+    assert.equal(shape(forwardUnary('-', difference(storedUnits.population))), 'person^1 times=0 x1')
+    assert.notEqual(unitToWriteIn(forwardUnary('-', difference(storedUnits.population))), undefined)
+    // where minus a temperature is no reading at all: -50F and -10C are not the same one
+    assert.equal(unitToWriteIn(forwardUnary('-', temperature)), undefined)
     assert.equal(shape(forwardUnary('!', people)), 'unknown')
+})
+
+void test('a negated number is the negative of it, so that it scales the right way', () => {
+    assert.equal(shape(forward('*', people, forwardUnary('-', constant(2)))), 'person^1 times=-2 x1')
+    assert.equal(shape(forward('*', people, forwardUnary('+', constant(2)))), 'person^1 times=2 x1')
 })
 
 // Not knowing which unit something is in is a different thing from nothing being of any unit, and

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert/strict'
 import test from 'node:test'
 
 import { BinaryOperatorSymbol, infixOperators } from '../src/urban-stats-script/operators'
-import { backward, constant, forward, forwardUnary, inconsistent, inUnit, Known, unitToWriteIn, unknown } from '../src/urban-stats-script/unit-algebra'
+import { backward, constant, forward, forwardUnary, inUnit, Known, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
 import { StoredUnit } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
@@ -16,6 +16,8 @@ function shape(known: Known): string {
     return `${written === '' ? 'dimensionless' : written} times=${known.unit.unit.times} x${known.unit.toBaseUnits}`
 }
 
+const unknown: Known = { kind: 'any' }
+const inconsistent: Known = { kind: 'none' }
 const people = inUnit(storedUnits.population)
 const area = inUnit(storedUnits.area)
 const temperature = inUnit(storedUnits.temperature)

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -2,13 +2,13 @@ import assert from 'assert/strict'
 import test from 'node:test'
 
 import { BinaryOperatorSymbol, infixOperators } from '../src/urban-stats-script/operators'
-import { backward, constant, forward, forwardUnary, inUnit, Known, unitToWriteIn, unknown } from '../src/urban-stats-script/unit-algebra'
+import { backward, constant, forward, forwardUnary, inconsistent, inUnit, Known, unitToWriteIn, unknown } from '../src/urban-stats-script/unit-algebra'
 import { StoredUnit } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
 /** What is known, as a string: the dimensions, how many of itself it is, and its scale. */
 function shape(known: Known): string {
-    if (known.unit === undefined) return 'unknown'
+    if (known.kind !== 'in') return known.kind === 'any' ? 'unknown' : 'inconsistent'
     const written = [...known.unit.unit.dimensions]
         .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
         .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
@@ -37,7 +37,8 @@ void test('a bare number scales a quantity rather than being a quantity', () => 
 void test('only alike things add, and the sum is of their kind', () => {
     assert.equal(shape(forward('+', people, people)), 'person^1 times=2 x1')
     assert.equal(shape(forward('-', people, people)), 'person^1 times=0 x1')
-    assert.equal(shape(forward('+', people, area)), 'unknown')
+    // nothing is both people and an area, so nothing is their sum
+    assert.equal(shape(forward('+', people, area)), 'inconsistent')
 })
 
 void test('a side that says nothing is taken to be of the other side\'s kind', () => {
@@ -68,8 +69,11 @@ void test('two temperatures are not a temperature, and nothing writes them as on
 })
 
 void test('a temperature cannot be multiplied by another quantity', () => {
-    assert.equal(shape(forward('*', temperature, people)), 'unknown')
-    assert.equal(shape(forward('**', temperature, constant(2))), 'unknown')
+    // twice a temperature is two of them, which is carried, though it is not a temperature
+    assert.equal(shape(forward('*', temperature, constant(2))), 'F^1 times=2 x1')
+    // where there is no such quantity at all as a temperature times a population
+    assert.equal(shape(forward('*', temperature, people)), 'inconsistent')
+    assert.equal(shape(forward('**', temperature, constant(2))), 'inconsistent')
     // a difference of two of them may be, since it is measured from nothing
     assert.equal(shape(forward('*', difference(storedUnits.temperature), constant(2))), 'F^1 times=0 x1')
 })
@@ -116,4 +120,19 @@ void test('every operator answers in both directions, whatever it is given', () 
 void test('negating a quantity leaves it what it was, and not-ing it says nothing', () => {
     assert.equal(shape(forwardUnary('-', people)), 'person^1 times=1 x1')
     assert.equal(shape(forwardUnary('!', people)), 'unknown')
+})
+
+// Not knowing which unit something is in is a different thing from nothing being of any unit, and
+// the second is worth telling a script's author about where the first is not
+void test('what cannot be told apart from what cannot be', () => {
+    assert.equal(shape(unknown), 'unknown')
+    assert.equal(shape(inconsistent), 'inconsistent')
+    assert.equal(shape(forward('+', people, area)), 'inconsistent')
+    assert.equal(shape(forward('+', unknown, unknown)), 'unknown')
+    // and nothing computed from what cannot be is either
+    assert.equal(shape(forward('*', forward('+', people, area), constant(2))), 'inconsistent')
+    assert.equal(shape(backward('*', forward('+', people, area), people, 'left')), 'inconsistent')
+    // neither is written in anything, which is all the display asks
+    assert.equal(unitToWriteIn(unknown), undefined)
+    assert.equal(unitToWriteIn(inconsistent), undefined)
 })

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -1,8 +1,8 @@
 import assert from 'assert/strict'
 import test from 'node:test'
 
-import { BinaryOperatorSymbol, infixOperators } from '../src/urban-stats-script/operators'
-import { backward, constant, forward, forwardUnary, inUnit, AbstractInterpValue, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
+import { BinaryOperatorSymbol, infixOperators, unaryOperators } from '../src/urban-stats-script/operators'
+import { backward, backwardUnary, constant, forward, forwardUnary, inUnit, AbstractInterpValue, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
 import { StoredUnit } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
@@ -148,4 +148,13 @@ void test('what cannot be told apart from what cannot be', () => {
     // neither is written in anything, which is all the display asks
     assert.equal(unitToWriteIn(unknown), undefined)
     assert.equal(unitToWriteIn(inconsistent), undefined)
+})
+
+void test('a unary operator undoes itself, so the operand is found the same way', () => {
+    for (const operand of [unknown, people, temperature, constant(2), inconsistent]) {
+        for (const operator of unaryOperators) {
+            assert.equal(shape(backwardUnary(operator, forwardUnary(operator, operand))),
+                operator === '!' ? 'unknown' : shape(operand))
+        }
+    }
 })


### PR DESCRIPTION
Stacked on #2297; the diff shown is against it. Second piece of #2216.

Inference needs both directions. Forwards gives the unit of a computed column. Backwards is what reads the `0.1` of `commute_bike < 0.1` as ten percent, since a bare number is in whatever unit the thing it is written against is in — and that is what the captions need.

## The domain

```ts
export interface Known {
    unit?: StoredUnit
    constant?: number
}
```

Knowing nothing is an ordinary member of it rather than a failure to be one, so every expression has an answer and no operation can fail. A test runs every operator over every combination of unknown, a quantity, a temperature and two constants, in all three directions, and asserts none of them throws.

Constants are in the domain because coefficients need them: `(t1 + t2) / 2` is only a temperature if the `2` is visible to the algebra.

## Three shapes, not thirteen cases

Every operator is one of:

| shape | operators | how the slots relate |
|---|---|---|
| same unit | `+ - == != < > <= >=` | every slot is the same unit; the operands' coefficients combine into the result's |
| product | `* /` | the operands' dimensions add, or subtract |
| power | `**` | the exponent has to be a constant |
| opaque | `& \|` | nothing relates them |

A bare number is dimensionless under *product* and takes the other side's unit under *same unit*, which is why `pop * 2` and `pop + 2` differ — the form decides, not the literal.

Solving for an operand is running the operator that undoes it, so `backward` is four lines over `forward` rather than a second set of rules to keep in step:

```ts
const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
```

## Coefficients are checked where they are used, not as they go

`t1 + t2` is two temperatures, which is not a temperature — but their mean is one again. Rejecting the sum on the way past would lose that, so the algebra carries whatever coefficient comes out and `unitToWriteIn` applies the constraint at the end:

```
t1 - t2            F^1 times=0     a number of degrees
t1 + t2            F^1 times=2     carried, but nothing writes it
(t1 + t2) / 2      F^1 times=1     a temperature again
t + 2              F^1 times=1     a temperature, the 2 being degrees
```

## Verification

`tsc`, lint, knip, 612 unit tests, thirteen of them new. The rendering sweep is unchanged: nothing here is reachable from a statistic yet.

Next is the walk over the AST, then the two entry points, then captions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
