### PR TITLE
Move the quiz merge rules into their own module so they can be unit tested

### DIFF
--- a/react/src/quiz/merge.ts
+++ b/react/src/quiz/merge.ts
@@ -1,0 +1,87 @@
+/*
+ * Merging two copies of a quiz profile. Kept apart from `sync.ts` so these stay pure functions of
+ * their arguments: `sync.ts` reaches for `QuizModel.shared` and Google Drive, neither of which a
+ * merge rule should need.
+ */
+
+import stableStringify from 'json-stable-stringify'
+
+import type { QuizFriends, QuizHistory } from './quiz'
+
+export function historyConflicts(a: QuizHistory, b: QuizHistory): string[] {
+    return Object.keys(a)
+        .filter(key =>
+            key in b
+            && stableStringify(a[key]) !== stableStringify(b[key]))
+}
+
+// When a result ties, we must resolve it consistently, otherwise we get into a sync loop
+export function mergeHistories(a: QuizHistory, b: QuizHistory): QuizHistory {
+    const conflicts = historyConflicts(a, b)
+    return {
+        ...a, ...b, ...Object.fromEntries(conflicts.map((key) => {
+            const aPattern = a[key].correct_pattern
+            const bPattern = b[key].correct_pattern
+            if (aPattern.length !== bPattern.length) {
+                // If one is more complete, return that one, since the user is taking the quiz
+                return [key, aPattern.length > bPattern.length ? a[key] : b[key]]
+            }
+
+            const aCorrect = aPattern.filter(value => value).length
+            const bCorrect = bPattern.filter(value => value).length
+            let quizRecord
+            if (aCorrect !== bCorrect) {
+                quizRecord = bCorrect > aCorrect ? a[key] : b[key]
+            }
+            else {
+                quizRecord = stableStringify(bCorrect)! > stableStringify(aCorrect)! ? a[key] : b[key]
+            }
+            return [key, quizRecord]
+        })),
+    }
+}
+
+/*
+ * Merge friends.
+ * When two lists have overlapping ids, the entry that has the lowest index in its list wins
+ * When both entries have the same index, the lowest name wins
+ */
+export function mergeFriends(a: QuizFriends, b: QuizFriends): QuizFriends {
+    let aIdx = 0
+    let bIdx = 0
+    const result: QuizFriends = []
+    const usedIds = new Set<string>()
+    while (aIdx < a.length && bIdx < b.length) {
+        if (a[aIdx][1] === b[bIdx][1]) {
+            // ids same
+            if (!usedIds.has(a[aIdx][1])) {
+                // prefer latest timestamp
+                if ((a[aIdx][2] ?? 0) > (b[bIdx][2] ?? 0)) {
+                    result.push(a[aIdx])
+                }
+                else {
+                    result.push(b[bIdx])
+                }
+                usedIds.add(a[aIdx][1])
+            }
+            aIdx++
+            bIdx++
+        }
+        // sort by timestamp
+        else if ((a[aIdx][2] ?? 0) < (b[bIdx][2] ?? 0)) {
+            if (!usedIds.has(a[aIdx][1])) {
+                result.push(a[aIdx])
+                usedIds.add(a[aIdx][1])
+            }
+            aIdx++
+        }
+        else {
+            if (!usedIds.has(b[aIdx][1])) {
+                result.push(b[aIdx])
+                usedIds.add(b[aIdx][1])
+            }
+            bIdx++
+        }
+    }
+    return result.concat(a.slice(aIdx)).concat(b.slice(bIdx))
+}

--- a/react/src/quiz/quiz.ts
+++ b/react/src/quiz/quiz.ts
@@ -8,7 +8,7 @@ import { randomID } from '../utils/random'
 import { cancelled, uploadFile } from '../utils/upload'
 
 import { infiniteQuizIsDone, sampleRandomQuestion } from './infinite'
-import { historyConflicts, mergeHistories } from './sync'
+import { historyConflicts, mergeHistories } from './merge'
 
 export type QuizDescriptor = { kind: 'juxtastat', name: number } | { kind: 'retrostat', name: string } | { kind: 'custom', name: string } | { kind: 'infinite', name: string, seed: string, version: number }
 
@@ -90,12 +90,6 @@ const quizPersonaSchema = z.object({
 }).strict()
 
 export type QuizPersona = z.infer<typeof quizPersonaSchema>
-
-// Used in sync but must be here to avoid circular dependency
-export const syncProfileSchema = z.object({
-    quiz_history: quizHistorySchema,
-    friends: quizFriends,
-})
 
 export class StoredProperty<T> extends Property<T> {
     constructor(readonly localStorageKey: string, load: (storageValue: string | null) => T, private readonly store: (value: T) => string | null) {

--- a/react/src/quiz/sync.ts
+++ b/react/src/quiz/sync.ts
@@ -5,7 +5,8 @@ import { TestUtils } from '../utils/TestUtils'
 import { gdriveClient } from '../utils/google-drive-client'
 import { traced } from '../utils/traced'
 
-import { QuizFriends, QuizHistory, QuizModel, syncProfileSchema } from './quiz'
+import { mergeFriends, mergeHistories } from './merge'
+import { quizFriends, quizHistorySchema, QuizModel } from './quiz'
 
 export class AuthenticationError extends Error {}
 
@@ -23,6 +24,11 @@ export async function syncWithGoogleDrive(token: string): Promise<void> {
     await uploadProfile(token, mergedProfile, fileId)
 }
 
+const syncProfileSchema = z.object({
+    quiz_history: quizHistorySchema,
+    friends: quizFriends,
+})
+
 type Profile = z.infer<typeof syncProfileSchema>
 
 function getLocalProfile(): Profile {
@@ -37,84 +43,6 @@ function mergeProfiles(a: Profile, b: Profile): Profile {
         quiz_history: mergeHistories(a.quiz_history, b.quiz_history),
         friends: mergeFriends(a.friends, b.friends),
     }
-}
-
-export function historyConflicts(a: QuizHistory, b: QuizHistory): string[] {
-    return Object.keys(a)
-        .filter(key =>
-            key in b
-            && stableStringify(a[key]) !== stableStringify(b[key]))
-}
-
-// When a result ties, we must resolve it consistently, otherwise we get into a sync loop
-export function mergeHistories(a: QuizHistory, b: QuizHistory): QuizHistory {
-    const conflicts = historyConflicts(a, b)
-    return {
-        ...a, ...b, ...Object.fromEntries(conflicts.map((key) => {
-            const aPattern = a[key].correct_pattern
-            const bPattern = b[key].correct_pattern
-            if (aPattern.length !== bPattern.length) {
-                // If one is more complete, return that one, since the user is taking the quiz
-                return [key, aPattern.length > bPattern.length ? a[key] : b[key]]
-            }
-
-            const aCorrect = aPattern.filter(value => value).length
-            const bCorrect = bPattern.filter(value => value).length
-            let quizRecord
-            if (aCorrect !== bCorrect) {
-                quizRecord = bCorrect > aCorrect ? a[key] : b[key]
-            }
-            else {
-                quizRecord = stableStringify(bCorrect)! > stableStringify(aCorrect)! ? a[key] : b[key]
-            }
-            return [key, quizRecord]
-        })),
-    }
-}
-
-/*
- * Merge friends.
- * When two lists have overlapping ids, the entry that has the lowest index in its list wins
- * When both entries have the same index, the lowest name wins
- */
-function mergeFriends(a: QuizFriends, b: QuizFriends): QuizFriends {
-    let aIdx = 0
-    let bIdx = 0
-    const result: QuizFriends = []
-    const usedIds = new Set<string>()
-    while (aIdx < a.length && bIdx < b.length) {
-        if (a[aIdx][1] === b[bIdx][1]) {
-            // ids same
-            if (!usedIds.has(a[aIdx][1])) {
-                // prefer latest timestamp
-                if ((a[aIdx][2] ?? 0) > (b[bIdx][2] ?? 0)) {
-                    result.push(a[aIdx])
-                }
-                else {
-                    result.push(b[bIdx])
-                }
-                usedIds.add(a[aIdx][1])
-            }
-            aIdx++
-            bIdx++
-        }
-        // sort by timestamp
-        else if ((a[aIdx][2] ?? 0) < (b[bIdx][2] ?? 0)) {
-            if (!usedIds.has(a[aIdx][1])) {
-                result.push(a[aIdx])
-                usedIds.add(a[aIdx][1])
-            }
-            aIdx++
-        }
-        else {
-            if (!usedIds.has(b[aIdx][1])) {
-                result.push(b[aIdx])
-                usedIds.add(b[aIdx][1])
-            }
-            bIdx++
-        }
-    }
-    return result.concat(a.slice(aIdx)).concat(b.slice(bIdx))
 }
 
 function getFileName(): string {

--- a/react/unit/quiz-merge.test.ts
+++ b/react/unit/quiz-merge.test.ts
@@ -1,0 +1,61 @@
+import assert from 'assert/strict'
+import { describe, test } from 'node:test'
+
+import { historyConflicts, mergeFriends, mergeHistories } from '../src/quiz/merge'
+import { QuizFriends, QuizHistory } from '../src/quiz/quiz'
+
+function quiz(...correct: boolean[]): QuizHistory[string] {
+    return { choices: correct.map(() => 'A'), correct_pattern: correct }
+}
+
+void describe('historyConflicts', () => {
+    void test('reports keys that are in both histories with different results', () => {
+        const a: QuizHistory = { 1: quiz(true), 2: quiz(true), 3: quiz(true) }
+        const b: QuizHistory = { 2: quiz(false), 3: quiz(true), 4: quiz(true) }
+        assert.deepEqual(historyConflicts(a, b), ['2'])
+    })
+})
+
+void describe('mergeHistories', () => {
+    void test('takes the union when there is no conflict', () => {
+        const a: QuizHistory = { 1: quiz(true) }
+        const b: QuizHistory = { 2: quiz(false) }
+        assert.deepEqual(mergeHistories(a, b), { 1: quiz(true), 2: quiz(false) })
+    })
+
+    void test('prefers the longer pattern, since that user is mid-quiz', () => {
+        const a: QuizHistory = { 1: quiz(true, true, true) }
+        const b: QuizHistory = { 1: quiz(false) }
+        assert.deepEqual(mergeHistories(a, b), { 1: quiz(true, true, true) })
+        assert.deepEqual(mergeHistories(b, a), { 1: quiz(true, true, true) })
+    })
+
+    void test('prefers the lower score when the patterns are the same length', () => {
+        const a: QuizHistory = { 1: quiz(true, true) }
+        const b: QuizHistory = { 1: quiz(true, false) }
+        assert.deepEqual(mergeHistories(a, b), { 1: quiz(true, false) })
+        assert.deepEqual(mergeHistories(b, a), { 1: quiz(true, false) })
+    })
+})
+
+void describe('mergeFriends', () => {
+    void test('keeps entries that appear in only one list', () => {
+        const a: QuizFriends = [['Alice', '0a', 1]]
+        const b: QuizFriends = [['Bob', '0b', 2]]
+        assert.deepEqual(mergeFriends(a, b), [['Alice', '0a', 1], ['Bob', '0b', 2]])
+    })
+
+    void test('prefers the more recently touched entry for a shared id', () => {
+        const a: QuizFriends = [['Alice', '0a', 5]]
+        const b: QuizFriends = [['Alicia', '0a', 9]]
+        assert.deepEqual(mergeFriends(a, b), [['Alicia', '0a', 9]])
+        assert.deepEqual(mergeFriends(b, a), [['Alicia', '0a', 9]])
+    })
+
+    void test('a tombstone wins over the entry it replaced', () => {
+        const a: QuizFriends = [[null, '0a', 7]]
+        const b: QuizFriends = [['Alice', '0a', 3]]
+        assert.deepEqual(mergeFriends(a, b), [[null, '0a', 7]])
+        assert.deepEqual(mergeFriends(b, a), [[null, '0a', 7]])
+    })
+})


### PR DESCRIPTION
Found while reviewing #1178 retroactively. Three of the bugs that review turned up live in `mergeHistories` and `mergeFriends`, and none of them had any test coverage — because `sync.ts` cannot be imported from a unit test. It pulls in `quiz.ts`, which fails under Node on `file-saver`'s CJS interop, so the only thing exercising these functions was the Google Drive e2e suite, which needs a real Google account and never reaches the edge cases.

`merge.ts` holds the three pure functions and takes only a type-only import from `quiz.ts`, so it loads under Node with nothing stubbed. That also removes the circular dependency that forced `syncProfileSchema` to live in `quiz.ts` with a comment explaining why; it now sits next to the code that parses with it.

No behavior change. The tests here cover the rules that are already correct. The two branches stacked on top of this one fix the rules that aren't, each with its own regression test.

Bottom of a chain: #02-fix-merge-friends and #03-fix-history-tiebreak sit on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)