### PR TITLE
Charge the search for figures a unit rounds away

### DIFF
--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -61,9 +61,6 @@ function roundToDigits(value: number, rounding: Rounding): string {
 }
 
 /** How a number is written: to a fixed number of decimal places, or to a number of digits. */
-/** The figures `significantFigures` writes, and the most any other style is asked for. */
-export const figuresWritten = 3
-
 export type NumberFormat = (
     { kind: 'fixed', places: number }
     | ({ kind: 'rounded' } & Rounding)
@@ -89,7 +86,7 @@ export function formatNumber(value: number, format: NumberFormat): string {
         case 'rounded':
             return roundToDigits(value, format)
         case 'significantFigures':
-            return separateNumber(formatToSignificantFigures(value, figuresWritten))
+            return separateNumber(formatToSignificantFigures(value, 3))
         case 'hoursMinutes':
             return hoursAndMinutes(value).written
     }

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -61,6 +61,9 @@ function roundToDigits(value: number, rounding: Rounding): string {
 }
 
 /** How a number is written: to a fixed number of decimal places, or to a number of digits. */
+/** The figures `significantFigures` writes, and the most any other style is asked for. */
+export const figuresWritten = 3
+
 export type NumberFormat = (
     { kind: 'fixed', places: number }
     | ({ kind: 'rounded' } & Rounding)
@@ -86,7 +89,7 @@ export function formatNumber(value: number, format: NumberFormat): string {
         case 'rounded':
             return roundToDigits(value, format)
         case 'significantFigures':
-            return separateNumber(formatToSignificantFigures(value, 3))
+            return separateNumber(formatToSignificantFigures(value, figuresWritten))
         case 'hoursMinutes':
             return hoursAndMinutes(value).written
     }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -10,7 +10,9 @@ export interface Written {
 const artificialZeroCost = 100
 
 /**
- * We charge 1 for every digit that is printed.
+ * We charge 1 for every digit that is printed, and 1 for every figure of the three a reader is
+ * given that the digits do not carry: 1 234 is four digits of four figures, where the same
+ * quantity written smaller is 0.001, four digits of one, and is the worse of the two to read.
  *
  * This is almost, but not quite, the same as the number of significant figures, because
  * e.g., 1000 is counted as 4, not 1.
@@ -25,7 +27,8 @@ function digitCost(value: number, format: NumberFormat): number {
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return artificialZeroCost
     }
-    return digits.length
+    const figures = digits.length - digits.search(/[1-9]/)
+    return digits.length + Math.max(0, 3 - figures)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -1,6 +1,6 @@
 import { assert } from './defensive'
 import type { BaseUnit, Dimension, NamedUnit } from './quantity'
-import { figuresWritten, formatNumber, NumberFormat } from './text'
+import { formatNumber, NumberFormat } from './text'
 
 export interface Written {
     unit: NamedUnit
@@ -9,25 +9,11 @@ export interface Written {
 
 const artificialZeroCost = 100
 
-/** How many figures a style sets out to write, of those that write to figures at all. */
-function figuresWanted(format: NumberFormat): number {
-    switch (format.kind) {
-        case 'rounded':
-            return format.significantDigits
-        case 'significantFigures':
-            return figuresWritten
-        // the places are the style's own decision, and rounding past them is precise enough for it
-        case 'fixed':
-        case 'hoursMinutes':
-            return 0
-    }
-}
-
 /**
- * We charge 1 for every digit that is printed, and 1 for every figure the style set out to write
- * that the digits do not carry: 1 234 is four digits carrying four figures, where the same
- * quantity written in a smaller unit is 0.001, four digits carrying one, and 1 234 and 1 500 are
- * written alike.
+ * We charge 1 for every digit that is printed, and 1 again for every zero between the point and
+ * the first figure, each of those having pushed a figure out of what the style writes: 1 234 is
+ * four digits carrying four figures, where the same quantity written in a smaller unit is 0.001,
+ * four digits carrying one, and 1 234 and 1 500 are written alike.
  *
  * This is almost, but not quite, the same as the number of significant figures, because
  * e.g., 1000 is counted as 4, not 1.
@@ -38,12 +24,12 @@ function figuresWanted(format: NumberFormat): number {
  *      unless in fixed point.
  */
 function digitCost(value: number, format: NumberFormat): number {
-    const digits = formatNumber(value, format).replace(/[^0-9]/g, '')
+    const written = formatNumber(value, format)
+    const digits = written.replace(/[^0-9]/g, '')
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return artificialZeroCost
     }
-    const figures = digits.length - digits.search(/[1-9]/)
-    return digits.length + Math.max(0, figuresWanted(format) - figures)
+    return digits.length + (/\.(0*)[1-9]/.exec(written)?.[1].length ?? 0)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -10,18 +10,9 @@ export interface Written {
 const artificialZeroCost = 100
 
 /**
- * We charge 1 for every digit that is printed, and, of a number below one, 1 again for every zero
- * between the point and the first figure, each of those having pushed a figure out of what the
- * style writes: 1 234 is four digits carrying four figures, where the same quantity written in a
- * smaller unit is 0.001, four digits carrying one, and 1 234 and 1 500 are written alike.
- *
- * This is almost, but not quite, the same as the number of significant figures, because
- * e.g., 1000 is counted as 4, not 1.
- *
- * Two caveats:
- * 1. It is counted from the number as printed, so 999.5 is counted as if it were 1000.
- * 2. If a number is formatted to an "artificial 0" e.g., 0.0001 -> 0.000, we apply a huge penalty
- *      unless in fixed point.
+ * We charge 1 for every digit as printed, with two adjustments:
+ * - a number rounded away to 0 is heavily penalized, unless in fixed point
+ * - every leading 0 past the decimal point is charged as another digit
  */
 function digitCost(value: number, format: NumberFormat): number {
     const written = formatNumber(value, format)

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -1,6 +1,6 @@
 import { assert } from './defensive'
 import type { BaseUnit, Dimension, NamedUnit } from './quantity'
-import { formatNumber, NumberFormat } from './text'
+import { figuresWritten, formatNumber, NumberFormat } from './text'
 
 export interface Written {
     unit: NamedUnit
@@ -9,10 +9,25 @@ export interface Written {
 
 const artificialZeroCost = 100
 
+/** How many figures a style sets out to write, of those that write to figures at all. */
+function figuresWanted(format: NumberFormat): number {
+    switch (format.kind) {
+        case 'rounded':
+            return format.significantDigits
+        case 'significantFigures':
+            return figuresWritten
+        // the places are the style's own decision, and rounding past them is precise enough for it
+        case 'fixed':
+        case 'hoursMinutes':
+            return 0
+    }
+}
+
 /**
- * We charge 1 for every digit that is printed, and 1 for every figure of the three a reader is
- * given that the digits do not carry: 1 234 is four digits of four figures, where the same
- * quantity written smaller is 0.001, four digits of one, and is the worse of the two to read.
+ * We charge 1 for every digit that is printed, and 1 for every figure the style set out to write
+ * that the digits do not carry: 1 234 is four digits carrying four figures, where the same
+ * quantity written in a smaller unit is 0.001, four digits carrying one, and 1 234 and 1 500 are
+ * written alike.
  *
  * This is almost, but not quite, the same as the number of significant figures, because
  * e.g., 1000 is counted as 4, not 1.
@@ -28,7 +43,7 @@ function digitCost(value: number, format: NumberFormat): number {
         return artificialZeroCost
     }
     const figures = digits.length - digits.search(/[1-9]/)
-    return digits.length + Math.max(0, 3 - figures)
+    return digits.length + Math.max(0, figuresWanted(format) - figures)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -10,10 +10,10 @@ export interface Written {
 const artificialZeroCost = 100
 
 /**
- * We charge 1 for every digit that is printed, and 1 again for every zero between the point and
- * the first figure, each of those having pushed a figure out of what the style writes: 1 234 is
- * four digits carrying four figures, where the same quantity written in a smaller unit is 0.001,
- * four digits carrying one, and 1 234 and 1 500 are written alike.
+ * We charge 1 for every digit that is printed, and, of a number below one, 1 again for every zero
+ * between the point and the first figure, each of those having pushed a figure out of what the
+ * style writes: 1 234 is four digits carrying four figures, where the same quantity written in a
+ * smaller unit is 0.001, four digits carrying one, and 1 234 and 1 500 are written alike.
  *
  * This is almost, but not quite, the same as the number of significant figures, because
  * e.g., 1000 is counted as 4, not 1.
@@ -29,7 +29,7 @@ function digitCost(value: number, format: NumberFormat): number {
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return artificialZeroCost
     }
-    return digits.length + (/\.(0*)[1-9]/.exec(written)?.[1].length ?? 0)
+    return digits.length + (/^-?0\.(0*)[1-9]/.exec(written)?.[1].length ?? 0)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -312,7 +312,8 @@ for (const [unitType, value, expected] of [
 for (const [unitType, dimensions, toBaseUnits, value, asStatistic, asDerived] of [
     ['contaminantLevel', [{ baseUnit: 'g', power: 1 }, { baseUnit: 'm', power: -3 }], 1e-6, 8.2, '8.20μg/m^{3}', '8.20μg/m^{3}'],
     ['distancePerYear', [{ baseUnit: 'm', power: 1 }, { baseUnit: 's', power: -1 }], 1 / (365.25 * 24 * 60 * 60), 1.2, '120.0cm/yr', '1.20m/yr'],
-    ['density', [{ baseUnit: 'person', power: 1 }, { baseUnit: 'm', power: -2 }], 1e-6, 1234, '1\u202f234/\u00a0km^{2}', '0.001/\u00a0m^{2}'],
+    // where a density read shortest is the same square kilometre the statistic is declared in
+    ['density', [{ baseUnit: 'person', power: 1 }, { baseUnit: 'm', power: -2 }], 1e-6, 1234, '1\u202f234/\u00a0km^{2}', '1\u202f234/\u00a0km^{2}'],
 ] as ['contaminantLevel' | 'distancePerYear' | 'density', Dimension[], number, number, string, string][]) {
     const write = (stored: StoredUnit): string => {
         const written = writeQuantity(value, stored)

--- a/react/unit/unit-search.test.ts
+++ b/react/unit/unit-search.test.ts
@@ -91,6 +91,8 @@ void test('a unit that pushes the figures past the point is not reached for', ()
     assert.equal(chosen(1e-3, { m: 1 }, [kilometer, meter, unit('cm', { m: 1 }, 0.01, 1)], () => threeFiguresRounded), 'cm^1')
     // and a leading zero with the figures behind it costs only the digit it is
     assert.equal(chosen(1000, { m: 2 }, [unit('acre', { m: 2 }, 4046.8564224, 1), unit('ft', { m: 1 }, 0.3048, 1)], () => threeFiguresRounded), 'acre^1')
+    // as does a zero the figures are written around: the 0 of 1.04 is a figure of it
+    assert.equal(chosen(1040, { m: 1 }, [unit('km', { m: 1 }, 1e3, 0.5), meter], () => threeFiguresRounded), 'km^1')
 })
 
 void test('a fixed number of places is a decision that rounding away is precise enough', () => {

--- a/react/unit/unit-search.test.ts
+++ b/react/unit/unit-search.test.ts
@@ -79,6 +79,18 @@ void test('a unit that rounds the quantity away is not worth choosing', () => {
     assert.equal(chosen(1e-5, { person: -1 }, [people, hundredThousand], () => threeDigits), '100k^-1')
 })
 
+const threeFiguresRounded: NumberFormat = { kind: 'rounded', significantDigits: 3 }
+const kilometer = unit('km', { m: 1 }, 1e3, 1)
+const meter = unit('m', { m: 1 }, 1)
+
+void test('a unit that leaves the figures behind is not reached for', () => {
+    // a thousand people per square kilometre is a thousandth of one per square metre, which is as
+    // many digits and one figure: written that way, a thousand and a thousand and a half are one
+    assert.equal(chosen(1e-3, { person: 1, m: -2 }, [people, kilometer, meter], () => threeFiguresRounded), 'km^-2 <none>^1')
+    // where a length small enough to leave three of them behind is
+    assert.equal(chosen(1e-3, { m: 1 }, [kilometer, meter, unit('cm', { m: 1 }, 0.01, 1)], () => threeFiguresRounded), 'cm^1')
+})
+
 void test('a fixed number of places is a decision that rounding away is precise enough', () => {
     // a fraction of a person is no people, which is what whole numbers of them means
     assert.equal(chosen(0.123, { person: 1 }, counting), '<none>^1')

--- a/react/unit/unit-search.test.ts
+++ b/react/unit/unit-search.test.ts
@@ -83,12 +83,14 @@ const threeFiguresRounded: NumberFormat = { kind: 'rounded', significantDigits: 
 const kilometer = unit('km', { m: 1 }, 1e3, 1)
 const meter = unit('m', { m: 1 }, 1)
 
-void test('a unit that leaves the figures behind is not reached for', () => {
+void test('a unit that pushes the figures past the point is not reached for', () => {
     // a thousand people per square kilometre is a thousandth of one per square metre, which is as
     // many digits and one figure: written that way, a thousand and a thousand and a half are one
     assert.equal(chosen(1e-3, { person: 1, m: -2 }, [people, kilometer, meter], () => threeFiguresRounded), 'km^-2 <none>^1')
     // where a length small enough to leave three of them behind is
     assert.equal(chosen(1e-3, { m: 1 }, [kilometer, meter, unit('cm', { m: 1 }, 0.01, 1)], () => threeFiguresRounded), 'cm^1')
+    // and a leading zero with the figures behind it costs only the digit it is
+    assert.equal(chosen(1000, { m: 2 }, [unit('acre', { m: 2 }, 4046.8564224, 1), unit('ft', { m: 1 }, 0.3048, 1)], () => threeFiguresRounded), 'acre^1')
 })
 
 void test('a fixed number of places is a decision that rounding away is precise enough', () => {


### PR DESCRIPTION
Towards #2204, and a prerequisite for putting derived units on screen.

## The defect

`digitCost` counts the digits a candidate unit would leave to read. That makes these two cost the same:

| | digits | figures |
|---|---|---|
| `1 234 / km²` | 4 | 4 |
| `0.001 / m²` | 4 | 1 |

They are not the same to read. The second carries one figure of the three the style asked for, so 1 234 and 1 500 are written identically. Tied on digits, the tie fell to the unit's own cost — a square metre is unscaled where a square kilometre is not — so **the search preferred the one that threw the figures away**.

Nothing shows this today, because every statistic whose dimensions have a negative power (density, pollution, rainfall) pins its own units and leaves the search nothing to choose. A *derived* quantity of those dimensions does not, which is where I hit it.

## The fix

Charge again for every zero between the point and the first figure, each of those having pushed a figure out of what the style has room to write:

```ts
return digits.length + (/\.(0*)[1-9]/.exec(written)?.[1].length ?? 0)
```

The zero in front of the point is a placeholder every such number carries, so it is not charged: `0.247 acres` keeps its three figures and pays for the digit alone, where `0.001` has lost two and pays for them. Charging *all* leading zeros would take `0.247 acres` to `10 764 ft²`, which is the worse of the two to read.

## What moves

Twelve of the 1 800 renderings the declared units make (30 unit types × 20 values × 3 reader settings), all the same kind of improvement:

| | before | after |
|---|---|---|
| area 0.01, 0.05 | `0.010 km²` | `10 000 m²` |
| elevation 0.001, 0.01 | `0.001 m` | `0.100 cm` |
| elevation 0.001, 0.01 imperial | `0.003 ft` | `0.039 in` |

An area under a tenth of a square kilometre and a length under a tenth of a metre — both smaller than any statistic the site carries, so I would expect no screenshot to move. Worth a CI run to confirm rather than my word.

## Verification

`tsc`, lint, knip, the full unit suite. Two new cases in `unit-search.test.ts`, and one expectation updated in `unit-display.test.ts`: it asserted that a bare person/m² of 1 234 floats to `0.001/ m²`, which was the defect written down. It now lands on `1 234/ km²`, the same square kilometre the density statistic declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)