### PR TITLE
Verify Google tokens were issued to us before trusting their email

### DIFF
--- a/urbanstats-persistent-data/tests/conftest.py
+++ b/urbanstats-persistent-data/tests/conftest.py
@@ -6,6 +6,7 @@ import fastapi
 import fastapi.testclient
 import pytest
 from urbanstats_persistent_data.main import app
+from urbanstats_persistent_data.routes.email import google_client_id
 
 
 @pytest.fixture()
@@ -17,7 +18,13 @@ def setup_app(mocker):
 
         class MockResponse:
             status_code = 200
-            content = json.dumps({"email": access_token})
+            content = json.dumps(
+                {
+                    "email": access_token,
+                    "email_verified": True,
+                    "aud": google_client_id,
+                }
+            )
 
         return MockResponse()
 

--- a/urbanstats-persistent-data/tests/test_email.py
+++ b/urbanstats-persistent-data/tests/test_email.py
@@ -1,3 +1,7 @@
+import json
+
+from urbanstats_persistent_data.routes.email import google_client_id
+
 from .utils import (
     associate_email,
     create_identity,
@@ -84,3 +88,45 @@ def test_user_limit_drop(client):
             total_associated += 1
 
     assert total_associated == 16
+
+
+def test_rejects_token_from_another_client(client, mocker):
+    class MockResponse:
+        status_code = 200
+        content = json.dumps(
+            {
+                "email": "victim@gmail.com",
+                "email_verified": True,
+                "aud": "attackers-own-client.apps.googleusercontent.com",
+            }
+        )
+
+    mocker.patch("requests.get", lambda url: MockResponse())
+
+    response = client.post(
+        "/juxtastat/associate_email",
+        headers=identity_1,
+        json={"token": "victim-token"},
+    )
+    assert response.status_code == 401
+
+
+def test_rejects_unverified_email(client, mocker):
+    class MockResponse:
+        status_code = 200
+        content = json.dumps(
+            {
+                "email": "victim@gmail.com",
+                "email_verified": False,
+                "aud": google_client_id,
+            }
+        )
+
+    mocker.patch("requests.get", lambda url: MockResponse())
+
+    response = client.post(
+        "/juxtastat/associate_email",
+        headers=identity_1,
+        json={"token": "unverified-token"},
+    )
+    assert response.status_code == 401

--- a/urbanstats-persistent-data/urbanstats_persistent_data/routes/email.py
+++ b/urbanstats-persistent-data/urbanstats_persistent_data/routes/email.py
@@ -9,6 +9,10 @@ from ..db.email import associate_email_db, dissociate_email_db, get_user_email
 from ..dependencies.authenticate import AuthenticateRequest, authenticate_responses
 from ..main import app
 
+google_client_id = (
+    "866758015458-r7t30bm7b492c1mevid587apej6cjte6.apps.googleusercontent.com"
+)
+
 
 class AssociateEmailRequestBody(BaseModel):
     token: str
@@ -40,12 +44,22 @@ def get_email_from_token(token: str) -> str:
 
     class InfoSchema(BaseModel):
         email: str
+        email_verified: bool
+        aud: str
 
     try:
         info = InfoSchema(**json.loads(response.content))
-        return info.email
     except Exception as exc:
         raise fastapi.HTTPException(500, "Invalid response from Google") from exc
+
+    # Google will describe a token issued to any client, so without this an
+    # attacker could authenticate as anyone who signed into an app they control
+    if info.aud != google_client_id:
+        raise fastapi.HTTPException(401, "Access token was issued to another client")
+    if not info.email_verified:
+        raise fastapi.HTTPException(401, "Email is not verified")
+
+    return info.email
 
 
 @app.post(


### PR DESCRIPTION
An access token from any OAuth client could associate any address with a device. `/juxtastat/associate_email` read `email` off Google's tokeninfo response without checking `aud`, and tokeninfo will describe a token issued to someone else's client just as readily as one of ours. The attack is to register your own Google app, get victims to sign in to it with the low-friction `email` scope (a one-line consent screen, no Drive access), then post that token with your own `X-User`/`X-Secure-Id` headers. `authenticate` resolves a device to every user sharing its email, so this hands over the victim's quiz history; and because `associate_email_db` evicts a random existing user once an email reaches 16 associations, it also lets an attacker push a victim's real devices off their own account.

Checking `aud` against our client ID closes it. This is the only place a Google token becomes an Urban Stats identity, so it's the right chokepoint, but anything added later that trusts a Google token needs the same check.

`email_verified` is defense in depth rather than part of the fix. Google declines to vouch for addresses on unverified domains, which are exactly the ones someone can claim without owning, and an address we key accounts on ought to be one Google stands behind. Every `@gmail.com` and verified-Workspace user passes; the tail that doesn't is the tail we shouldn't be trusting as an identity.

Two things I decided rather than discovered. The client ID is a module constant next to the route instead of configuration, mirroring how the frontend hardcodes it — it isn't a secret and there's one of them. And a tokeninfo response missing `aud` or `email_verified` now fails schema parsing and returns the pre-existing 500 rather than a 401; arguably it should be 401, but a real Google response always carries both fields and I left the existing error path alone.

The durable version of this is keying accounts on `sub`, Google's stable per-user ID, instead of the address — that would also survive a user changing their Gmail address, which today silently orphans their quiz history. It's a schema migration and the address still has to stick around for the friends-by-email lookup, so it's left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)