### PR TITLE
Generate the quiz IDs with getRandomValues instead of Math.random

### DIFF
--- a/react/src/utils/random.ts
+++ b/react/src/utils/random.ts
@@ -1,9 +1,7 @@
 export function randomID(numCharacters = 15): string {
-    let randomHex = ''
-    for (let i = 0; i < numCharacters; i++) {
-        randomHex += Math.floor(Math.random() * 16).toString(16)[0]
-    }
-    return randomHex
+    const bytes = new Uint8Array(numCharacters)
+    crypto.getRandomValues(bytes)
+    return Array.from(bytes, byte => (byte & 0xf).toString(16)).join('')
 }
 
 export function randomBase62ID(numCharacters: number): string {


### PR DESCRIPTION
The secure ID is the only thing guarding a quiz account, and the persistent ID it guards is public — [quiz-friends.tsx:356](react/src/quiz/quiz-friends.tsx#L356) puts it in the `juxtastat.org` link users paste into group chats. Both were drawn from the same `Math.random` stream, back to back in the same page context, so the credential was only as unguessable as V8's xorshift128+ state, which the published value leaks bits of.

I did not build the state-recovery attack, and with 15 nibbles observed it may well not be practical against V8's batching. That isn't the point: a non-cryptographic PRNG should not be generating an authentication credential, and the fix is three lines.

Existing users are unaffected — their IDs are already in localStorage, and this only changes how new ones are minted. Trust-on-first-use in `check_secureid` means unguessable IDs are also what stops someone pre-claiming accounts, so this shores that up too.

`randomBase62ID` is left alone. It names mapper elements and quiz seeds, neither of which guards anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)