### PR TITLE
Read what a regression works out, field by field

### DIFF
--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -1,29 +1,36 @@
 import { unitTypeToStoredUnit } from '../utils/unit'
 
-import { UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
+import { UrbanStatsASTArg, UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
 import { TypeEnvironment } from './types-values'
 import { AbstractInterpValue, constant, forward, forwardUnary, inUnit, join } from './unit-algebra'
 
 const anything: AbstractInterpValue = { kind: 'any' }
 
+/** A script has objects in it as well as quantities, a regression's result being one. */
+type Inferred = AbstractInterpValue | { kind: 'fields', fields: Map<string, AbstractInterpValue> }
+
+function quantity(value: Inferred): AbstractInterpValue {
+    return value.kind === 'fields' ? anything : value
+}
+
+type Bindings = Map<string, Inferred>
+
 /** What has been worked out so far: the statistics as the script found them, and the names it gave. */
 interface Scope {
     typeEnvironment: TypeEnvironment
-    named: Map<string, AbstractInterpValue>
+    named: Bindings
 }
 
 /** A block is worth as much as its last statement, and an empty one as much as nothing said. */
-function block(statements: UrbanStatsASTStatement[], scope: Scope): AbstractInterpValue {
-    let value = anything
+function block(statements: UrbanStatsASTStatement[], scope: Scope): Inferred {
+    let value: Inferred = anything
     for (const statement of statements) {
         value = infer(statement, scope)
     }
     return value
 }
 
-type Bindings = Map<string, AbstractInterpValue>
-
-function branch(statement: UrbanStatsASTStatement, scope: Scope): { value: AbstractInterpValue, named: Bindings } {
+function branch(statement: UrbanStatsASTStatement, scope: Scope): { value: Inferred, named: Bindings } {
     const named = new Map(scope.named)
     return { value: infer(statement, { ...scope, named }), named }
 }
@@ -31,11 +38,12 @@ function branch(statement: UrbanStatsASTStatement, scope: Scope): { value: Abstr
 /** A name an arm bound is worth what that arm made it where its mask held, and what it was where it did not. */
 function bindArms(scope: Scope, consequent: Bindings, alternative: Bindings): void {
     for (const name of new Set([...consequent.keys(), ...alternative.keys()])) {
-        scope.named.set(name, join(consequent.get(name) ?? { kind: 'none' }, alternative.get(name) ?? { kind: 'none' }))
+        const either = [consequent, alternative].map(arm => quantity(arm.get(name) ?? { kind: 'none' }))
+        scope.named.set(name, join(either[0], either[1]))
     }
 }
 
-function identifier(name: string, scope: Scope): AbstractInterpValue {
+function identifier(name: string, scope: Scope): Inferred {
     const named = scope.named.get(name)
     if (named !== undefined) {
         return named
@@ -44,7 +52,32 @@ function identifier(name: string, scope: Scope): AbstractInterpValue {
     return unit === undefined ? anything : inUnit(unitTypeToStoredUnit(unit))
 }
 
-function infer(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, scope: Scope): AbstractInterpValue {
+const parameterName = /^x(\d+)$/
+
+function namedArgument(args: UrbanStatsASTArg[], name: string): UrbanStatsASTExpression | undefined {
+    return args.find(arg => arg.type === 'named' && arg.name.node === name)?.value
+}
+
+/**
+ * The intercept is in the units of what was regressed, the residuals are a difference of those,
+ * and each coefficient is that difference over a difference of the parameter it belongs to.
+ */
+function regressionFields(args: UrbanStatsASTArg[], scope: Scope): Inferred {
+    const regressed = namedArgument(args, 'y')
+    const level = regressed === undefined ? anything : quantity(infer(regressed, scope))
+    const change = forward('-', level, level)
+    const fields = new Map<string, AbstractInterpValue>([['b', level], ['residuals', change], ['r2', anything]])
+    for (const arg of args) {
+        const parameter = arg.type === 'named' ? parameterName.exec(arg.name.node) : null
+        if (parameter !== null) {
+            const of = quantity(infer(arg.value, scope))
+            fields.set(`m${parameter[1]}`, forward('/', change, forward('-', of, of)))
+        }
+    }
+    return { kind: 'fields', fields }
+}
+
+function infer(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, scope: Scope): Inferred {
     switch (ast.type) {
         case 'expression':
             return infer(ast.value, scope)
@@ -70,21 +103,29 @@ function infer(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, scope: Sco
         case 'constant':
             return ast.value.node.type === 'number' ? constant(ast.value.node.value) : anything
         case 'unaryOperator':
-            return forwardUnary(ast.operator.node, infer(ast.expr, scope))
+            return forwardUnary(ast.operator.node, quantity(infer(ast.expr, scope)))
         case 'binaryOperator':
-            return forward(ast.operator.node, infer(ast.left, scope), infer(ast.right, scope))
+            return forward(ast.operator.node, quantity(infer(ast.left, scope)), quantity(infer(ast.right, scope)))
         case 'vectorLiteral':
-            return ast.elements.reduce<AbstractInterpValue>((soFar, element) => join(soFar, infer(element, scope)), { kind: 'none' })
+            return ast.elements.reduce<AbstractInterpValue>((soFar, element) => join(soFar, quantity(infer(element, scope))), { kind: 'none' })
+        case 'objectLiteral':
+            return { kind: 'fields', fields: new Map(ast.properties.map(([name, value]) => [name, quantity(infer(value, scope))])) }
+        case 'attribute': {
+            const object = infer(ast.expr, scope)
+            return object.kind === 'fields' ? object.fields.get(ast.name.node) ?? anything : anything
+        }
+        case 'call':
+            // a name the script bound is whatever it bound it to, rather than the regression it hides
+            return ast.fn.type === 'identifier' && ast.fn.name.node === 'regression' && !scope.named.has('regression')
+                ? regressionFields(ast.args, scope)
+                : anything
         case 'if': {
             const consequent = branch(ast.then, scope)
             // an arm that is not there leaves the value it would have written as it was
             const alternative = ast.else === undefined ? undefined : branch(ast.else, scope)
             bindArms(scope, consequent.named, alternative?.named ?? new Map(scope.named))
-            return alternative === undefined ? consequent.value : join(consequent.value, alternative.value)
+            return alternative === undefined ? consequent.value : join(quantity(consequent.value), quantity(alternative.value))
         }
-        case 'attribute':
-        case 'call':
-        case 'objectLiteral':
         case 'parseError':
             return anything
     }
@@ -92,5 +133,5 @@ function infer(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, scope: Sco
 
 /** What kind of quantity an expression works out to, as far as reading it can say. */
 export function inferUnit(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment): AbstractInterpValue {
-    return infer(ast, { typeEnvironment, named: new Map() })
+    return quantity(infer(ast, { typeEnvironment, named: new Map() }))
 }

--- a/react/unit/unit-inference.test.ts
+++ b/react/unit/unit-inference.test.ts
@@ -110,6 +110,28 @@ void test('a vector is of the kind of what is in it', () => {
     assert.ok(writable('if (population > 0) { area } else { area - area }'))
 })
 
+void test('a regression is read field by field', () => {
+    const people = 'regr = regression(y=population, x1=area)\n'
+    // the intercept is in the units of what was regressed, and the residuals are a difference of those
+    assert.equal(inferred(`${people}regr.b`), 'person^1 times=1 x1')
+    assert.equal(inferred(`${people}regr.residuals`), 'person^1 times=0 x1')
+    // a coefficient is that difference over a difference of its parameter: people per square kilometre
+    assert.equal(inferred(`${people}regr.m1`), 'm^-2 person^1 times=unknown x0.000001')
+    assert.equal(inferred(`${people}regr.r2`), 'unknown')
+    assert.equal(inferred(`${people}regr.nonesuch`), 'unknown')
+})
+
+void test('a regression says nothing of a parameter it cannot read', () => {
+    // the coefficient of a log is a share over nothing anybody can name
+    assert.equal(inferred('regr = regression(y=commute_bike, x1=ln(population))\nregr.m1'), 'unknown')
+    // and one of no dependent variable is a regression in name only
+    assert.equal(inferred('regr = regression(x1=area)\nregr.b'), 'unknown')
+})
+
+void test('a name bound over regression is that name, not the regression', () => {
+    assert.equal(inferred('regression = population\nregression'), 'person^1 times=1 x1')
+})
+
 void test('what cannot be read comes back as anything, rather than throwing', () => {
     assert.equal(inferred('someFunctionOrOther(population)'), 'unknown')
     assert.equal(inferred('"a string"'), 'unknown')


### PR DESCRIPTION
Towards #2204, off main, and split out of #2305.

## What a regression works out

A script regresses one statistic on others and maps what comes back:

```
regr = regression(y=commute_transit, x1=ln(density_pw_1km), weight=population)
condition (population > 10000)
cMap(data=do { x = regr.residuals; x }, ...)
```

Each field of the result has a unit, and they are all read off the one that was regressed:

| field | unit |
|---|---|
| `b` | what was regressed, as a level |
| `residuals` | a difference of those |
| `m{i}` | that difference over a difference of parameter *i* |
| `r2` | a plain number |

None of that needed new rules — **residuals are `y - y`, and a coefficient is that over `x - x`**, so the algebra from #2301 works them out:

```
regression(y=commute_transit, x1=ln(density_pw_1km)).residuals   a share, as a difference
regression(y=commute_transit, x1=ln(density_pw_1km)).b           a share, as a level
regression(y=commute_transit, x1=ln(density_pw_1km)).m1          nothing: a share over a logarithm
regression(y=population, x1=area).m1                             people per square kilometre
regression(y=high_temp, x1=population).residuals                 degrees, not a reading
```

The difference matters most where the units are affine: a residual of a temperature regression is a number of degrees, so it converts to Celsius by its scale alone, where a reading would take the offset too.

## What the walk gains

A script has objects in it as well as quantities, so the walk carries one:

```ts
type Inferred = AbstractInterpValue | { kind: 'fields', fields: Map<string, AbstractInterpValue> }
```

That is what lets a name hold a regression — `regr = regression(...)` in the preamble, `regr.residuals` in the map — and an object literal is read the same way. Anywhere a quantity is wanted, an object is nothing in particular, so arithmetic on one says nothing rather than failing. A field of something that is not an object, or one a regression has not got, likewise.

`regression` here is the constant of that name, so a script that binds the name to something else gets whatever it bound.

## Verification

`tsc`, lint, knip, the full unit suite, 3 new tests. Nothing calls the inference yet on main, so nothing renders differently; #2305 is where it reaches the screen, and where a residual map picks up the leading `+` that a difference is written with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
