### PR TITLE
Say the two rules for a larger of two plainly

### DIFF
--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -99,12 +99,11 @@ function whatItGives(propagation: Exclude<UnitPropagation, { kind: 'regression' 
             return forward('**', value, constant(propagation.exponent))
         case 'either': {
             const other = argument(args, 1, scope)
-            // two knowns must be alike, and the larger of them is one of them rather than two: an
-            // area and an area is an area, where a population and an area is nothing at all
+            // Two known units must match, and the result is one of them, not their sum.
             if (value.kind === 'in' && other.kind === 'in') {
                 return sameDimensions(value.unit, other.unit) ? join(value, other) : { kind: 'none' }
             }
-            // a bare number takes the unit of what it is compared with, as it does in a sum
+            // A bare number takes the other argument's unit, as it does in a sum.
             return forward('+', value, other)
         }
         case 'rank': {


### PR DESCRIPTION
Comments only, no behaviour. The two comments #2340 landed with state their rules by example and parallel construction rather than by saying them:

```
- // two knowns must be alike, and the larger of them is one of them rather than two: an
- // area and an area is an area, where a population and an area is nothing at all
+ // Two known units must match, and the result is one of them, not their sum.

- // a bare number takes the unit of what it is compared with, as it does in a sum
+ // A bare number takes the other argument's unit, as it does in a sum.
```

These were written during #2340's review and missed the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)