### PR TITLE
Keep a re-run from publishing the previous attempt's screenshots

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,22 +200,25 @@ jobs:
         run: |
           name="${{ matrix.test-file }}"
           echo "name=${name:0:200}" >> $GITHUB_OUTPUT
+      # A re-run keeps the artifacts the earlier attempt uploaded, so these names carry the
+      # attempt. Re-running only the failed jobs loses nothing, because only a failing shard
+      # writes screenshots, and a failing shard is exactly what gets re-run.
       - uses: actions/upload-artifact@v4
         if: "!cancelled()"
         with:
-          name: delta-${{ steps.artifact-name.outputs.name }}
+          name: delta-${{ github.run_attempt }}-${{ steps.artifact-name.outputs.name }}
           path: react/delta
       - uses: actions/upload-artifact@v4
         if: "!cancelled()"
         with:
-          name: changed_screenshots-${{ steps.artifact-name.outputs.name }}
+          name: changed_screenshots-${{ github.run_attempt }}-${{ steps.artifact-name.outputs.name }}
           path: react/changed_screenshots
       # Both TestCafe's take-on-fail shots and the ones `flaky` takes per attempt land here, and
       # a run that passes deletes them, so this only ever carries pictures of something going wrong.
       - uses: actions/upload-artifact@v4
         if: "!cancelled()"
         with:
-          name: error_screenshots-${{ steps.artifact-name.outputs.name }}
+          name: error_screenshots-${{ github.run_attempt }}-${{ steps.artifact-name.outputs.name }}
           path: react/screenshots/**/*.error.png
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
@@ -223,31 +226,31 @@ jobs:
         with:
           name: test_histories-${{ steps.artifact-name.outputs.name }}
           path: react/test_histories
+          overwrite: true
 
   merge-screenshots:
     runs-on: ubuntu-22.04
     needs: [e2e]
     if: "!cancelled()"
     steps:
-      - uses: actions/upload-artifact/merge@v4
-        with:
-          name: delta
-          pattern: "delta-*"
-        continue-on-error: true
-      - uses: actions/upload-artifact/merge@v4
-        with:
-          name: changed_screenshots
-          pattern: "changed_screenshots-*"
-        continue-on-error: true
-      - id: upload-combined
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: combined
-          pattern: "{delta,changed_screenshots}"
-          separate-directories: true
-        continue-on-error: true
       - *checkout
       - uses: ./.github/actions/node_modules
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "delta-${{ github.run_attempt }}-*"
+          path: combined/delta
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "changed_screenshots-${{ github.run_attempt }}-*"
+          path: combined/changed_screenshots
+          merge-multiple: true
+      - id: upload-combined
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-${{ github.run_attempt }}
+          path: combined
+          if-no-files-found: ignore
       - uses: actions/download-artifact@v4
         with:
           pattern: "test_histories-*"

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -56,24 +56,27 @@ jobs:
 
             const latestRun = runs.data.workflow_runs[0];
             core.setOutput('run-id', latestRun.id);
+            core.setOutput('run-attempt', latestRun.run_attempt);
 
-      - name: Download changed_screenshots artifact
+      - name: Download combined artifact
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
 
+            const name = `combined-${{ steps.workflow-run.outputs.run-attempt }}`;
+
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: '${{ steps.workflow-run.outputs.run-id }}',
-              name: 'changed_screenshots'
+              name
             });
 
             const artifact = artifacts.data.artifacts[0];
 
             if (!artifact) {
-              core.setFailed('No changed_screenshots artifact found');
+              core.setFailed(`No ${name} artifact found`);
               return;
             }
 
@@ -84,12 +87,13 @@ jobs:
               archive_format: 'zip'
             });
 
-            fs.writeFileSync('changed_screenshots.zip', Buffer.from(download.data));
+            fs.writeFileSync('combined.zip', Buffer.from(download.data));
 
       - name: Extract and copy screenshots
         run: |
           # Extract the artifact
-          unzip changed_screenshots.zip -d changed_screenshots_temp/
+          unzip combined.zip -d combined_temp/
+          mv combined_temp/changed_screenshots changed_screenshots_temp
 
           # Check if there are any screenshots to copy
           if [ ! -d "changed_screenshots_temp" ] || [ -z "$(find changed_screenshots_temp -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' 2>/dev/null)" ]; then


### PR DESCRIPTION
A re-run keeps the artifacts the earlier attempt uploaded, and every artifact name in the e2e fan-out was fixed, so attempt 2 merged attempt 1's leftovers. A shard that failed on screenshots and then passed leaves its stale delta behind, since a passing shard uploads nothing to displace it. The merges into the fixed names `delta` and `changed_screenshots` also failed against the names attempt 1 already took, and `continue-on-error` swallowed that, so the run published the earlier attempt's merge.

Every artifact name now carries `github.run_attempt`, so no name is reused across attempts and nothing downstream can reach a superseded one. This is safe for "re-run failed jobs", which does not re-run the shards that passed: only a failing shard writes screenshots, so the shards whose artifacts the merge needs are exactly the ones that get re-run.

The intermediate `delta` and `changed_screenshots` artifacts existed only to name directories inside `combined` via `separate-directories`. Downloading straight into `combined/delta` and `combined/changed_screenshots` names them just as well, so those artifacts and all three `continue-on-error: true` are gone — a `pattern` matching nothing makes `download-artifact` a no-op rather than a failure, and `if-no-files-found: ignore` on the single upload now expresses the no-screenshots-changed case directly instead of it being inferred from three swallowed errors. Checkout moved to the top of the job because it empties the workspace.

`test_histories` is the deliberate exception, keeping a fixed name plus `overwrite: true`. A re-run of only the failed shards still needs the passing shards' histories, both for the PR comment and for `save-durations`, which asserts every test succeeded; scoping it by attempt would have written partial durations on main. Overwrite-by-name gets the carry-forward and makes the re-run shard's own history win deterministically.

`update-screenshots.yml` looked `changed_screenshots` up by exact name, so it follows, reading `run_attempt` off the workflow run it already fetches. A clean re-run now reports no artifact rather than silently committing the previous attempt's screenshots as references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)