### PR TITLE
Skip cancelled check runs when looking for screenshots

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -49,12 +49,14 @@ jobs:
               status: 'completed'
             });
 
-            if (runs.data.workflow_runs.length === 0) {
+            const usableRuns = runs.data.workflow_runs.filter(run => run.conclusion !== 'cancelled');
+
+            if (usableRuns.length === 0) {
               core.setFailed('No completed workflow runs found for this PR head commit');
               return;
             }
 
-            const latestRun = runs.data.workflow_runs[0];
+            const latestRun = usableRuns[0];
             core.setOutput('run-id', latestRun.id);
 
       - name: Download changed_screenshots artifact


### PR DESCRIPTION
`update-screenshots` picked the newest completed `check.yml` run for the PR head, including cancelled ones. A cancelled run has no `changed_screenshots` artifact, so the workflow failed at the download step even though a good run existed further down the list.

Cancellations are routine when working with stacked PRs: pushing to a lower branch cancels the checks in flight on the branches above it, and those cancelled runs stay attached to the same head commit. Filtering them out lets the workflow fall through to the run that actually produced screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)