### PR TITLE
Stop writing D++ for a difference of two leads, and test what derived quantities are written in

### DIFF
--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -410,7 +410,8 @@ export function writeQuantity(value: number, stored: StoredUnit, settings: Reade
         party = getParty(leads, inBaseUnits)
         inBaseUnits = Math.abs(inBaseUnits)
     }
-    const explicitSign = unit.times === 0 && inBaseUnits >= 0 ? '+' : ''
+    // whose lead it is carries a plus of its own, and a difference of two leads is not D++4.5
+    const explicitSign = party === undefined && unit.times === 0 && inBaseUnits >= 0 ? '+' : ''
     const written = formatNumber(representation.scale(inBaseUnits), representation.format)
     return {
         renderedValue: `${party === undefined ? '' : `${party.label}+`}${explicitSign}${representation.prefix ?? ''}${written}`,

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -65,6 +65,42 @@ void test('a statistic that names its own units is written in them, counted thin
     assert.equal(written(unitOfMap('traffic_fatalities_per_capita'), 1e-5), '1.00/\u00a0100k')
 })
 
+// What a map of each of these is written in, at a stored value of 1234
+for (const [data, expected] of [
+    // a rate times a time is a length, and a count over a time is a rate of its own
+    ['rainfall * sunny_hours', '14.1cm'],
+    ['population / sunny_hours', '20.6/\u00a0min'],
+    ['elevation * elevation', '1\u202f234m^{2}'],
+    ['area ** -1', '1\u202f234/\u00a0km^{2}'],
+    // of no dimension left, and of no kind either
+    ['area / area', '1\u202f230'],
+    ['population ** 0', '1\u202f230'],
+    ['inverseQuantile(area, area)', '1\u202f230'],
+    // a reading over a reading has no zero to divide from, and two lengths held apart do not meet
+    ['high_temp / high_temp', 'nothing'],
+    ['minimum(elevation, hospital_mean_dist)', 'nothing'],
+    // an empty vector is of every kind and so of none
+    ['[]', 'nothing'],
+    // the ways a script has of saying the same thing
+    ['if (population > 0) { area } else { area }', '1\u202f234km^{2}'],
+    ['if (population > 0) { area }', '1\u202f234km^{2}'],
+    ['do { x = area; x }', '1\u202f234km^{2}'],
+    ['[area, area]', '1\u202f234km^{2}'],
+    ['sum(area)', '1\u202f234km^{2}'],
+] as const) {
+    void test(`a map of ${data} is written ${expected}`, () => {
+        assert.equal(written(unitOfMap(data), 1234), expected)
+    })
+}
+
+void test('a difference of two leads is written as the lead it is, and not twice over', () => {
+    // whose lead it is carries a plus of its own, so a swing of four and a half is D+4.50%
+    assert.equal(written(unitOfMap('pres_2020_margin - pres_2016_margin'), 0.045), 'D+4.50%')
+    assert.equal(written(unitOfMap('pres_2020_margin'), 0.045), 'D+4.50%')
+    // where a change of no party's keeps the plus that says it is a change
+    assert.equal(written(unitOfMap('commute_bike - commute_transit'), 0.045), '+4.50%')
+})
+
 void test('a quantity with no writing is left to whatever its name is taken for', () => {
     // a root of a count is in no unit any pool holds, and asking for one threw
     assert.equal(mapUnit('population ** 0.5'), 'nothing')


### PR DESCRIPTION
Off main. A stress of the inference that landed in #2305 — I ran about fifty expressions through it, every shape a script has for making a quantity. One was written wrong; that is fixed here, and fifteen of the rest are written down as tests.

## The one wrong

A difference of two party margins was written **`D++4.50%`**. Whose lead it is carries a plus of its own, and a difference carries another:

```ts
const explicitSign = party === undefined && unit.times === 0 && inBaseUnits >= 0 ? '+' : ''
```

Only reachable since #2305, since a declared swing is decorated with a hue rather than a lead. A change of no party's keeps its plus: `commute_bike - commute_transit` is `+4.50%`.

## The rest, now tested

| script | written |
|---|---|
| `rainfall * sunny_hours` | `14.1cm` — a rate times a time is a depth |
| `population / sunny_hours` | `20.6 / min` |
| `elevation * elevation` | `1 234m²` |
| `area ** -1` | `1 234 / km²` |
| `area / area`, `population ** 0`, `inverseQuantile(area, area)` | a number of no kind |
| `high_temp / high_temp` | nothing — no zero to divide from |
| `minimum(elevation, hospital_mean_dist)` | nothing — metres and kilometres do not meet |
| `[]` | nothing |
| `if … else`, `if` alone, `do { x = area; x }`, `[area, area]`, `sum(area)` | `1 234km²` |

That `minimum` one is worth a look: both are lengths, but one is stored in metres and the other in kilometres, so the smaller of the two raw numbers means nothing. Refusing is right.

## Also checked, and right as they are

`population * 0` is a difference of no people, `population / 0` is still people however many, `commute_bike * 100` really is a share of 500% — the script scaled it — and a fraction of a second reads `30min` where a thousand hours reads `1234:00h`.

## Verification

`tsc`, lint, knip, the full unit suite, 18 new cases. The 1 800-case sweep of declared units is byte-identical: the double plus needs a lead in a difference, which only a derived quantity can be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

