### PR TITLE
Retry a checkbox click that the panel's relayout swallowed

### DIFF
--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -39,7 +39,12 @@ export async function checkTextboxesDirect(t: TestController, txts: string[], nt
             .nth(nth)
         // find checkbox
             .find('input')
-        await t.click(checkbox)
+        // a click that lands while the panel is still moving misses, leaving the setting as it was
+        await flaky(t, async () => {
+            const wasChecked = await checkbox.checked
+            await t.click(checkbox)
+            await t.expect(checkbox.checked).eql(!wasChecked, `Clicking ${txt} did not toggle it`)
+        })
     }
 }
 /** For the checkboxes that are still in the sidebar: the settings, appearance and random ones. */


### PR DESCRIPTION
`checkTextboxesDirect` could report success for a click that toggled nothing, which is where the statistics screenshot flake came from.

Unchecking one setting removes its sub-editor, so everything below it shifts up, and the collapsable container only learns its new height from a `ResizeObserver` on the hidden measuring copy in `RenderTwiceHidden` — a frame or more after the DOM change. The helper clicks its boxes back to back with nothing in between, so the second click can be aimed at coordinates that have stopped being that checkbox. TestCafe is happy either way.

The test then ran on against a setting it believed it had changed. In the case that surfaced this, `setUpSecondColumn` means to uncheck the copied `unit=unitNumber` on the second column so the unit is derived instead; when the uncheck was swallowed the column stayed dimensionless, and the failure landed several steps later on an exported image reading `62.6` where the reference reads `63 / km²` — three significant figures and no suffix, rather than the density unit's two.

Asserting the toggle inside `flaky()` moves the failure to the click itself and retries it, giving the panel a chance to settle. The state is re-read on each attempt, so a retry cannot toggle a click that did work back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)