### PR TITLE
Write a statistic in the units it names, counted things and all

### DIFF
--- a/react/src/urban-stats-script/derive-unit.ts
+++ b/react/src/urban-stats-script/derive-unit.ts
@@ -12,7 +12,7 @@ function unitOf(values: UrbanStatsASTExpression | undefined, uss: MapUSS, typeEn
         return undefined
     }
     const unit = unitToWriteIn(inferUnit(values, typeEnvironment, inferBindings(uss, typeEnvironment)))
-    return unit !== undefined && writableDimensions(unit.unit.dimensions) ? unit : undefined
+    return unit !== undefined && writableDimensions(unit.unit) ? unit : undefined
 }
 
 export function deriveMapUnit(uss: MapUSS, typeEnvironment: TypeEnvironment): StoredUnit | undefined {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -201,17 +201,21 @@ const counted: BaseUnit[] = ['person', 'usd', 'fatality']
 
 /**
  * A count goes unnamed, so it can only be the one thing counted: people times square kilometres
- * would be written `km²` and read as an area. A fractional power is in no pool at all.
+ * would be written `km²` and read as an area. A fractional power is in no pool at all. A statistic
+ * that says which units it is written in has named them, counted things and all.
  */
-export function writableDimensions(dimensions: Dimension[]): boolean {
-    if (!dimensions.every(({ power }) => Number.isInteger(power))) {
+export function writableDimensions(unit: Unit): boolean {
+    if (!unit.dimensions.every(({ power }) => Number.isInteger(power))) {
         return false
     }
-    const counts = dimensions.filter(({ baseUnit }) => counted.includes(baseUnit))
+    if (unit.decoration.kind === 'writtenIn') {
+        return true
+    }
+    const counts = unit.dimensions.filter(({ baseUnit }) => counted.includes(baseUnit))
     if (counts.length === 0) {
         return true
     }
-    const above = dimensions.filter(({ power }) => power > 0)
+    const above = unit.dimensions.filter(({ power }) => power > 0)
     return counts.length === 1 && counts[0].power === 1 && above.length === 1
 }
 

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -58,6 +58,13 @@ void test('a map of a regression is written in the units of what was regressed',
     assert.equal(written(map(people, 'regr.residuals'), 1000), '+1\u202f000')
 })
 
+void test('a statistic that names its own units is written in them, counted things and all', () => {
+    // fatalities over people, both of them counted, which the statistic names as fatalities per 100k
+    const perCapita = deriveTableColumnUnit(mapUSSFromString('table(columns=[column(values=ped_cyclist_fatalities_per_capita)])'), defaultTypeEnvironment('USA'), 0)
+    assert.equal(written(perCapita, 1e-5), '1.00/\u00a0100k')
+    assert.equal(written(unitOfMap('traffic_fatalities_per_capita'), 1e-5), '1.00/\u00a0100k')
+})
+
 void test('a quantity with no writing is left to whatever its name is taken for', () => {
     // a root of a count is in no unit any pool holds, and asking for one threw
     assert.equal(mapUnit('population ** 0.5'), 'nothing')


### PR DESCRIPTION
A bug from #2305, off main.

## Reproduction

```
column(values=ped_cyclist_fatalities_per_capita)   NO UNIT
column(values=traffic_fatalities_per_capita)       NO UNIT
```

Since #2305, a per-capita column and a per-capita map have been written as bare numbers. The new test fails on main with `actual: 'nothing'` and passes with the fix.

## Why

`writableDimensions` refuses a count anywhere but as the single thing above the line:

> A count goes unnamed, so it can only be the one thing counted: people times square kilometres would be written `km²` and read as an area.

Fatalities per capita is a count over a count, so it was refused. But that rule is about the units a floated quantity is *free* to be written in, where a nameless one may turn up. A statistic that states which units it is written in has already named them — `fatalities`, and people in `100k` — and there is nothing nameless left to hide:

```ts
if (unit.decoration.kind === 'writtenIn') {
    return true
}
```

The function now takes the unit rather than its dimensions alone, that decoration being the thing to ask.

## What changes

A per-capita column or map regains `/ 100k`, as the statistic panel for the same data has shown all along. Derived quantities are refused exactly as before — `population * area`, `area / population`, `population ** 0.5` — since none of them names its own units.

## Verification

`tsc`, lint, knip, the full unit suite, two new cases. Screenshots showing a per-capita custom table or map will move, by gaining the unit they should have had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
