### PR TITLE
Cancel the pending hover popover when the mouse leaves the token

### DIFF
--- a/react/src/urban-stats-script/Editor.tsx
+++ b/react/src/urban-stats-script/Editor.tsx
@@ -309,8 +309,9 @@ export function Editor(
         return () => { editor.removeEventListener('blur', listener) }
     }, [])
 
+    const [hover, setHover] = useState<{ token: AnnotatedToken, elemOffset: number, opts: Omit<InspectState, 'kind' | 'element'> } | undefined>(undefined)
+
     useEffect(() => {
-        let hoveredToken: AnnotatedToken | undefined
         const listener = (event: MouseEvent): void => {
             for (const elem of document.elementsFromPoint(event.clientX, event.clientY)) {
                 const token = spanTokenMapRef.current.get(elem)
@@ -319,39 +320,39 @@ export function Editor(
                     const documentation = typeEnvironment.get(name)
                     const value = assignments.get(name)
                     if (documentation !== undefined || value !== undefined) {
-                        hoveredToken = token
-                        const opts = {
-                            location: token.location,
-                            name,
-                            documentation,
-                            value,
-                        }
-                        const elemOffset = totalOffset(elem).left
-                        setTimeout(() => {
-                            if (hoveredToken === token) {
-                                setPopoverState({
-                                    kind: 'inspect',
-                                    ...opts,
-                                    element: createDocumentationPopover(colors, editorRef.current!, elemOffset),
-                                })
-                            }
-                        }, 500)
+                        // Keep the same object while we're on the same token, so we don't restart the delay
+                        const next = { token, elemOffset: totalOffset(elem).left, opts: { location: token.location, name, documentation, value } }
+                        setHover(prev => prev?.token === token ? prev : next)
                         return
                     }
                 }
                 if (popoverState?.kind === 'inspect' && popoverState.element === elem) {
-                    hoveredToken = undefined
+                    setHover(undefined)
                     return
                 }
             }
-            hoveredToken = undefined
+            setHover(undefined)
             if (popoverState?.kind === 'inspect') {
                 setPopoverState(undefined)
             }
         }
         document.addEventListener('mousemove', listener)
         return () => { document.removeEventListener('mousemove', listener) }
-    }, [colors, typeEnvironment, popoverState, assignments])
+    }, [typeEnvironment, popoverState, assignments])
+
+    useEffect(() => {
+        if (hover === undefined) {
+            return
+        }
+        const timeout = setTimeout(() => {
+            setPopoverState({
+                kind: 'inspect',
+                ...hover.opts,
+                element: createDocumentationPopover(colors, editorRef.current!, hover.elemOffset),
+            })
+        }, 500)
+        return () => { clearTimeout(timeout) }
+    }, [hover, colors])
 
     const borderColor = useResultsColor(colorKey(results))
 


### PR DESCRIPTION
Moving the mouse off an identifier just before the 500ms hover delay elapsed still showed the documentation popover, which then stayed put until the next mouse movement.

The timer's guard read an effect-local `hoveredToken` variable, but that effect is torn down and rebuilt whenever `popoverState`, `colors`, `typeEnvironment`, or `assignments` change. A timer scheduled before one of those re-runs kept checking the previous run's variable, which was no longer being updated by the live listener, so the guard passed for a token the pointer had already left. Nothing cleared the timer either.

The fix separates hover tracking from the delay. `mousemove` now only records which token is under the pointer in state, and a second effect owns the `setTimeout` and clears it in its finalizer — the standard pattern, which wasn't usable before because the listener effect's frequent teardown would have cancelled legitimate pending hovers. The timer effect depends only on the hovered token and `colors`, so unrelated re-renders leave it alone, and setting hover to `undefined` cancels the popover.

The functional `setHover` matters: it keeps the previous state object while the pointer stays on the same token, so drifting within a token doesn't restart the delay and the popover can actually appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)