### PR TITLE
Write a large number out rather than in scientific notation

### DIFF
--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -56,8 +56,20 @@ function decimalPlaces(value: number, { significantDigits, minDecimals, maxDecim
     return Math.min(Math.max(significantDigits - Math.ceil(Math.log10(Math.abs(value))), minDecimals ?? 0), most)
 }
 
+/** The digits of an exponential and then as many zeros, every float that large being a whole one. */
+function expanded(exponential: string): string {
+    const [mantissa, exponent] = exponential.split('e')
+    const digits = mantissa.replace(/[-.]/g, '')
+    return `${mantissa.startsWith('-') ? '-' : ''}${digits}${'0'.repeat(Number(exponent) - digits.length + 1)}`
+}
+
+/** toFixed gives up past 1e21 and writes an exponent, which no quantity here is written with. */
+function toPlainFixed(value: number, places: number): string {
+    return Math.abs(value) < 1e21 ? value.toFixed(places) : expanded(value.toExponential())
+}
+
 function roundToDigits(value: number, rounding: Rounding): string {
-    return separateNumber(value.toFixed(decimalPlaces(value, rounding)))
+    return separateNumber(toPlainFixed(value, decimalPlaces(value, rounding)))
 }
 
 /** How a number is written: to a fixed number of decimal places, or to a number of digits. */
@@ -82,7 +94,7 @@ export function hoursAndMinutes(inMinutes: number): { written: string, unit: 'h'
 export function formatNumber(value: number, format: NumberFormat): string {
     switch (format.kind) {
         case 'fixed':
-            return separateNumber(value.toFixed(format.places))
+            return separateNumber(toPlainFixed(value, format.places))
         case 'rounded':
             return roundToDigits(value, format)
         case 'significantFigures':
@@ -121,12 +133,13 @@ export function formatToSignificantFigures(value: number, sigFigs: number = 3): 
         const integerPart = Math.floor(Math.abs(rounded))
         const integerDigits = integerPart.toString().length
         const places = Math.max(0, sigFigs - integerDigits)
-        return rounded.toFixed(places)
+        // past 1e21 the figures asked for are all there is to write, the rest being zeros
+        return Math.abs(rounded) < 1e21 ? rounded.toFixed(places) : expanded(rounded.toExponential(sigFigs - 1))
     }
     else {
         // For numbers < 1, we need sigFigs digits after the decimal point
         // The first non-zero digit is at position -magnitude
         const places = -magnitude + sigFigs - 1
-        return rounded.toFixed(places)
+        return toPlainFixed(rounded, places)
     }
 }

--- a/react/src/utils/text.ts
+++ b/react/src/utils/text.ts
@@ -56,14 +56,14 @@ function decimalPlaces(value: number, { significantDigits, minDecimals, maxDecim
     return Math.min(Math.max(significantDigits - Math.ceil(Math.log10(Math.abs(value))), minDecimals ?? 0), most)
 }
 
-/** The digits of an exponential and then as many zeros, every float that large being a whole one. */
-function expanded(exponential: string): string {
-    const [mantissa, exponent] = exponential.split('e')
+/** The digits of a number in scientific notation and then as many zeros, every float that large being a whole one. */
+function expanded(scientific: string): string {
+    const [mantissa, exponent] = scientific.split('e')
     const digits = mantissa.replace(/[-.]/g, '')
     return `${mantissa.startsWith('-') ? '-' : ''}${digits}${'0'.repeat(Number(exponent) - digits.length + 1)}`
 }
 
-/** toFixed gives up past 1e21 and writes an exponent, which no quantity here is written with. */
+/** toFixed gives up past 1e21 and writes scientific notation, which no quantity here is written in. */
 function toPlainFixed(value: number, places: number): string {
     return Math.abs(value) < 1e21 ? value.toFixed(places) : expanded(value.toExponential())
 }

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -10,17 +10,20 @@ export interface Written {
 const artificialZeroCost = 100
 
 /**
- * We charge 1 for every digit as printed, with two adjustments:
+ * We charge 1 for every digit as printed, with three adjustments:
  * - a number rounded away to 0 is heavily penalized, unless in fixed point
  * - every leading 0 past the decimal point is charged as another digit
+ * - an exponent is charged for the digits it stands in for, having printed none of them
  */
 function digitCost(value: number, format: NumberFormat): number {
     const written = formatNumber(value, format)
-    const digits = written.replace(/[^0-9]/g, '')
+    const [mantissa, exponent] = written.split('e')
+    const digits = mantissa.replace(/[^0-9]/g, '')
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return artificialZeroCost
     }
-    return digits.length + (/^-?0\.(0*)[1-9]/.exec(written)?.[1].length ?? 0)
+    const standsIn = exponent === undefined ? 0 : Math.abs(Number(exponent))
+    return digits.length + standsIn + (/^-?0\.(0*)[1-9]/.exec(mantissa)?.[1].length ?? 0)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -17,12 +17,13 @@ const artificialZeroCost = 100
  */
 function digitCost(value: number, format: NumberFormat): number {
     const written = formatNumber(value, format)
-    const [mantissa, exponent] = written.split('e')
+    const exponent = /e([+-]?\d+)$/.exec(written)
+    const mantissa = exponent === null ? written : written.slice(0, exponent.index)
     const digits = mantissa.replace(/[^0-9]/g, '')
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return artificialZeroCost
     }
-    const standsIn = exponent === undefined ? 0 : Math.abs(Number(exponent))
+    const standsIn = exponent === null ? 0 : Math.abs(Number(exponent[1]))
     return digits.length + standsIn + (/^-?0\.(0*)[1-9]/.exec(mantissa)?.[1].length ?? 0)
 }
 

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -10,21 +10,17 @@ export interface Written {
 const artificialZeroCost = 100
 
 /**
- * We charge 1 for every digit as printed, with three adjustments:
+ * We charge 1 for every digit as printed, with two adjustments:
  * - a number rounded away to 0 is heavily penalized, unless in fixed point
  * - every leading 0 past the decimal point is charged as another digit
- * - an exponent is charged for the digits it stands in for, having printed none of them
  */
 function digitCost(value: number, format: NumberFormat): number {
     const written = formatNumber(value, format)
-    const exponent = /e([+-]?\d+)$/.exec(written)
-    const mantissa = exponent === null ? written : written.slice(0, exponent.index)
-    const digits = mantissa.replace(/[^0-9]/g, '')
+    const digits = written.replace(/[^0-9]/g, '')
     if (value !== 0 && format.kind !== 'fixed' && !/[1-9]/.test(digits)) {
         return artificialZeroCost
     }
-    const standsIn = exponent === null ? 0 : Math.abs(Number(exponent[1]))
-    return digits.length + standsIn + (/^-?0\.(0*)[1-9]/.exec(mantissa)?.[1].length ?? 0)
+    return digits.length + (/^-?0\.(0*)[1-9]/.exec(written)?.[1].length ?? 0)
 }
 
 type Exponents = Partial<Record<BaseUnit, number>>

--- a/react/unit/formatToSignificantFigures.test.ts
+++ b/react/unit/formatToSignificantFigures.test.ts
@@ -118,4 +118,11 @@ void describe('formatToSignificantFigures', () => {
         assert.equal(formatToSignificantFigures(1e11), '100000000000')
         assert.equal(formatToSignificantFigures(1e12), '1000000000000')
     })
+
+    void test('writes a number too large for toFixed in full, rather than with an exponent', () => {
+        // toFixed gives up past 1e21, and a unit written 1e+22cm^{4} says nothing to anybody
+        assert.equal(formatToSignificantFigures(1e22), '10000000000000000000000')
+        assert.equal(formatToSignificantFigures(1.234e22), '12300000000000000000000')
+        assert.equal(formatToSignificantFigures(-1e22), '-10000000000000000000000')
+    })
 })

--- a/react/unit/formatToSignificantFigures.test.ts
+++ b/react/unit/formatToSignificantFigures.test.ts
@@ -119,7 +119,7 @@ void describe('formatToSignificantFigures', () => {
         assert.equal(formatToSignificantFigures(1e12), '1000000000000')
     })
 
-    void test('writes a number too large for toFixed in full, rather than with an exponent', () => {
+    void test('writes a number too large for toFixed in full, rather than in scientific notation', () => {
         // toFixed gives up past 1e21, and a unit written 1e+22cm^{4} says nothing to anybody
         assert.equal(formatToSignificantFigures(1e22), '10000000000000000000000')
         assert.equal(formatToSignificantFigures(1.234e22), '12300000000000000000000')

--- a/react/unit/unit-search.test.ts
+++ b/react/unit/unit-search.test.ts
@@ -95,6 +95,13 @@ void test('a unit that pushes the figures past the point is not reached for', ()
     assert.equal(chosen(1040, { m: 1 }, [unit('km', { m: 1 }, 1e3, 0.5), meter], () => threeFiguresRounded), 'km^1')
 })
 
+void test('a unit that hides the number behind an exponent is not reached for', () => {
+    const centimeter = unit('cm', { m: 1 }, 0.01, 1)
+    // a hundred square kilometres squared is 1e+22 square centimetres squared, which prints one
+    // figure and an exponent standing in for twenty-two digits nobody has been shown
+    assert.equal(chosen(1e14, { m: 4 }, [kilometer, meter, centimeter], () => threeFiguresRounded), 'km^4')
+})
+
 void test('a fixed number of places is a decision that rounding away is precise enough', () => {
     // a fraction of a person is no people, which is what whole numbers of them means
     assert.equal(chosen(0.123, { person: 1 }, counting), '<none>^1')


### PR DESCRIPTION
Off main. Found while poking at captions in #2320.

## The symptom

```
area ** 2, at a hundred square kilometres squared:   1e+22cm^{4}
```

The search counts the digits a candidate unit leaves to read, and `1e+22` prints three. So the smallest unit in the pool won whenever a quantity got large enough to be written that way.

## Where the fix goes

My first attempt charged the exponent for the digits it stood in for, inside `digitCost`. That was the wrong end: **nothing here is written with an exponent**, so nothing should write one, and then a digit's cost is just a digit's cost again.

`toFixed` gives up past 1e21 and switches to scientific notation; both of this file's paths end in it. Every float that large is a whole number, so the digits it is written to and then as many zeros are the whole of it:

```ts
function toPlainFixed(value: number, places: number): string {
    return Math.abs(value) < 1e21 ? value.toFixed(places) : expanded(value.toExponential())
}
```

Which digits those are is the caller's business: all the ones that tell the number apart where the places were fixed, and only the figures asked for where a number of them was — `formatToSignificantFigures(1.234e22)` writes `12300000000000000000000`, not the float's exact `12299999999999998951424`.

`digitCost` is untouched by this PR now.

## What moves

```
area ** 2      100.0km^{4}
area ** 3      100.0km^{6}
area * area    100.0km^{4}
```

Nothing a declared unit writes: the 1 800-case sweep (30 unit types × 20 values × 3 reader settings) is byte-identical. Only a quantity derived from several statistics has the dimensions to reach 1e21 at all.

## Verification

`tsc`, lint, knip, the full unit suite, four new cases — three on the formatter, and the search one, which picks `cm^4` if a number may be written with an exponent and `km^4` once it may not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

