### PR TITLE
Let a difference of temperatures multiply

### DIFF
--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -288,8 +288,16 @@ export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {
     return renderAsKey(gathered(left.unit.dimensions)) === renderAsKey(gathered(right.unit.dimensions))
 }
 
+/**
+ * Nothing scales a temperature, 0°C being no more nothing than 0°F is. A difference of two is
+ * another matter: no degrees is no degrees on either scale, so it multiplies like anything else.
+ */
+function scales(unit: Unit): boolean {
+    return unit.baseIsScalar || unit.times === 0
+}
+
 export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined {
-    if (!left.unit.baseIsScalar || !right.unit.baseIsScalar) {
+    if (!scales(left.unit) || !scales(right.unit)) {
         return undefined
     }
     const [over, under] = [left.unit.dimensions, right.unit.dimensions]
@@ -301,7 +309,7 @@ export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 |
 }
 
 export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined {
-    if (!stored.unit.baseIsScalar) {
+    if (!scales(stored.unit)) {
         return undefined
     }
     const raised = stored.unit.dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -292,12 +292,12 @@ export function sameDimensions(left: StoredUnit, right: StoredUnit): boolean {
  * Nothing scales a temperature, 0°C being no more nothing than 0°F is. A difference of two is
  * another matter: no degrees is no degrees on either scale, so it multiplies like anything else.
  */
-function scales(unit: Unit): boolean {
+function multiplies(unit: Unit): boolean {
     return unit.baseIsScalar || unit.times === 0
 }
 
 export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 | -1): StoredUnit | undefined {
-    if (!scales(left.unit) || !scales(right.unit)) {
+    if (!multiplies(left.unit) || !multiplies(right.unit)) {
         return undefined
     }
     const [over, under] = [left.unit.dimensions, right.unit.dimensions]
@@ -309,7 +309,7 @@ export function unitProduct(left: StoredUnit, right: StoredUnit, rightPower: 1 |
 }
 
 export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | undefined {
-    if (!scales(stored.unit)) {
+    if (!multiplies(stored.unit)) {
         return undefined
     }
     const raised = stored.unit.dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -277,6 +277,21 @@ void test('a difference of temperatures multiplies as any other quantity does', 
     assert.equal(shape(forward('/', forwardUnary('-', temperature), area)), 'inconsistent')
 })
 
+void test('a difference of temperatures divides into things as well as by them', () => {
+    const change = forward('-', temperature, temperature)
+    const perDegree = unitToWriteIn(forward('/', people, change))
+    assert.notEqual(perDegree, undefined)
+    const write = (settings: object): string => {
+        const written = writeQuantity(5, perDegree!, settings)
+        return `${written.renderedValue}${reifyString(written.unitName)}`
+    }
+    // five to the Fahrenheit degree is nine to the Celsius one, that being the larger degree
+    assert.equal(write({}), '5.00/\u00a0°F')
+    assert.equal(write({ temperatureUnit: 'celsius' }), '9.00/\u00a0°C')
+    // and a reading is no more divisible into than it is by: nothing is so many people per 50°F
+    assert.equal(shape(forward('/', people, temperature)), 'inconsistent')
+})
+
 void test('a difference per something is read in degrees of the reader\'s own scale', () => {
     const perArea = unitToWriteIn(forward('/', forward('-', temperature, temperature), area))
     assert.notEqual(perArea, undefined)

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -266,3 +266,26 @@ void test('a coefficient that is not a number of anything is no longer known', (
     assert.equal(shape(forward('**', forwardUnary('-', area), constant(0.5))), 'm^1 times=unknown x1000')
     assert.equal(shape(forward('/', area, forward('-', area, area))), 'dimensionless times=unknown x1')
 })
+
+void test('a difference of temperatures multiplies as any other quantity does', () => {
+    const change = forward('-', temperature, temperature)
+    assert.equal(shape(forward('/', change, area)), 'F^1 m^-2 times=0 x0.000001')
+    assert.equal(shape(forward('**', change, constant(2))), 'F^2 times=0 x1')
+    // where a reading has no zero to multiply from, and nothing comes of trying
+    assert.equal(shape(forward('/', temperature, area)), 'inconsistent')
+    assert.equal(shape(forward('*', temperature, temperature)), 'inconsistent')
+    assert.equal(shape(forward('/', forwardUnary('-', temperature), area)), 'inconsistent')
+})
+
+void test('a difference per something is read in degrees of the reader\'s own scale', () => {
+    const perArea = unitToWriteIn(forward('/', forward('-', temperature, temperature), area))
+    assert.notEqual(perArea, undefined)
+    const write = (settings: object): string => {
+        const written = writeQuantity(5, perArea!, settings)
+        return `${written.renderedValue}${reifyString(written.unitName)}`
+    }
+    // five Fahrenheit degrees per square kilometre is two and a bit Celsius degrees, the zero
+    // of neither scale being in it
+    assert.equal(write({}), '+5.00°F/km^{2}')
+    assert.equal(write({ temperatureUnit: 'celsius' }), '+2.78°C/km^{2}')
+})


### PR DESCRIPTION
Off main, split out of #2305's review.

## The rule as it was

Nothing scales a temperature — twice as far above freezing is not twice as warm — so `unitProduct` and `unitPower` refuse a base that has a zero of its own:

```ts
if (!left.unit.baseIsScalar || !right.unit.baseIsScalar) {
    return undefined
}
```

That is right for a *reading* and wrong for a *difference of two*. No degrees is no degrees on either scale, so a difference multiplies and divides like any other quantity.

## The rule now

```ts
function multiplies(unit: Unit): boolean {
    return unit.baseIsScalar || unit.times === 0
}
```

The coefficient already tells the two apart — a reading is one of itself, a difference is none — so this is the distinction the framework has been carrying since #2296, applied where it had not been.

```
(high_temp - low_temp) / area        F^1 m^-2, and a thing to write
(high_temp - low_temp) ** 2          F^2
high_temp / area                     still nothing
high_temp * high_temp                still nothing
-high_temp / area                    still nothing, being minus one of itself
```

And it comes out in the reader's own degrees, by the scale alone:

| | |
|---|---|
| Fahrenheit | `+5.00°F/km²` |
| Celsius | `+2.78°C/km²` |

## Where it shows

Where a regression's coefficient is a temperature over something measured — `regression(y=high_temp, x1=area).m1` is degrees per square kilometre, and was nothing at all.

No declared unit renders differently: the 1 800-case sweep (30 unit types × 20 values × 3 reader settings) is byte-identical, since `unitProduct` and `unitPower` are only reachable from what the inference works out.

## Verification

`tsc`, lint, knip, the full unit suite, two new tests: the shapes above, and the Fahrenheit/Celsius pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
