### PR TITLE
Say less of an operand of a sum whose total is unknown

### DIFF
--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -250,8 +250,7 @@ export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpV
                 return known
             }
             assert(operator === '+' || operator === '-', `${operator} keeps the unit of what it adds`)
-            // with nothing known of the sum, an operand is of the other's dimensions, but a
-            // temperature and a difference of two add to each other either way round
+            // An operand of an unknown sum may be a level or a difference, so only its dimensions are known.
             return result.kind === 'any' ? manyOf(known) : undo(operator, result, known, side)
         case 'product':
             assert(operator === '*' || operator === '/', `${operator} is a product`)

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -250,7 +250,9 @@ export function backward(operator: BinaryOperatorSymbol, result: AbstractInterpV
                 return known
             }
             assert(operator === '+' || operator === '-', `${operator} keeps the unit of what it adds`)
-            return undo(operator, result, known, side)
+            // with nothing known of the sum, an operand is of the other's dimensions, but a
+            // temperature and a difference of two add to each other either way round
+            return result.kind === 'any' ? manyOf(known) : undo(operator, result, known, side)
         case 'product':
             assert(operator === '*' || operator === '/', `${operator} is a product`)
             return undo(operator, result, known, side)

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -107,6 +107,17 @@ void test('a difference gives back the level it was taken from', () => {
     assert.equal(shape(backward('+', people, difference(storedUnits.population), 'left')), 'person^1 times=1 x1')
 })
 
+void test('with nothing known of a sum, an operand is of the other\'s dimensions and no count of them', () => {
+    // a temperature and a difference of two add to each other either way round, so which of the
+    // two an operand is cannot be said, and the 32 of high_temp - 32 is no reading of 32 degrees
+    assert.equal(shape(backward('-', unknown, temperature, 'right')), 'F^1 times=unknown x1')
+    assert.equal(shape(backward('+', unknown, temperature, 'left')), 'F^1 times=unknown x1')
+    assert.equal(unitToWriteIn(backward('-', unknown, temperature, 'right')), undefined)
+    // people and a difference of people are written alike, so saying only that much costs nothing
+    assert.equal(shape(backward('-', unknown, people, 'right')), 'person^1 times=unknown x1')
+    assert.notEqual(unitToWriteIn(backward('-', unknown, people, 'right')), undefined)
+})
+
 void test('every operator answers in both directions, whatever it is given', () => {
     const inputs = [unknown, people, temperature, constant(2), constant(0)]
     for (const operator of infixOperators satisfies readonly BinaryOperatorSymbol[]) {


### PR DESCRIPTION
Split out of #2320's review, where it was the one change to the algebra among the caption plumbing.

## The rule

Asked what an operand of `a - b` is when nothing is known of the result, `backward` answered "a level":

```ts
return undo(operator, result, known, side)   // forward('-', high_temp, ⊤) → a temperature
```

`forward` reads an operand it knows nothing about as a difference — "a bare number added to a temperature is a number of degrees" — which is right going forwards and wrong coming back. A temperature and a difference of two add to each other **either way round**, so with the total unknown, an operand is of the other's dimensions and how many of them it is cannot be said:

```ts
return result.kind === 'any' ? manyOf(known) : undo(operator, result, known, side)
```

## Why it matters

`high_temp - 32`. The 32 is 32 degrees below a reading, not a reading of 32 degrees — and a reader in Celsius would have been shown `0°C` where the script meant 17.8 degrees. Now nothing is claimed of it, so it is written as the plain number it is.

People and a difference of people are written alike, so saying only this much costs nothing there: `population - 1000` still reads `1 000`.

## Verification

`tsc`, lint, knip, the full unit suite, one new test. `backward` has no caller on main, so nothing renders differently; #2320 is where it is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
