### PR TITLE
Let a larger of a quantity and a bare number be that quantity

### DIFF
--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -1,4 +1,4 @@
-import { dimensionless } from '../utils/quantity'
+import { dimensionless, sameDimensions } from '../utils/quantity'
 import { unitTypeToStoredUnit } from '../utils/unit'
 
 import { UrbanStatsASTArg, UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
@@ -98,10 +98,14 @@ function whatItGives(propagation: Exclude<UnitPropagation, { kind: 'regression' 
         case 'power':
             return forward('**', value, constant(propagation.exponent))
         case 'either': {
-            // a bare number is comparable with anything, so it takes the unit of what it is compared
-            // with, as it does in a sum; two knowns have to agree, and two bare numbers stay bare
             const other = argument(args, 1, scope)
-            return value.kind === 'any' || other.kind === 'any' ? forward('+', value, other) : join(value, other)
+            // two knowns must be alike, and the larger of them is one of them rather than two: an
+            // area and an area is an area, where a population and an area is nothing at all
+            if (value.kind === 'in' && other.kind === 'in') {
+                return sameDimensions(value.unit, other.unit) ? join(value, other) : { kind: 'none' }
+            }
+            // a bare number takes the unit of what it is compared with, as it does in a sum
+            return forward('+', value, other)
         }
         case 'rank': {
             // of one kind, so nothing is the rank of a population among areas

--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -97,8 +97,12 @@ function whatItGives(propagation: Exclude<UnitPropagation, { kind: 'regression' 
         }
         case 'power':
             return forward('**', value, constant(propagation.exponent))
-        case 'either':
-            return join(value, argument(args, 1, scope))
+        case 'either': {
+            // a bare number is comparable with anything, so it takes the unit of what it is compared
+            // with, as it does in a sum; two knowns have to agree, and two bare numbers stay bare
+            const other = argument(args, 1, scope)
+            return value.kind === 'any' || other.kind === 'any' ? forward('+', value, other) : join(value, other)
+        }
         case 'rank': {
             // of one kind, so nothing is the rank of a population among areas
             const alike = forward('-', value, argument(args, 1, scope))

--- a/react/unit/unit-inference.test.ts
+++ b/react/unit/unit-inference.test.ts
@@ -122,8 +122,8 @@ for (const [code, expected] of [
     ['quantile(population, 0.5)', 'person^1 times=1 x1'],
     ['percentile(area, 90)', 'm^2 times=1 x1000000'],
     ['maximum(population, population)', 'person^1 times=1 x1'],
-    // of two unlike kinds, neither
-    ['maximum(population, area)', 'unknown'],
+    // nothing is the larger of a population and an area
+    ['maximum(population, area)', 'inconsistent'],
     ['inverseQuantile(population, population)', 'dimensionless times=1 x1'],
     ['sign(population)', 'dimensionless times=1 x1'],
     // a function that states no rule says any quantity at all, rather than none
@@ -159,9 +159,11 @@ void test('a larger of a quantity and a bare number is that quantity', () => {
     assert.equal(inferred('maximum(high_temp, 80)'), 'F^1 times=1 x1')
     assert.equal(inferred('minimum(area, 100)'), 'm^2 times=1 x1000000')
     assert.equal(inferred('maximum(0.05, commute_bike)'), 'dimensionless times=1 x1')
-    // where two bare numbers are bare, and two of unlike units are of neither
+    // two bare numbers stay bare, no unit being known of either
     assert.equal(inferred('maximum(1, 2)'), 'unknown')
-    assert.equal(inferred('maximum(population, area)'), 'unknown')
+    // and nothing is the larger of a population and an area, as nothing is their sum
+    assert.equal(inferred('maximum(population, area)'), 'inconsistent')
+    assert.equal(inferred('maximum(population + area, population)'), 'inconsistent')
 })
 
 void test('a total is as many of them as there were, which is not a number anyone knows', () => {

--- a/react/unit/unit-inference.test.ts
+++ b/react/unit/unit-inference.test.ts
@@ -154,6 +154,16 @@ void test('a rank is of two of one kind, and is a number of none', () => {
     assert.equal(inferred('inverseQuantile(population, area)'), 'inconsistent')
 })
 
+void test('a larger of a quantity and a bare number is that quantity', () => {
+    // as a sum of one and the other is, only alike things being comparable in the first place
+    assert.equal(inferred('maximum(high_temp, 80)'), 'F^1 times=1 x1')
+    assert.equal(inferred('minimum(area, 100)'), 'm^2 times=1 x1000000')
+    assert.equal(inferred('maximum(0.05, commute_bike)'), 'dimensionless times=1 x1')
+    // where two bare numbers are bare, and two of unlike units are of neither
+    assert.equal(inferred('maximum(1, 2)'), 'unknown')
+    assert.equal(inferred('maximum(population, area)'), 'unknown')
+})
+
 void test('a total is as many of them as there were, which is not a number anyone knows', () => {
     assert.equal(inferred('sum(population)'), 'person^1 times=unknown x1')
     // so many people are people all the same, where so many temperatures are no temperature


### PR DESCRIPTION
Off main. Found by the four-column table test in #2320, where a column's **name** said `max(Commute Bike %, 5%)` while its **values** were written bare.

## The bug

The `either` rule from #2311 — `maximum`, `minimum` — joined its two arguments:

```ts
return join(value, argument(args, 1, scope))
```

A join is a least upper bound, and a bare number could be a quantity of anything, so joining one with a known unit gives neither:

```
maximum(commute_bike, 0.05)   any        column written 0.0500
maximum(high_temp, 80)        any
minimum(area, 100)            any
maximum(area, area)           m^2        two knowns were always fine
commute_bike + 0.05           a share    + had it right all along
```

## The rule

A number written bare is comparable with anything and takes the unit of what it is compared with — which is what `addedForward` already does for a sum, so `either` asks it:

```ts
const other = argument(args, 1, scope)
return value.kind === 'any' || other.kind === 'any' ? forward('+', value, other) : join(value, other)
```

```
maximum(commute_bike, 0.05)   5.00%
maximum(high_temp, 80)        a temperature
minimum(area, 100)            an area
maximum(area, area)           an area, not two of one
maximum(population, area)     nothing
maximum(1, 2)                 bare
```

Two knowns must be alike, and where they are not the answer is **none** rather than any-quantity-at-all: nothing is both a population and an area, so nothing is their sum, and nothing is the larger of them either. A join answers a conflict by rising above it, which is not what is wanted of a comparison.

## Verification

`tsc`, lint, knip, the full unit suite, five new cases — the first of which fails on main with `unknown`. The 1 800-case sweep of declared units is byte-identical; only a derived quantity reaches this rule.

Once this lands, the four-column e2e in #2320 expects `5.00%` where it currently expects `0.0500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

