### PR TITLE
Break equal-score merge conflicts on the record, not on a comparison of a number with itself

### DIFF
--- a/react/src/quiz/merge.ts
+++ b/react/src/quiz/merge.ts
@@ -34,7 +34,8 @@ export function mergeHistories(a: QuizHistory, b: QuizHistory): QuizHistory {
                 quizRecord = bCorrect > aCorrect ? a[key] : b[key]
             }
             else {
-                quizRecord = stableStringify(bCorrect)! > stableStringify(aCorrect)! ? a[key] : b[key]
+                // Same score, different answers. Order on the records so both devices pick the same one
+                quizRecord = stableStringify(a[key])! < stableStringify(b[key])! ? a[key] : b[key]
             }
             return [key, quizRecord]
         })),

--- a/react/src/quiz/quiz.ts
+++ b/react/src/quiz/quiz.ts
@@ -191,7 +191,7 @@ export class QuizModel {
 
 ${conflicts.map(key => `• ${key.startsWith('W') ? 'Retrostat' : 'Juxtastat'} ${key}`).join('\n')}
 
-Are you sure you want to merge them? (The lowest score will be used)`)) {
+Are you sure you want to merge them? (Whichever result is further along will be used, and otherwise the lowest score)`)) {
                     newHistory = mergeHistories(currentHistory, persona.quiz_history)
                 }
                 else {

--- a/react/test/quiz_test_template.ts
+++ b/react/test/quiz_test_template.ts
@@ -638,7 +638,7 @@ export function quizTestImportExport({ platform }: { platform: 'desktop' | 'mobi
                 + '• Juxtastat 91\n'
                 + '• Retrostat W39\n'
                 + '\n'
-                + 'Are you sure you want to merge them? (The lowest score will be used)',
+                + 'Are you sure you want to merge them? (Whichever result is further along will be used, and otherwise the lowest score)',
                 type: 'confirm',
                 url: `${target}/quiz.html#date=91`,
             },

--- a/react/unit/quiz-merge.test.ts
+++ b/react/unit/quiz-merge.test.ts
@@ -36,6 +36,12 @@ void describe('mergeHistories', () => {
         assert.deepEqual(mergeHistories(a, b), { 1: quiz(true, false) })
         assert.deepEqual(mergeHistories(b, a), { 1: quiz(true, false) })
     })
+
+    void test('resolves an equal-score conflict the same way from either side', () => {
+        const a: QuizHistory = { 1: quiz(true, false) }
+        const b: QuizHistory = { 1: quiz(false, true) }
+        assert.deepEqual(mergeHistories(a, b), mergeHistories(b, a))
+    })
 })
 
 void describe('mergeFriends', () => {


### PR DESCRIPTION
From the retroactive review of #1178.

`mergeHistories` reaches its tie-break only when `aCorrect === bCorrect`, and then compares `stableStringify(bCorrect)` with `stableStringify(aCorrect)` — two stringifications of the same number. The comparison is always false, so the branch always returns `b`.

That happens to converge, because `syncWithGoogleDrive` always passes local as `a` and remote as `b`, so remote always wins and every device lands on remote. But it isn't what the comment above the function promises, and it stops being true the moment anything calls `mergeHistories` with the arguments the other way round. Comparing the records resolves the tie from the content, so the answer no longer depends on which side the caller put each history on.

Import picks up the same fix, and its dialog now describes what the merge actually does. It has claimed "the lowest score will be used" since before `mergeHistories` gained the rule that a longer `correct_pattern` wins outright — which is the right rule, since a longer pattern means that device is mid-quiz, but it is not the lowest score. The e2e assertion on the dialog text moves with it.

Top of the chain, stacked on #2357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)