### PR TITLE
Let a representative belong to a party with no article

### DIFF
--- a/react/src/components/congressional-table/party-page.ts
+++ b/react/src/components/congressional-table/party-page.ts
@@ -1,0 +1,13 @@
+import partyPages from '../../data/party_pages'
+
+export type PartyPage = (typeof partyPages)[keyof typeof partyPages]
+
+/**
+ * Parties the data has no page for, of which Independent is one: representatives.csv names them
+ * but party_pages.json lists only those with an article, so a lookup has to come up empty.
+ */
+export function getPartyPage(party: string | null | undefined): PartyPage | undefined {
+    return party !== null && party !== undefined && party in partyPages
+        ? partyPages[party as keyof typeof partyPages]
+        : undefined
+}

--- a/react/src/components/congressional-table/render.tsx
+++ b/react/src/components/congressional-table/render.tsx
@@ -1,6 +1,5 @@
 import React, { CSSProperties, Fragment, ReactNode, useMemo } from 'react'
 
-import partyPages from '../../data/party_pages'
 import { NavLink, Navigator } from '../../navigation/Navigator'
 import { Colors } from '../../page_template/color-themes'
 import { useColors } from '../../page_template/colors'
@@ -18,21 +17,14 @@ import {
     RepresentativesForRegion,
     RepresentativesForRegionAndDistrictSet,
 } from './model'
-
-function getPartyPage(party: string): (typeof partyPages)[keyof typeof partyPages] {
-    assert(party in partyPages, `Party ${party} not found in partyPages data`)
-    return partyPages[party as keyof typeof partyPages]
-}
+import { getPartyPage } from './party-page'
 
 /** Party hue used for links and run cell backgrounds; mirrors `RepresentativeParty`. */
 function partyHueColorString(colors: Colors, party: string | null | undefined): string | undefined {
-    if (!party || party === 'Independent') {
+    const partyPage = getPartyPage(party)
+    if (partyPage === undefined) {
         return undefined
     }
-    if (!(party in partyPages)) {
-        return undefined
-    }
-    const partyPage = partyPages[party as keyof typeof partyPages]
     // eslint-disable-next-line no-restricted-syntax -- not actual colors, just remapping
     const colorStr = partyPage.party_color === 'black' || partyPage.party_color === 'gray' ? 'grey' : partyPage.party_color
     return colors.hueColors[colorStr as keyof typeof colors.hueColors]
@@ -93,17 +85,18 @@ function displayRunFillStyle(
 
 function RepresentativeParty(props: { party?: string | null }): ReactNode {
     const colors = useColors()
-    if (!props.party || props.party === 'Independent') {
+    const party = props.party
+    const partyPage = getPartyPage(party)
+    if (party === null || party === undefined || partyPage === undefined) {
         return null
     }
-    const partyPage = getPartyPage(props.party)
     // eslint-disable-next-line no-restricted-syntax -- not actual colors, just remapping
     const colorStr = partyPage.party_color === 'black' || partyPage.party_color === 'gray' ? 'grey' : partyPage.party_color
     const color = colors.hueColors[colorStr]
 
     return (
         <a href={partyPage.wikipedia_page} style={{ textDecoration: 'none', color }} target="_blank" rel="noopener noreferrer">
-            {` (${props.party.slice(0, 1)})`}
+            {` (${party.slice(0, 1)})`}
         </a>
     )
 }

--- a/react/unit/congressional-party.test.ts
+++ b/react/unit/congressional-party.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert/strict'
+import { test } from 'node:test'
+
+import { getPartyPage } from '../src/components/congressional-table/party-page'
+
+void test('a party with an article has its page and colour', () => {
+    assert.equal(getPartyPage('Democratic Party')?.wikipedia_page, 'https://en.wikipedia.org/wiki/Democratic_Party_(United_States)')
+    assert.notEqual(getPartyPage('Silver Party')?.party_color, undefined)
+})
+
+// representatives.csv names 44 parties where party_pages.json describes the 42 with an article,
+// so a lookup has to come up empty rather than insist: Francis G. Newlands sat for Nevada in the
+// 53rd Congress for the Fusion Party, and asserting on it took the whole article down
+for (const party of ['Fusion Party', 'Independent', 'Whatever Party', '', null, undefined] as const) {
+    void test(`a party the data has no page for, ${JSON.stringify(party)}, has none`, () => {
+        assert.equal(getPartyPage(party), undefined)
+    })
+}


### PR DESCRIPTION
Fixes #2184.

## What happens

`representatives.csv` names 44 parties. `party_pages.json` describes the 42 that have a Wikipedia article. The party beside a representative's name was looked up like this:

```ts
function getPartyPage(party: string) {
    assert(party in partyPages, `Party ${party} not found in partyPages data`)
    return partyPages[party as keyof typeof partyPages]
}
```

so one of the other two threw during render and took the whole article down. Francis G. Newlands sat for Nevada at large in the 53rd Congress for the **Fusion Party** — the one row in the data with that party — which is why the URL in the issue crashes, and why every Nevada article whose representatives reach back that far does the same.

## The fix

The same file already coped with this twenty lines away: the run-cell colours return `undefined` for a party they cannot find. And `Independent`, the *other* party with no article, was special-cased by name in both places.

Those are all one case, so there is now one rule — no page, no link, no colour — and `Independent` falls under it rather than being named. Its rendering is unchanged, since it has no entry either way.

The lookup moved to `party-page.ts` so that it can be tested: `render.tsx` reaches `file-saver` through the screenshot helper, which will not load under the unit runner.

## What is not fixed here

The upstream export drops a party from `party_pages.json` when it has no Wikipedia article, discarding the colour it assigned it two lines earlier, and nothing checks that every party in the CSV appears there. Worth fixing in `all-congressional-representatives`, but a page still cannot be allowed to crash over reference data it is missing.

## Verification

`tsc`, lint, knip, 633 unit tests, seven of them new: a party with an article keeps its page, and `Fusion Party`, `Independent`, an unknown name, the empty string, `null` and `undefined` all come back with none rather than throwing.

No screenshots should move: the only rendering that changes is the one that used to crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
