### PR TITLE
Remove the default arguments from writeQuantity and renderQuantity

### DIFF
--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -37,7 +37,7 @@ function InParty({ value, hue }: { value: string, hue: Hue }): ReactNode {
     return <span style={spanStyle}>{value}</span>
 }
 
-export function renderQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}, placement: UnitPlacement = {}): DisplayedQuantity {
+export function renderQuantity(value: number, stored: StoredUnit, settings: ReaderSettings, placement: UnitPlacement): DisplayedQuantity {
     const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings, placement)
     return {
         value: hue === undefined ? <span>{renderedValue}</span> : <InParty value={renderedValue} hue={hue} />,
@@ -53,7 +53,7 @@ export function renderQuantity(value: number, stored: StoredUnit, settings: Read
 export function QuantityTogether({ value, stored }: { value: number, stored: StoredUnit }): ReactNode {
     const [useImperial] = useSetting('use_imperial')
     const [temperatureUnit] = useSetting('temperature_unit')
-    const { renderedValue, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit })
+    const { renderedValue, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit }, {})
     const colors = useColors()
     return (
         <span style={hue === undefined ? undefined : { color: colors.hueColors[hue] }}>

--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -306,7 +306,7 @@ function trimTrailingZeros(value: string): string {
 
 function formatNumber(number: number, unit?: StoredUnit): HumanReadableElement[] {
     if (unit !== undefined) {
-        const { renderedValue, unitName } = writeQuantity(number, unit)
+        const { renderedValue, unitName } = writeQuantity(number, unit, {}, {})
         return [{ type: 'atom', value: trimTrailingZeros(renderedValue) }, ...unitName]
     }
     if (number >= 1e4) {

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -403,7 +403,7 @@ export interface WrittenQuantity {
     hue?: Hue
 }
 
-export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings = {}, placement: UnitPlacement = {}): WrittenQuantity {
+export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings, placement: UnitPlacement): WrittenQuantity {
     if (!isFinite(value)) {
         return { renderedValue: missingValue, unitName: [] }
     }

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -12,7 +12,7 @@ function written(unit: StoredUnit | undefined, value = 1000, settings: ReaderSet
     if (unit === undefined) {
         return 'nothing'
     }
-    const quantity = writeQuantity(value, unit, settings)
+    const quantity = writeQuantity(value, unit, settings, {})
     return `${quantity.renderedValue}${reifyString(quantity.unitName)}`
 }
 

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -211,7 +211,7 @@ for (const [level, declared] of [
         const inferred = unitToWriteIn(forward('-', inUnit(storedUnits[level]), inUnit(storedUnits[level])))
         assert.notEqual(inferred, undefined)
         const write = (stored: StoredUnit): string => {
-            const written = writeQuantity(0.05, stored)
+            const written = writeQuantity(0.05, stored, {}, {})
             return `${written.renderedValue}${reifyString(written.unitName)} ${written.hue ?? ''}`
         }
         assert.equal(write(inferred!), write(storedUnits[declared]))
@@ -246,8 +246,8 @@ void test('either of two shares of different parties is a share of neither', () 
     const orange = inUnit(storedUnits.partyPctOrange)
     const joined = join(orange, inUnit(storedUnits.partyPctRed))
     assert.equal(shape(joined), shape(orange))
-    assert.equal(writeQuantity(0.05, unitToWriteIn(joined)!).hue, undefined)
-    assert.notEqual(writeQuantity(0.05, unitToWriteIn(orange)!).hue, undefined)
+    assert.equal(writeQuantity(0.05, unitToWriteIn(joined)!, {}, {}).hue, undefined)
+    assert.notEqual(writeQuantity(0.05, unitToWriteIn(orange)!, {}, {}).hue, undefined)
 })
 
 void test('a coefficient is carried through a product and raised through a power', () => {
@@ -293,7 +293,7 @@ void test('a difference of temperatures divides into things as well as by them',
     const perDegree = unitToWriteIn(forward('/', people, change))
     assert.notEqual(perDegree, undefined)
     const write = (settings: object): string => {
-        const written = writeQuantity(5, perDegree!, settings)
+        const written = writeQuantity(5, perDegree!, settings, {})
         return `${written.renderedValue}${reifyString(written.unitName)}`
     }
     // five to the Fahrenheit degree is nine to the Celsius one, that being the larger degree
@@ -307,7 +307,7 @@ void test('a difference per something is read in degrees of the reader\'s own sc
     const perArea = unitToWriteIn(forward('/', forward('-', temperature, temperature), area))
     assert.notEqual(perArea, undefined)
     const write = (settings: object): string => {
-        const written = writeQuantity(5, perArea!, settings)
+        const written = writeQuantity(5, perArea!, settings, {})
         return `${written.renderedValue}${reifyString(written.unitName)}`
     }
     // five Fahrenheit degrees per square kilometre is two and a bit Celsius degrees, the zero

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -18,7 +18,7 @@ function textOf(node: unknown): string {
 }
 
 function renderValue(unitType: UnitType, value: number, useImperial = false, temperatureUnit = 'fahrenheit'): string {
-    const { value: valueEl, unit: unitEl } = renderQuantity(value, unitTypeToStoredUnit(unitType), { useImperial, temperatureUnit })
+    const { value: valueEl, unit: unitEl } = renderQuantity(value, unitTypeToStoredUnit(unitType), { useImperial, temperatureUnit }, {})
     return `${textOf(valueEl)}${textOf(unitEl)}`.trim()
 }
 
@@ -259,7 +259,7 @@ for (const [unitType, value, expected, hue] of [
     ['partyChangeTeal', -0.125, '-12.50', 'cyan'],
 ] as const) {
     void test(`${unitType} writes ${value} as ${expected} in ${hue}`, () => {
-        const written = writeQuantity(value, storedUnits[unitType])
+        const written = writeQuantity(value, storedUnits[unitType], {}, {})
         assert.equal(written.renderedValue, expected)
         assert.equal(written.hue, hue)
     })
@@ -269,7 +269,7 @@ for (const [unitType, value, expected, hue] of [
 // A quantity we do not have belongs to no party, and is measured in nothing
 for (const unitType of ['democraticMargin', 'partyPctOrange', 'percentage', 'temperature'] as const) {
     void test(`${unitType} writes a missing value plainly`, () => {
-        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType]), { renderedValue: 'N/A', unitName: [] })
+        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType], {}, {}), { renderedValue: 'N/A', unitName: [] })
     })
 }
 
@@ -316,7 +316,7 @@ for (const [unitType, dimensions, toBaseUnits, value, asStatistic, asDerived] of
     ['density', [{ baseUnit: 'person', power: 1 }, { baseUnit: 'm', power: -2 }], 1e-6, 1234, '1\u202f234/km^{2}', '1\u202f234/km^{2}'],
 ] as ['contaminantLevel' | 'distancePerYear' | 'density', Dimension[], number, number, string, string][]) {
     const write = (stored: StoredUnit): string => {
-        const written = writeQuantity(value, stored)
+        const written = writeQuantity(value, stored, {}, {})
         return `${written.renderedValue}${reifyString(written.unitName)}`
     }
     void test(`${unitType} keeps its units, where the same dimensions on their own do not`, () => {
@@ -341,7 +341,7 @@ for (const [times, value, temperatureUnit, expected] of [
     void test(`${times === 1 ? 'a temperature' : 'a difference'} of ${value}F reads as ${expected}`, () => {
         const temperature = unitTypeToStoredUnit('temperature')
         const stored: StoredUnit = { ...temperature, unit: { ...temperature.unit, times } }
-        const written = writeQuantity(value, stored, { temperatureUnit })
+        const written = writeQuantity(value, stored, { temperatureUnit }, {})
         assert.equal(`${written.renderedValue}${reifyString(written.unitName)}`, expected)
     })
 }


### PR DESCRIPTION
`writeQuantity` and `renderQuantity` both defaulted `settings` and `placement` to `{}`. A caller that forgot the reader's settings wrote metric to an imperial reader, and nothing said so — which is how the column headers fixed in #2348 came to be written in the site's units.

The defaults are gone; every call site passes both arguments. Behavior is unchanged: each site that was relying on the default now passes `{}` explicitly.

The one such site in `src/` is the number inside a script-derived caption (`derive-human-readable-name.ts`). It still writes in the site's units; #2348 is what makes it read the settings of whoever is looking at the page.

Landing this first, then merging main into #2348.