### PR TITLE
Supersede a PR's in-flight checks when it gets a new push

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,12 +5,12 @@ on:
       - main
   pull_request:
 concurrency:
-  # A PR gets a synchronize event when its base branch is updated, as well as when its own
-  # head is. Pushing a stack of branches therefore starts two identical runs for every PR
-  # above the bottom one. Grouping by commit collapses those, while leaving a run for an
-  # earlier commit alone.
-  group: check-${{ github.event.pull_request.head.sha || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Grouping by PR means a push supersedes whatever that PR was already running. It also
+  # collapses the two identical runs a stacked push produces, since a PR above the bottom
+  # one gets a synchronize event for its base branch as well as for its own head.
+  group: check-${{ github.event.pull_request.number || github.sha }}
+  # Label a PR `keep-ci` to let its in-flight runs finish instead of being superseded.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'keep-ci') }}
 env:
   # This is used in ci_proxy, do not remove. It is necessary so that
   # we can test against non-production data

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Push your branch to Github. If changes on the frontend depend on changes on the 
 
 Correct any failing checks.
 
+Pushing again cancels the checks still running on the PR's previous commit. Label the PR
+`keep-ci` if you need those to finish — the label has to be on the PR before you push.
+
 Create a PR for your branch.
 
 # Running Multiple Urban Stats Frontends at Once


### PR DESCRIPTION
Grouping the concurrency key by commit meant a push left the previous commit's run going, so a PR that got three pushes in a row occupied three sets of e2e shards, only the newest of which anyone would look at. Grouping by PR number cancels the older run instead, and still collapses the duplicate runs a stacked push produces, since those share a PR as well as a commit.

The escape hatch is a `keep-ci` label rather than a marker in the commit message. `concurrency` is evaluated against the event payload, and a `pull_request` payload carries the PR's title, body and labels but not any commit message, so a commit-message marker isn't reachable from that key. A label also costs nothing to toggle. It is read from the payload of the incoming run, so it only protects a run if it was already applied when the next push happened, and a labelled PR loses the stacked-push dedup along with the cancelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)