### PR TITLE
Take the best infinite run across a user's devices instead of an arbitrary row

### DIFF
--- a/urbanstats-persistent-data/tests/test_friends.py
+++ b/urbanstats-persistent-data/tests/test_friends.py
@@ -348,3 +348,55 @@ def test_unfriend_after_email_association(client):
     # But a can still see b since b has friended them
     result = check_todays_score_for(client, identity_a, ["b"], "1", "juxtastat")
     assert result == {"results": [{"corrects": None, "friends": True}]}
+
+
+def test_friends_infinite_across_associated_devices(client):
+    # a + b are the same person on two devices
+    associate_email(client, identity_a, "email@gmail.com")
+    associate_email(client, identity_b, "email@gmail.com")
+
+    # friend from c to a
+    response = client.post(
+        "/juxtastat/friend_request", headers=identity_c, json={"requestee": "a"}
+    )
+    assert response.status_code == 204
+
+    # friend from b to c
+    response = client.post(
+        "/juxtastat/friend_request", headers=identity_b, json={"requestee": "c"}
+    )
+    assert response.status_code == 204
+
+    # The device that got less far reports first
+    response = client.post(
+        "/juxtastat_infinite/store_user_stats",
+        headers=identity_a,
+        json={"seed": "abc", "version": 1, "corrects": [True, False]},
+    )
+    assert response.status_code == 204
+
+    response = client.post(
+        "/juxtastat_infinite/store_user_stats",
+        headers=identity_b,
+        json={"seed": "abc", "version": 1, "corrects": [True, True, True, False]},
+    )
+    assert response.status_code == 204
+
+    # c sees the better of the two runs, not whichever row the planner returns first
+    response = client.post(
+        "/juxtastat/infinite_results",
+        headers=identity_c,
+        json={"requesters": ["a"], "seed": "abc", "version": 1},
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "results": [
+            {
+                "forThisSeed": 3,
+                "friends": True,
+                "maxScore": 3,
+                "maxScoreSeed": "abc",
+                "maxScoreVersion": 1,
+            }
+        ]
+    }

--- a/urbanstats-persistent-data/urbanstats_persistent_data/db/friends.py
+++ b/urbanstats-persistent-data/urbanstats_persistent_data/db/friends.py
@@ -143,11 +143,11 @@ def _infinite_results(
     """
 
     c.execute(
-        f"SELECT score FROM JuxtaStatInfiniteStats WHERE user IN {sqlTuple(len(for_users))} AND seed=? AND version=?",
+        f"SELECT MAX(score) FROM JuxtaStatInfiniteStats WHERE user IN {sqlTuple(len(for_users))} AND seed=? AND version=?",
         list(for_users) + [seed, version],
     )
-    res = c.fetchone()
-    for_this_seed = None if res is None else res[0]
+    # MAX over no rows still returns one row, holding NULL
+    for_this_seed = c.fetchone()[0]
 
     c.execute(
         f"SELECT seed, version, score FROM JuxtaStatInfiniteStats WHERE user IN {sqlTuple(len(for_users))} "


### PR DESCRIPTION
From the retroactive review of #1178.

`_infinite_results` computes `forThisSeed` with a bare `fetchone()` over `WHERE user IN (...)`. Since #1178 that `IN` spans every device sharing an email, so a seed played on two devices has two rows and the query has no `ORDER BY` to choose between them. A friend sees whichever row the planner happens to return first.

`_compute_daily_score`, directly above it, already handles exactly this case on purpose — it collects every row and returns the worst score, matching how the client merges daily results. The infinite path was missed.

`MAX` is the right aggregate here rather than the `min` its neighbour uses. Infinite scores are `sum(corrects)` over a run that ends when you run out of lives, so a higher score means that device got further — the same thing the client's merge means when it prefers the longer `correct_pattern`. It also matches the `maxScore` query immediately below, which has always aggregated over the whole user set.

`test_friends_transitive_infinite` passed over this because its two devices happen to score in ascending user-id order, so the first row was the right one. The new test stores the better run on the higher user id; it reports `forThisSeed: 1` without the fix and `3` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)