### PR TITLE
Deploy the OG Worker from the commit that built the site

### DIFF
--- a/react/cf-og-worker/README.md
+++ b/react/cf-og-worker/README.md
@@ -55,8 +55,10 @@ origin rather than openfreemap. The card screenshot tests point it at a snapshot
 [`site_workflows/deploy-cf-og-worker.yml`](../../site_workflows/deploy-cf-og-worker.yml)
 is copied into the site repository by
 [`urbanstats/website_data/build.py`](../../urbanstats/website_data/build.py) along with the rest of
-the site, and runs *there*, on that repo's `page_build` event. It checks out urbanstats `main` and
-deploys the Worker from it, on the assumption that whatever built the site is on `main` by then.
+the site, and runs *there*, on that repo's `page_build` event. `build.py` substitutes the urbanstats
+commit it is building from into the workflow's `ref`, so the Worker is deployed from the same code
+as the site it fronts. Building the site from a commit that is not pushed to urbanstats fails that
+checkout rather than deploying a mismatched Worker.
 
 It needs three secrets on the site repository: `URBANSTATS_TOKEN` to check out this repo, and
 `CLOUDFLARE_API_TOKEN` plus `CLOUDFLARE_ACCOUNT_ID` for an account holding the `urbanstats.org`

--- a/site_workflows/deploy-cf-og-worker.yml
+++ b/site_workflows/deploy-cf-og-worker.yml
@@ -6,8 +6,14 @@ name: Deploy CF OG Worker
 # It bundles the site's page-loading code and reads its data files, so redeploying whenever
 # the Pages site is built keeps the two in step.
 #
-# The Worker is built from urbanstats main, on the assumption that whatever built the site is on
-# main by the time it is deployed; workflow_dispatch is here for the times it isn't.
+# build.py substitutes the urbanstats commit that built the site into the ref below when it writes
+# this file, so the Worker is built from the same code as the site it fronts rather than from
+# whatever main has drifted to. A site built from an unpushed commit fails the checkout here rather
+# than deploying a mismatched Worker.
+#
+# A push made with the default GITHUB_TOKEN triggers none of this repo's workflows, so the retrostat
+# job's commits never reach this, though Pages still builds and deploys them through GitHub's own
+# pages-build-deployment. They leave the ref alone, so the deployed Worker is already the right one.
 on:
   page_build:
   workflow_dispatch:
@@ -23,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kavigupta/urbanstats
+          ref: $URBANSTATS_REF
           token: ${{ secrets.URBANSTATS_TOKEN }}
           # Everything the Worker bundles lives under react/.
           sparse-checkout: react

--- a/urbanstats/website_data/build.py
+++ b/urbanstats/website_data/build.py
@@ -364,12 +364,18 @@ def build_urbanstats(
     shutil.copy("icons/main/arrow-right.png", f"{site_folder}/")
 
     os.makedirs(f"{site_folder}/.github/workflows", exist_ok=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
     for workflow in [
         "update-retrostat.yml",
         "deploy-cf-og-worker.yml",
         "sync-cf-proxy.yml",
     ]:
-        shutil.copy(f"site_workflows/{workflow}", f"{site_folder}/.github/workflows/")
+        with open(f"site_workflows/{workflow}") as f_workflow:
+            contents = f_workflow.read()
+        with open(f"{site_folder}/.github/workflows/{workflow}", "w") as f_workflow:
+            f_workflow.write(contents.replace("$URBANSTATS_REF", head))
 
     with open(f"{site_folder}/CNAME", "w") as f_cname:
         f_cname.write("urbanstats.org")

--- a/urbanstats/website_data/build.py
+++ b/urbanstats/website_data/build.py
@@ -216,7 +216,7 @@ def build_react_site(site_folder: str, mode: str) -> None:
 BUILD_STEPS = frozenset({"shapes", "articles", "index", "ordering", "sitemap", "juxta"})
 
 
-# pylint: disable-next=too-many-branches,too-many-statements
+# pylint: disable-next=too-many-branches,too-many-statements,too-many-locals
 def build_urbanstats(
     site_folder: str, *, steps: Union[Set[str], FrozenSet[str]], mode: str
 ) -> None:


### PR DESCRIPTION
The Worker deploy checked out urbanstats `main`, so anything merged between a site build and its deploy shipped a Worker built from code the deployed site does not contain. The Worker bundles the site's page-loading code, so that mismatch is real, not theoretical.

`build.py` now substitutes its own `HEAD` into the workflow's `ref` as it writes the file into the site repo, which pins the Worker to the site it fronts. The nice side effect is that building the site from a commit that was never pushed fails the checkout loudly rather than quietly deploying whatever `main` happens to hold.

The other half of this is documentation. The workflow looks like it never runs on densitydb.github.io, and I went looking for the bug: there isn't one. It has run on `page_build`, successfully, for human pushes. The two Pages builds since came from the retrostat job's `github-actions[bot]` commits, and a push made with the default `GITHUB_TOKEN` triggers none of the site repo's own workflows. Pages still builds and deploys those commits — `pages-build-deployment` is GitHub's workflow, not the repo's — and they do not change the `ref`, so there is nothing to redeploy. That is now a comment in the workflow header so the next person does not repeat the search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)