### PR TITLE
Say what an expression is in, and what its operands must be

### DIFF
--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -1,5 +1,5 @@
 import { assert } from '../utils/defensive'
-import { Decoration, dimensionless, Party, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
+import { Decoration, dimensionless, Party, sameDimensions, snapToWhole, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
 
 import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 
@@ -60,8 +60,8 @@ function sharedDecoration(left: Decoration, right: Decoration): Decoration {
     return { kind: 'none' }
 }
 
-function withTimes(unit: StoredUnit, times: number): AbstractInterpValue {
-    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
+function written(unit: StoredUnit, times: number, decoration = unit.unit.decoration): AbstractInterpValue {
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, decoration, times: snapToWhole(times) } } }
 }
 
 /** How an operator's slots relate, which is what both directions are read off. */
@@ -98,24 +98,20 @@ function addedForward(form: { combine: (left: number, right: number) => number }
     // a side saying nothing is taken to be of the other's kind, since only alike things add; a
     // bare number added to a temperature is a number of degrees
     if (left.kind === 'any') {
-        return right.kind === 'any' ? { kind: 'any' } : withTimes(right.unit, form.combine(0, right.unit.unit.times))
+        return right.kind === 'any' ? { kind: 'any' } : written(right.unit, form.combine(0, right.unit.unit.times))
     }
     if (right.kind === 'any') {
-        return withTimes(left.unit, form.combine(left.unit.unit.times, 0))
+        return written(left.unit, form.combine(left.unit.unit.times, 0))
     }
     // nothing is both people and an area, so nothing is their sum
     if (!sameDimensions(left.unit, right.unit)) {
         return { kind: 'none' }
     }
-    const unit = {
-        ...left.unit,
-        unit: {
-            ...left.unit.unit,
-            decoration: sharedDecoration(left.unit.unit.decoration, right.unit.unit.decoration),
-            times: form.combine(left.unit.unit.times, right.unit.unit.times),
-        },
-    }
-    return { kind: 'in', unit }
+    return written(
+        left.unit,
+        form.combine(left.unit.unit.times, right.unit.unit.times),
+        sharedDecoration(left.unit.unit.decoration, right.unit.unit.decoration),
+    )
 }
 
 function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
@@ -125,7 +121,7 @@ function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): Ab
         }
         // scaling a quantity scales how many of itself it is: half of two temperatures is one
         if (rightPower === 1) {
-            return withTimes(right.unit, right.unit.unit.times * left.constant)
+            return written(right.unit, right.unit.unit.times * left.constant)
         }
         // where a number over a quantity is not that many of it, but one over it
         const inverted = unitProduct(dimensionless, right.unit, -1)
@@ -134,7 +130,7 @@ function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): Ab
     if (right.kind === 'any') {
         return right.constant === undefined
             ? { kind: 'any' }
-            : withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
+            : written(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
     }
     const product = unitProduct(left.unit, right.unit, rightPower)
     return product === undefined ? { kind: 'none' } : { kind: 'in', unit: product }
@@ -219,6 +215,6 @@ export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInt
     if (operand.kind === 'any') {
         return { kind: 'any', constant: negated }
     }
-    const { unit } = operand
-    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times: -unit.unit.times } }, constant: negated }
+    const negatedTimes = written(operand.unit, -operand.unit.unit.times)
+    return negatedTimes.kind === 'in' ? { ...negatedTimes, constant: negated } : negatedTimes
 }

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -1,5 +1,5 @@
 import { assert } from '../utils/defensive'
-import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
+import { Decoration, dimensionless, Party, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
 
 import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
 
@@ -35,6 +35,30 @@ export function unitToWriteIn(known: AbstractInterpValue): StoredUnit | undefine
 
 /** What an operand can be, once forward and backward have refused what came from nothing. */
 type KnownAIV = Exclude<AbstractInterpValue, { kind: 'none' }>
+
+function sameParty(left: Party | undefined, right: Party | undefined): boolean {
+    if (left === undefined || right === undefined) {
+        return left === right
+    }
+    if (left.kind === 'color' && right.kind === 'color') {
+        return left.hue === right.hue
+    }
+    return left.kind === 'lead' && right.kind === 'lead' && left.system === right.system
+}
+
+/**
+ * What both sides were dressed in, where that is the same thing. An orange share less a red one is
+ * a share of no party, and a lead less a share is not a lead: whose it is does not survive.
+ */
+function sharedDecoration(left: Decoration, right: Decoration): Decoration {
+    if (left.kind === 'percent' && right.kind === 'percent') {
+        return sameParty(left.party, right.party) ? left : { kind: 'percent' }
+    }
+    if (left.kind === 'writtenIn' && right.kind === 'writtenIn' && left.in === right.in) {
+        return left
+    }
+    return { kind: 'none' }
+}
 
 function withTimes(unit: StoredUnit, times: number): AbstractInterpValue {
     return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
@@ -83,7 +107,15 @@ function addedForward(form: { combine: (left: number, right: number) => number }
     if (!sameDimensions(left.unit, right.unit)) {
         return { kind: 'none' }
     }
-    return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
+    const unit = {
+        ...left.unit,
+        unit: {
+            ...left.unit.unit,
+            decoration: sharedDecoration(left.unit.unit.decoration, right.unit.unit.decoration),
+            times: form.combine(left.unit.unit.times, right.unit.unit.times),
+        },
+    }
+    return { kind: 'in', unit }
 }
 
 function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): AbstractInterpValue {

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -1,0 +1,192 @@
+import { assert } from '../utils/defensive'
+import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../utils/quantity'
+
+import { BinaryOperatorSymbol, UnaryOperatorSymbol } from './operators'
+
+/** `any` is that it could be in any unit; `none` is that no quantity is of it, as people plus an area. */
+export type AbstractInterpValue = (
+    { kind: 'any', constant?: number }
+    | { kind: 'none' }
+    | { kind: 'in', unit: StoredUnit, constant?: number }
+)
+
+export function constant(value: number): AbstractInterpValue {
+    return { kind: 'any', constant: value }
+}
+
+export function inUnit(unit: StoredUnit): AbstractInterpValue {
+    return { kind: 'in', unit }
+}
+
+/**
+ * Asked at the end rather than at every step: two temperatures added are neither one temperature
+ * nor none, but their mean is one again, and refusing the sum on the way past would lose that.
+ */
+export function unitToWriteIn(known: AbstractInterpValue): StoredUnit | undefined {
+    if (known.kind !== 'in') {
+        return undefined
+    }
+    const { unit } = known
+    if (!unit.unit.baseIsScalar && unit.unit.times !== 0 && unit.unit.times !== 1) {
+        return undefined
+    }
+    return unit
+}
+
+/** What an operand can be, once forward and backward have refused what came from nothing. */
+type KnownAIV = Exclude<AbstractInterpValue, { kind: 'none' }>
+
+function withTimes(unit: StoredUnit, times: number): AbstractInterpValue {
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times } } }
+}
+
+/** How an operator's slots relate, which is what both directions are read off. */
+type Form =
+    /** Every slot is the same unit, and the operands' coefficients combine into the result's. */
+    | { kind: 'sameUnit', combine: (left: number, right: number) => number, keepsUnit: boolean }
+    /** The operands' dimensions add, or subtract where the right is taken to the power -1. */
+    | { kind: 'product', rightPower: 1 | -1 }
+    /** The left raised to the right, which has to be a constant for anything to be said. */
+    | { kind: 'power' }
+    /** Nothing relates the slots. */
+    | { kind: 'opaque' }
+
+const comparison: Form = { kind: 'sameUnit', combine: () => 0, keepsUnit: false }
+
+const forms: Record<BinaryOperatorSymbol, Form> = {
+    '+': { kind: 'sameUnit', combine: (left, right) => left + right, keepsUnit: true },
+    '-': { kind: 'sameUnit', combine: (left, right) => left - right, keepsUnit: true },
+    // between two of the same kind, and itself of no kind
+    '==': comparison,
+    '!=': comparison,
+    '<': comparison,
+    '>': comparison,
+    '<=': comparison,
+    '>=': comparison,
+    '*': { kind: 'product', rightPower: 1 },
+    '/': { kind: 'product', rightPower: -1 },
+    '**': { kind: 'power' },
+    '&': { kind: 'opaque' },
+    '|': { kind: 'opaque' },
+}
+
+function addedForward(form: { combine: (left: number, right: number) => number }, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
+    // a side saying nothing is taken to be of the other's kind, since only alike things add; a
+    // bare number added to a temperature is a number of degrees
+    if (left.kind === 'any') {
+        return right.kind === 'any' ? { kind: 'any' } : withTimes(right.unit, form.combine(0, right.unit.unit.times))
+    }
+    if (right.kind === 'any') {
+        return withTimes(left.unit, form.combine(left.unit.unit.times, 0))
+    }
+    // nothing is both people and an area, so nothing is their sum
+    if (!sameDimensions(left.unit, right.unit)) {
+        return { kind: 'none' }
+    }
+    return withTimes(left.unit, form.combine(left.unit.unit.times, right.unit.unit.times))
+}
+
+function productForward(rightPower: 1 | -1, left: KnownAIV, right: KnownAIV): AbstractInterpValue {
+    if (left.kind === 'any') {
+        if (right.kind === 'any' || left.constant === undefined) {
+            return { kind: 'any' }
+        }
+        // scaling a quantity scales how many of itself it is: half of two temperatures is one
+        if (rightPower === 1) {
+            return withTimes(right.unit, right.unit.unit.times * left.constant)
+        }
+        // where a number over a quantity is not that many of it, but one over it
+        const inverted = unitProduct(dimensionless, right.unit, -1)
+        return inverted === undefined ? { kind: 'none' } : { kind: 'in', unit: inverted }
+    }
+    if (right.kind === 'any') {
+        return right.constant === undefined
+            ? { kind: 'any' }
+            : withTimes(left.unit, left.unit.unit.times * (rightPower === 1 ? right.constant : 1 / right.constant))
+    }
+    const product = unitProduct(left.unit, right.unit, rightPower)
+    return product === undefined ? { kind: 'none' } : { kind: 'in', unit: product }
+}
+
+export function forward(operator: BinaryOperatorSymbol, left: AbstractInterpValue, right: AbstractInterpValue): AbstractInterpValue {
+    // nothing computed from what cannot be, can be
+    if (left.kind === 'none' || right.kind === 'none') {
+        return { kind: 'none' }
+    }
+    const form = forms[operator]
+    switch (form.kind) {
+        case 'opaque':
+            return { kind: 'any' }
+        case 'sameUnit':
+            return form.keepsUnit ? addedForward(form, left, right) : { kind: 'any' }
+        case 'product':
+            return productForward(form.rightPower, left, right)
+        case 'power': {
+            if (left.kind !== 'in' || right.kind !== 'any' || right.constant === undefined) {
+                return { kind: 'any' }
+            }
+            const raised = unitPower(left.unit, right.constant)
+            return raised === undefined ? { kind: 'none' } : { kind: 'in', unit: raised }
+        }
+    }
+}
+
+const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
+
+/** Solving an operator for one of its operands is running the operator that undoes it. */
+function undo(operator: keyof typeof inverses, result: AbstractInterpValue, known: AbstractInterpValue, side: 'left' | 'right'): AbstractInterpValue {
+    if (side === 'left') {
+        return forward(inverses[operator], result, known)
+    }
+    // the right of a sum or a product is found the same way; of a difference or a quotient, the
+    // operands change places, since the right of `a - b` is `a - result` rather than `result - a`
+    return operator === '+' || operator === '*'
+        ? forward(inverses[operator], result, known)
+        : forward(operator, known, result)
+}
+
+/** How the 0.1 of `commute_bike < 0.1` is read as ten percent. */
+export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpValue, known: AbstractInterpValue, side: 'left' | 'right'): AbstractInterpValue {
+    if (result.kind === 'none' || known.kind === 'none') {
+        return { kind: 'none' }
+    }
+    const form = forms[operator]
+    switch (form.kind) {
+        case 'opaque':
+        // a power is undone by a root, which is not one of these operators
+        case 'power':
+            return { kind: 'any' }
+        case 'sameUnit':
+            if (!form.keepsUnit) {
+                // a comparison says nothing of its own kind, but its operands are of each other's
+                return known
+            }
+            assert(operator === '+' || operator === '-', `${operator} keeps the unit of what it adds`)
+            return undo(operator, result, known, side)
+        case 'product':
+            assert(operator === '*' || operator === '/', `${operator} is a product`)
+            return undo(operator, result, known, side)
+    }
+}
+
+/** Each of these undoes itself: negating twice, or leaving alone twice, is what was there. */
+export function backwardUnary(operator: UnaryOperatorSymbol, result: AbstractInterpValue): AbstractInterpValue {
+    return forwardUnary(operator, result)
+}
+
+export function forwardUnary(operator: UnaryOperatorSymbol, operand: AbstractInterpValue): AbstractInterpValue {
+    if (operator === '!') {
+        return { kind: 'any' }
+    }
+    if (operator === '+' || operand.kind === 'none') {
+        return operand
+    }
+    // negating takes it from nothing, so a level becomes minus one of itself, which a temperature
+    // has no reading for, where a difference of two is still one
+    const negated = operand.constant === undefined ? undefined : -operand.constant
+    if (operand.kind === 'any') {
+        return { kind: 'any', constant: negated }
+    }
+    const { unit } = operand
+    return { kind: 'in', unit: { ...unit, unit: { ...unit.unit, times: -unit.unit.times } }, constant: negated }
+}

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -258,7 +258,50 @@ function product(written: Written[]): HumanReadableElement[] {
     ])
 }
 
-/** The names of the units chosen. The ones with no name of their own are left out. */
+function computedUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit {
+    return { unit: { dimensions, decoration: { kind: 'none' }, times: 1, baseIsScalar: true }, toBaseUnits }
+}
+
+export const dimensionless = computedUnit([], 1)
+
+/** Each base unit counted once, and the ones that cancelled left out. */
+function gathered(dimensions: Dimension[]): Dimension[] {
+    const totals = new Map<BaseUnit, number>()
+    for (const { baseUnit, power } of dimensions) {
+        totals.set(baseUnit, (totals.get(baseUnit) ?? 0) + power)
+    }
+    return [...totals].filter(([, power]) => power !== 0).map(([baseUnit, power]) => ({ baseUnit, power }))
+}
+
+export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {
+    return renderAsKey(gathered(left.unit.dimensions)) === renderAsKey(gathered(right.unit.dimensions))
+}
+
+/**
+ * A quotient is the right taken to the power -1. Neither side may be measured from a zero of its
+ * own: how many temperatures twice one is depends on the two of them, not on their units.
+ */
+export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined {
+    if (!left.unit.baseIsScalar || !right.unit.baseIsScalar) {
+        return undefined
+    }
+    const [over, under] = [left.unit.dimensions, right.unit.dimensions]
+    const dimensions = [...over, ...under.map(({ baseUnit, power }) => ({ baseUnit, power: power * rightPower }))]
+    const toBaseUnits = rightPower === 1
+        ? left.toBaseUnits * right.toBaseUnits
+        : left.toBaseUnits / right.toBaseUnits
+    return computedUnit(gathered(dimensions), toBaseUnits)
+}
+
+/** A length squared is an area. */
+export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined {
+    if (!stored.unit.baseIsScalar) {
+        return undefined
+    }
+    const raised = stored.unit.dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))
+    return computedUnit(gathered(raised), Math.pow(stored.toBaseUnits, exponent))
+}
+
 export function nameOf(written: Written[]): HumanReadableElement[] {
     const named = written.filter(({ unit }) => unit.name !== '')
     const over = named.filter(({ power }) => power > 0)

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -264,7 +264,6 @@ function computedUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit 
 
 export const dimensionless = computedUnit([], 1)
 
-/** Each base unit counted once, and the ones that cancelled left out. */
 function gathered(dimensions: Dimension[]): Dimension[] {
     const totals = new Map<BaseUnit, number>()
     for (const { baseUnit, power } of dimensions) {
@@ -277,10 +276,6 @@ export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {
     return renderAsKey(gathered(left.unit.dimensions)) === renderAsKey(gathered(right.unit.dimensions))
 }
 
-/**
- * A quotient is the right taken to the power -1. Neither side may be measured from a zero of its
- * own: how many temperatures twice one is depends on the two of them, not on their units.
- */
 export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined {
     if (!left.unit.baseIsScalar || !right.unit.baseIsScalar) {
         return undefined
@@ -293,7 +288,6 @@ export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 |
     return computedUnit(gathered(dimensions), toBaseUnits)
 }
 
-/** A length squared is an area. */
 export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined {
     if (!stored.unit.baseIsScalar) {
         return undefined

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -264,12 +264,22 @@ function computedUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit 
 
 export const dimensionless = computedUnit([], 1)
 
+/**
+ * A power that arithmetic has left a hair off a whole one: a cube raised to a tenth and then to
+ * ten comes back as 3.0000000000000004, which is no dimension anything is written in.
+ */
+function snapToWhole(value: number): number {
+    return Math.abs(value - Math.round(value)) < 1e-9 ? Math.round(value) : value
+}
+
 function gathered(dimensions: Dimension[]): Dimension[] {
     const totals = new Map<BaseUnit, number>()
     for (const { baseUnit, power } of dimensions) {
         totals.set(baseUnit, (totals.get(baseUnit) ?? 0) + power)
     }
-    return [...totals].filter(([, power]) => power !== 0).map(([baseUnit, power]) => ({ baseUnit, power }))
+    return [...totals]
+        .map(([baseUnit, power]): Dimension => ({ baseUnit, power: snapToWhole(power) }))
+        .filter(({ power }) => power !== 0)
 }
 
 export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -268,7 +268,7 @@ export const dimensionless = computedUnit([], 1)
  * A power that arithmetic has left a hair off a whole one: a cube raised to a tenth and then to
  * ten comes back as 3.0000000000000004, which is no dimension anything is written in.
  */
-function snapToWhole(value: number): number {
+export function snapToWhole(value: number): number {
     return Math.abs(value - Math.round(value)) < 1e-9 ? Math.round(value) : value
 }
 

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -206,3 +206,14 @@ for (const [level, declared] of [
         assert.equal(write(inferred!), write(storedUnits[declared]))
     })
 }
+
+void test('a coefficient that comes back a hair off a whole one is the whole one', () => {
+    // 49 * (1/49) is 0.9999999999999999, so the mean of 49 temperatures would be no temperature
+    let sum = temperature
+    for (let count = 1; count < 49; count++) {
+        sum = forward('+', sum, temperature)
+    }
+    const mean = forward('*', sum, constant(1 / 49))
+    assert.equal(shape(mean), 'F^1 times=1 x1')
+    assert.notEqual(unitToWriteIn(mean), undefined)
+})

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -1,0 +1,160 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { BinaryOperatorSymbol, infixOperators, unaryOperators } from '../src/urban-stats-script/operators'
+import { backward, backwardUnary, constant, forward, forwardUnary, inUnit, AbstractInterpValue, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
+import { StoredUnit } from '../src/utils/quantity'
+import { storedUnits } from '../src/utils/unit'
+
+/** What is known, as a string: the dimensions, how many of itself it is, and its scale. */
+function shape(known: AbstractInterpValue): string {
+    if (known.kind !== 'in') return known.kind === 'any' ? 'unknown' : 'inconsistent'
+    const written = [...known.unit.unit.dimensions]
+        .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+    return `${written === '' ? 'dimensionless' : written} times=${known.unit.unit.times} x${known.unit.toBaseUnits}`
+}
+
+const unknown: AbstractInterpValue = { kind: 'any' }
+const inconsistent: AbstractInterpValue = { kind: 'none' }
+const people = inUnit(storedUnits.population)
+const area = inUnit(storedUnits.area)
+const temperature = inUnit(storedUnits.temperature)
+const difference = (of: StoredUnit): AbstractInterpValue => inUnit({ ...of, unit: { ...of.unit, times: 0 } })
+
+void test('a product adds dimensions and a quotient subtracts them', () => {
+    assert.equal(shape(forward('*', people, area)), 'm^2 person^1 times=1 x1000000')
+    assert.equal(shape(forward('/', people, area)), 'm^-2 person^1 times=1 x0.000001')
+    assert.equal(shape(forward('/', people, people)), 'dimensionless times=1 x1')
+})
+
+void test('a bare number scales a quantity rather than being a quantity', () => {
+    assert.equal(shape(forward('*', people, constant(2))), 'person^1 times=2 x1')
+    assert.equal(shape(forward('*', constant(2), people)), 'person^1 times=2 x1')
+    // and a number over a quantity is one over it, not that many of it
+    assert.equal(shape(forward('/', constant(1), people)), 'person^-1 times=1 x1')
+})
+
+void test('only alike things add, and the sum is of their kind', () => {
+    assert.equal(shape(forward('+', people, people)), 'person^1 times=2 x1')
+    assert.equal(shape(forward('-', people, people)), 'person^1 times=0 x1')
+    // nothing is both people and an area, so nothing is their sum
+    assert.equal(shape(forward('+', people, area)), 'inconsistent')
+})
+
+void test('a side that says nothing is taken to be of the other side\'s kind', () => {
+    assert.equal(shape(forward('+', people, unknown)), 'person^1 times=1 x1')
+    assert.equal(shape(forward('+', unknown, people)), 'person^1 times=1 x1')
+    assert.equal(shape(forward('+', unknown, unknown)), 'unknown')
+})
+
+void test('a temperature is one of itself, and only stays a quantity while it is one or none', () => {
+    assert.equal(shape(temperature), 'F^1 times=1 x1')
+    // a difference of two temperatures is none of one, which is a quantity of degrees
+    assert.equal(shape(forward('-', temperature, temperature)), 'F^1 times=0 x1')
+    // their sum is two temperatures, which is carried along even though it is not one
+    assert.equal(shape(forward('+', temperature, temperature)), 'F^1 times=2 x1')
+    // because their mean is a temperature again
+    assert.equal(shape(forward('/', forward('+', temperature, temperature), constant(2))), 'F^1 times=1 x1')
+    // and a number of degrees added to one is a temperature
+    assert.equal(shape(forward('+', temperature, constant(2))), 'F^1 times=1 x1')
+})
+
+void test('two temperatures are not a temperature, and nothing writes them as one', () => {
+    assert.equal(unitToWriteIn(forward('+', temperature, temperature)), undefined)
+    assert.equal(unitToWriteIn(forward('*', temperature, constant(2))), undefined)
+    // where a mean of them, and a difference, are things to write
+    assert.notEqual(unitToWriteIn(forward('/', forward('+', temperature, temperature), constant(2))), undefined)
+    assert.notEqual(unitToWriteIn(forward('-', temperature, temperature)), undefined)
+    assert.notEqual(unitToWriteIn(people), undefined)
+})
+
+void test('a temperature cannot be multiplied by another quantity', () => {
+    // twice a temperature is two of them, which is carried, though it is not a temperature
+    assert.equal(shape(forward('*', temperature, constant(2))), 'F^1 times=2 x1')
+    // where there is no such quantity at all as a temperature times a population
+    assert.equal(shape(forward('*', temperature, people)), 'inconsistent')
+    assert.equal(shape(forward('**', temperature, constant(2))), 'inconsistent')
+    // a difference of two of them may be, since it is measured from nothing
+    assert.equal(shape(forward('*', difference(storedUnits.temperature), constant(2))), 'F^1 times=0 x1')
+})
+
+void test('a power needs its exponent to be a constant', () => {
+    assert.equal(shape(forward('**', inUnit(storedUnits.distanceInKm), constant(2))), 'm^2 times=1 x1000000')
+    assert.equal(shape(forward('**', inUnit(storedUnits.distanceInKm), people)), 'unknown')
+})
+
+void test('a comparison is of no kind, and its operands are of each other\'s', () => {
+    assert.equal(shape(forward('<', people, constant(2))), 'unknown')
+    assert.equal(shape(backward('<', unknown, people, 'right')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('==', unknown, area, 'left')), 'm^2 times=1 x1000000')
+})
+
+void test('an operand is found by undoing the operator', () => {
+    const perArea = forward('/', people, area)
+    assert.equal(shape(backward('/', perArea, area, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('/', perArea, people, 'right')), 'm^2 times=1 x1000000')
+    const total = forward('*', people, area)
+    assert.equal(shape(backward('*', total, area, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('*', total, people, 'right')), 'm^2 times=1 x1000000')
+})
+
+void test('a difference gives back the level it was taken from', () => {
+    const change = forward('-', people, people)
+    assert.equal(shape(backward('-', change, people, 'left')), 'person^1 times=1 x1')
+    assert.equal(shape(backward('+', people, difference(storedUnits.population), 'left')), 'person^1 times=1 x1')
+})
+
+void test('every operator answers in both directions, whatever it is given', () => {
+    const inputs = [unknown, people, temperature, constant(2), constant(0)]
+    for (const operator of infixOperators satisfies readonly BinaryOperatorSymbol[]) {
+        for (const left of inputs) {
+            for (const right of inputs) {
+                assert.doesNotThrow(() => forward(operator, left, right))
+                assert.doesNotThrow(() => backward(operator, left, right, 'left'))
+                assert.doesNotThrow(() => backward(operator, left, right, 'right'))
+            }
+        }
+    }
+})
+
+void test('negating takes a quantity from nothing, which is not what it was', () => {
+    assert.equal(shape(forwardUnary('+', people)), 'person^1 times=1 x1')
+    assert.equal(shape(forwardUnary('-', people)), 'person^1 times=-1 x1')
+    // a difference of two is one however it is signed, so it stays one to write
+    assert.equal(shape(forwardUnary('-', difference(storedUnits.population))), 'person^1 times=0 x1')
+    assert.notEqual(unitToWriteIn(forwardUnary('-', difference(storedUnits.population))), undefined)
+    // where minus a temperature is no reading at all: -50F and -10C are not the same one
+    assert.equal(unitToWriteIn(forwardUnary('-', temperature)), undefined)
+    assert.equal(shape(forwardUnary('!', people)), 'unknown')
+})
+
+void test('a negated number is the negative of it, so that it scales the right way', () => {
+    assert.equal(shape(forward('*', people, forwardUnary('-', constant(2)))), 'person^1 times=-2 x1')
+    assert.equal(shape(forward('*', people, forwardUnary('+', constant(2)))), 'person^1 times=2 x1')
+})
+
+// Not knowing which unit something is in is a different thing from nothing being of any unit, and
+// the second is worth telling a script's author about where the first is not
+void test('what cannot be told apart from what cannot be', () => {
+    assert.equal(shape(unknown), 'unknown')
+    assert.equal(shape(inconsistent), 'inconsistent')
+    assert.equal(shape(forward('+', people, area)), 'inconsistent')
+    assert.equal(shape(forward('+', unknown, unknown)), 'unknown')
+    // and nothing computed from what cannot be is either
+    assert.equal(shape(forward('*', forward('+', people, area), constant(2))), 'inconsistent')
+    assert.equal(shape(backward('*', forward('+', people, area), people, 'left')), 'inconsistent')
+    // neither is written in anything, which is all the display asks
+    assert.equal(unitToWriteIn(unknown), undefined)
+    assert.equal(unitToWriteIn(inconsistent), undefined)
+})
+
+void test('a unary operator undoes itself, so the operand is found the same way', () => {
+    for (const operand of [unknown, people, temperature, constant(2), inconsistent]) {
+        for (const operator of unaryOperators) {
+            assert.equal(shape(backwardUnary(operator, forwardUnary(operator, operand))),
+                operator === '!' ? 'unknown' : shape(operand))
+        }
+    }
+})

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -3,7 +3,8 @@ import test from 'node:test'
 
 import { BinaryOperatorSymbol, infixOperators, unaryOperators } from '../src/urban-stats-script/operators'
 import { backward, backwardUnary, constant, forward, forwardUnary, inUnit, AbstractInterpValue, unitToWriteIn } from '../src/urban-stats-script/unit-algebra'
-import { StoredUnit } from '../src/utils/quantity'
+import { reifyString } from '../src/utils/human-readable-name'
+import { StoredUnit, writeQuantity } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
 /** What is known, as a string: the dimensions, how many of itself it is, and its scale. */
@@ -187,3 +188,21 @@ void test('scaling a share leaves it the party\'s that it was', () => {
     assert.equal(partyOf(forward('-', inUnit(storedUnits.partyPctOrange), constant(0.05))), 'orange')
 })
 /* eslint-enable no-restricted-syntax */
+
+// Taking a level from a level leaves a difference, and the site declares some of those already:
+// what is inferred for one of them is what was declared for it
+for (const [level, declared] of [
+    ['partyPctOrange', 'partyChangeOrange'],
+    ['partyPctBlue', 'partyChangeBlue'],
+    ['percentage', 'percentageChange'],
+] as const) {
+    void test(`${level} less itself is written as ${declared} is`, () => {
+        const inferred = unitToWriteIn(forward('-', inUnit(storedUnits[level]), inUnit(storedUnits[level])))
+        assert.notEqual(inferred, undefined)
+        const write = (stored: StoredUnit): string => {
+            const written = writeQuantity(0.05, stored)
+            return `${written.renderedValue}${reifyString(written.unitName)} ${written.hue ?? ''}`
+        }
+        assert.equal(write(inferred!), write(storedUnits[declared]))
+    })
+}

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -158,3 +158,32 @@ void test('a unary operator undoes itself, so the operand is found the same way'
         }
     }
 })
+
+// Whose a quantity is survives a sum only where both sides are the same party's: an orange share
+// less a red one belongs to neither, and a lead less a share is no lead at all
+/* eslint-disable no-restricted-syntax -- these name the theme's hues, they are not css colors */
+function partyOf(value: AbstractInterpValue): string {
+    if (value.kind !== 'in') return value.kind
+    const { decoration } = value.unit.unit
+    if (decoration.kind !== 'percent') return decoration.kind
+    if (decoration.party === undefined) return 'percent'
+    return decoration.party.kind === 'color' ? decoration.party.hue : `lead ${decoration.party.system}`
+}
+
+for (const [label, left, right, expected] of [
+    ['a share less the same party\'s', storedUnits.partyPctOrange, storedUnits.partyPctOrange, 'orange'],
+    ['a share less another party\'s', storedUnits.partyPctOrange, storedUnits.partyPctRed, 'percent'],
+    ['a share less a plain percentage', storedUnits.partyPctOrange, storedUnits.percentage, 'percent'],
+    ['a lead less a percentage', storedUnits.democraticMargin, storedUnits.percentage, 'percent'],
+    ['a density less a density', storedUnits.density, storedUnits.density, 'writtenIn'],
+] as const) {
+    void test(`${label} is written as ${expected}`, () => {
+        assert.equal(partyOf(forward('-', inUnit(left), inUnit(right))), expected)
+    })
+}
+
+void test('scaling a share leaves it the party\'s that it was', () => {
+    assert.equal(partyOf(forward('*', inUnit(storedUnits.partyPctOrange), constant(2))), 'orange')
+    assert.equal(partyOf(forward('-', inUnit(storedUnits.partyPctOrange), constant(0.05))), 'orange')
+})
+/* eslint-enable no-restricted-syntax */

--- a/react/unit/unit-arithmetic.test.ts
+++ b/react/unit/unit-arithmetic.test.ts
@@ -4,7 +4,6 @@ import test from 'node:test'
 import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../src/utils/quantity'
 import { storedUnits } from '../src/utils/unit'
 
-/** The dimensions and scale of a unit, as a string, so that a test can say what it expects. */
 function shape(stored: StoredUnit | undefined): string {
     if (stored === undefined) return 'none'
     const written = [...stored.unit.dimensions]
@@ -15,7 +14,6 @@ function shape(stored: StoredUnit | undefined): string {
 }
 
 void test('a product adds the dimensions and multiplies what they are stored in', () => {
-    // people per km^2 times km^2 is people: 1e-6 * 1e6
     assert.equal(shape(unitProduct(storedUnits.density, storedUnits.area, 1)), 'person^1 x1')
     assert.equal(shape(unitProduct(storedUnits.population, storedUnits.area, 1)), 'm^2 person^1 x1000000')
 })
@@ -31,7 +29,6 @@ void test('dimensions that cancel are gone rather than left at nothing', () => {
 })
 
 void test('a power raises the dimensions and the scale together', () => {
-    // a kilometer squared is a million square meters
     assert.equal(shape(unitPower(storedUnits.distanceInKm, 2)), 'm^2 x1000000')
     assert.equal(shape(unitPower(storedUnits.distanceInKm, -1)), 'm^-1 x0.001')
     assert.equal(shape(unitPower(storedUnits.population, 0)), 'dimensionless x1')
@@ -50,7 +47,6 @@ void test('two temperatures are the same kind of thing, so one can be taken from
 })
 
 void test('a quantity measured from its own zero cannot be multiplied or raised', () => {
-    // how many temperatures twice a temperature is depends on the two, not on the units
     assert.equal(shape(unitProduct(storedUnits.temperature, storedUnits.population, 1)), 'none')
     assert.equal(shape(unitProduct(storedUnits.population, storedUnits.temperature, -1)), 'none')
     assert.equal(shape(unitPower(storedUnits.temperature, 2)), 'none')
@@ -58,6 +54,5 @@ void test('a quantity measured from its own zero cannot be multiplied or raised'
 
 void test('what a statistic is written in does not survive being computed with', () => {
     assert.equal(unitProduct(storedUnits.population, storedUnits.area, -1)?.unit.decoration.kind, 'none')
-    // where the density statistic itself keeps its km^2
     assert.equal(storedUnits.density.unit.decoration.kind, 'writtenIn')
 })

--- a/react/unit/unit-arithmetic.test.ts
+++ b/react/unit/unit-arithmetic.test.ts
@@ -1,0 +1,63 @@
+import assert from 'assert/strict'
+import test from 'node:test'
+
+import { dimensionless, sameDimensions, StoredUnit, unitPower, unitProduct } from '../src/utils/quantity'
+import { storedUnits } from '../src/utils/unit'
+
+/** The dimensions and scale of a unit, as a string, so that a test can say what it expects. */
+function shape(stored: StoredUnit | undefined): string {
+    if (stored === undefined) return 'none'
+    const written = [...stored.unit.dimensions]
+        .sort((a, b) => a.baseUnit.localeCompare(b.baseUnit))
+        .map(({ baseUnit, power }) => `${baseUnit}^${power}`)
+        .join(' ')
+    return `${written === '' ? 'dimensionless' : written} x${stored.toBaseUnits}`
+}
+
+void test('a product adds the dimensions and multiplies what they are stored in', () => {
+    // people per km^2 times km^2 is people: 1e-6 * 1e6
+    assert.equal(shape(unitProduct(storedUnits.density, storedUnits.area, 1)), 'person^1 x1')
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.area, 1)), 'm^2 person^1 x1000000')
+})
+
+void test('a quotient subtracts them', () => {
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.area, -1)), 'm^-2 person^1 x0.000001')
+    assert.equal(shape(unitProduct(storedUnits.fatalities, storedUnits.population, -1)), 'fatality^1 person^-1 x1')
+})
+
+void test('dimensions that cancel are gone rather than left at nothing', () => {
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.population, -1)), 'dimensionless x1')
+    assert.equal(shape(unitProduct(storedUnits.distanceInKm, storedUnits.distanceInM, -1)), 'dimensionless x1000')
+})
+
+void test('a power raises the dimensions and the scale together', () => {
+    // a kilometer squared is a million square meters
+    assert.equal(shape(unitPower(storedUnits.distanceInKm, 2)), 'm^2 x1000000')
+    assert.equal(shape(unitPower(storedUnits.distanceInKm, -1)), 'm^-1 x0.001')
+    assert.equal(shape(unitPower(storedUnits.population, 0)), 'dimensionless x1')
+})
+
+void test('two quantities of the same kind can be told from two of different kinds', () => {
+    assert.ok(sameDimensions(storedUnits.distanceInKm, storedUnits.distanceInM))
+    assert.ok(sameDimensions(storedUnits.number, dimensionless))
+    assert.ok(!sameDimensions(storedUnits.population, storedUnits.fatalities))
+    assert.ok(!sameDimensions(storedUnits.area, storedUnits.distanceInM))
+})
+
+void test('two temperatures are the same kind of thing, so one can be taken from the other', () => {
+    assert.ok(sameDimensions(storedUnits.temperature, storedUnits.temperature))
+    assert.ok(!sameDimensions(storedUnits.temperature, storedUnits.number))
+})
+
+void test('a quantity measured from its own zero cannot be multiplied or raised', () => {
+    // how many temperatures twice a temperature is depends on the two, not on the units
+    assert.equal(shape(unitProduct(storedUnits.temperature, storedUnits.population, 1)), 'none')
+    assert.equal(shape(unitProduct(storedUnits.population, storedUnits.temperature, -1)), 'none')
+    assert.equal(shape(unitPower(storedUnits.temperature, 2)), 'none')
+})
+
+void test('what a statistic is written in does not survive being computed with', () => {
+    assert.equal(unitProduct(storedUnits.population, storedUnits.area, -1)?.unit.decoration.kind, 'none')
+    // where the density statistic itself keeps its km^2
+    assert.equal(storedUnits.density.unit.decoration.kind, 'writtenIn')
+})

--- a/react/unit/unit-arithmetic.test.ts
+++ b/react/unit/unit-arithmetic.test.ts
@@ -56,3 +56,12 @@ void test('what a statistic is written in does not survive being computed with',
     assert.equal(unitProduct(storedUnits.population, storedUnits.area, -1)?.unit.decoration.kind, 'none')
     assert.equal(storedUnits.density.unit.decoration.kind, 'writtenIn')
 })
+
+void test('a power that comes back a hair off a whole one is the whole one', () => {
+    // a cube raised to a tenth and then to ten is 3.0000000000000004 of a meter, which is no unit
+    const cube = storedUnits.contaminantLevel
+    const roundTrip = unitPower(unitPower(cube, 0.1)!, 10)!
+    assert.ok(sameDimensions(roundTrip, cube))
+    // the scale it is stored in comes back a hair off too, which is below anything a rendering shows
+    assert.ok(Math.abs(roundTrip.toBaseUnits / cube.toBaseUnits - 1) < 1e-12)
+})


### PR DESCRIPTION
Stacked on #2300; the diff shown is against it. Second of the pieces of #2216.

Inference needs both directions. Forwards gives the unit of a computed column. Backwards reads the `0.1` of `commute_bike < 0.1` as ten percent, since a bare number is in whatever unit the thing it is written against is in — which is what the captions need.

## The domain

```ts
export type AbstractInterpValue = (
    { kind: 'any', constant?: number }
    | { kind: 'none' }
    | { kind: 'in', unit: StoredUnit, constant?: number }
)
```

Not knowing which unit something is in is a different thing from nothing being of any unit, and only the second is worth telling a script's author about. Both are ordinary members of the domain rather than failures to be one, so every expression has an answer and no operation can fail: a test runs every operator over every kind of value in all three directions and asserts none of them throws.

Constants are in the domain because coefficients need them — `(t1 + t2) / 2` is only a temperature if the `2` is visible to the algebra.

## Three shapes, not thirteen cases

| shape | operators | how the slots relate |
|---|---|---|
| same unit | `+ - == != < > <= >=` | every slot is the same unit; the operands' coefficients combine into the result's |
| product | `* /` | the operands' dimensions add, or subtract |
| power | `**` | the exponent has to be a constant |
| opaque | `& \|` | nothing relates them |

A bare number is dimensionless under *product* and takes the other side's unit under *same unit*, which is why `pop * 2` and `pop + 2` differ — the form decides, not the literal. Negating one negates it, so `pop * -2` scales by minus two without a separate walk over the AST to find it.

Solving for an operand is running the operator that undoes it:

```ts
const inverses = { '+': '-', '-': '+', '*': '/', '/': '*' } as const
```

so `backward` is a few lines over `forward` rather than a second set of rules to keep in step. The unary operators are their own inverses, and `backwardUnary` says so rather than leaving a caller to know it.

## Coefficients are checked where they are used

```
t1 - t2            times=0     a number of degrees
t1 + t2            times=2     carried, but nothing writes it
(t1 + t2) / 2      times=1     a temperature again
t + 2              times=1     a temperature, the 2 being degrees
-t                 times=-1    no reading: -50F and -10C are not the same one
```

Refusing the sum on the way past would lose the mean, so `unitToWriteIn` asks at the end.

## Verification

`tsc`, lint, knip, 615 unit tests, sixteen of them new. The rendering sweep is unchanged: nothing here is reachable from a statistic yet.

Next is the walk over the AST, then the two entry points, then the captions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
