### PR TITLE
Put the site folder back on the deployed history before pushing to it

### DIFF
--- a/scripts/deploy_site.py
+++ b/scripts/deploy_site.py
@@ -39,6 +39,7 @@ def update_scripts(branch):
     if current_branch != branch:
         # create a new branch if it doesn't exist
         subprocess.run(["git", "checkout", "-b", branch], cwd=PATH, check=True)
+    catch_up_with_deployed(branch)
     # add the files to the git repo
     subprocess.run(["git", "add", "."], cwd=PATH, check=True)
     # commit the changes, using the commit message corresponding to the one in the local repo
@@ -51,6 +52,19 @@ def update_scripts(branch):
     ).stdout.strip()
     subprocess.run(["git", "commit", "-m", local_commit_message], cwd=PATH, check=True)
     subprocess.run(["git", "push", "origin", branch], cwd=PATH, check=True)
+
+
+def catch_up_with_deployed(branch):
+    """
+    Put the site folder back on the history that is deployed, keeping the files just copied
+    into it. Anything deployed since this folder was last written to would otherwise make the
+    push a non-fast-forward, which git refuses.
+    """
+    fetched = subprocess.run(["git", "fetch", "origin", branch], cwd=PATH, check=False)
+    if fetched.returncode != 0:
+        # nothing is deployed under this name yet, so there is nothing to catch up with
+        return
+    subprocess.run(["git", "reset", "--soft", "FETCH_HEAD"], cwd=PATH, check=True)
 
 
 def update_all():


### PR DESCRIPTION
`deploy_site.py update --target scripts` fails with a non-fast-forward rejection whenever anything has been deployed since the site folder was last written to. `synchronize()` pulls the *backup* repo it rsyncs from; nothing ever brought `/home/kavi/temp/site` itself up to date, so it committed onto a stale history and pushed.

On this machine that folder is five commits behind the site and one ahead of it, so every deploy was being rejected.

`catch_up_with_deployed` fetches the branch and `reset --soft`s onto it. The files just copied in stay exactly as they are — they are the thing being deployed — and the commit made next sits on top of what is live, so the push fast-forwards. A branch that is not deployed yet is left alone.

Checked against a reproduction of the diverged state (remote five ahead, local one ahead, fresh files copied in): the push is refused before the change and fast-forwards after it, and the deployed tree is the copied files. `pylint` 10.00, `vulture`, `black`, `isort`.

One consequence worth knowing: a commit the site folder had made but never pushed stops being on the branch. Its files are still on disk and go into the commit the deploy makes, so nothing is lost from what gets served.