### PR TITLE
Give the Google tokeninfo request a timeout

### DIFF
--- a/urbanstats-persistent-data/tests/conftest.py
+++ b/urbanstats-persistent-data/tests/conftest.py
@@ -11,7 +11,8 @@ from urbanstats_persistent_data.routes.email import google_client_id
 
 @pytest.fixture()
 def setup_app(mocker):
-    def mock_get(url):
+    def mock_get(url, timeout):
+        del timeout
         parsed_url = urlparse(url)
         params = parse_qs(parsed_url.query)
         access_token = params.get("access_token", [None])[0]

--- a/urbanstats-persistent-data/tests/test_email.py
+++ b/urbanstats-persistent-data/tests/test_email.py
@@ -1,6 +1,10 @@
 import json
 
-from urbanstats_persistent_data.routes.email import google_client_id
+import requests
+from urbanstats_persistent_data.routes.email import (
+    google_client_id,
+    google_tokeninfo_timeout_seconds,
+)
 
 from .utils import (
     associate_email,
@@ -101,7 +105,7 @@ def test_rejects_token_from_another_client(client, mocker):
             }
         )
 
-    mocker.patch("requests.get", lambda url: MockResponse())
+    mocker.patch("requests.get", lambda url, timeout: MockResponse())
 
     response = client.post(
         "/juxtastat/associate_email",
@@ -122,7 +126,7 @@ def test_rejects_unverified_email(client, mocker):
             }
         )
 
-    mocker.patch("requests.get", lambda url: MockResponse())
+    mocker.patch("requests.get", lambda url, timeout: MockResponse())
 
     response = client.post(
         "/juxtastat/associate_email",
@@ -130,3 +134,24 @@ def test_rejects_unverified_email(client, mocker):
         json={"token": "unverified-token"},
     )
     assert response.status_code == 401
+
+
+def test_associate_email_survives_google_hanging(client, mocker):
+    timeouts = []
+
+    def hang(url, timeout):
+        del url
+        timeouts.append(timeout)
+        raise requests.Timeout()
+
+    mocker.patch("requests.get", hang)
+
+    response = client.post(
+        "/juxtastat/associate_email",
+        headers=identity_1,
+        json={"token": "email@gmail.com"},
+    )
+
+    # Without a timeout this request pins a worker thread for as long as Google holds it open
+    assert timeouts == [google_tokeninfo_timeout_seconds]
+    assert response.status_code == 500

--- a/urbanstats-persistent-data/urbanstats_persistent_data/routes/email.py
+++ b/urbanstats-persistent-data/urbanstats_persistent_data/routes/email.py
@@ -13,6 +13,8 @@ google_client_id = (
     "866758015458-r7t30bm7b492c1mevid587apej6cjte6.apps.googleusercontent.com"
 )
 
+google_tokeninfo_timeout_seconds = 5
+
 
 class AssociateEmailRequestBody(BaseModel):
     token: str
@@ -32,9 +34,15 @@ def associate_email(
 
 
 def get_email_from_token(token: str) -> str:
-    response = requests.get(
-        f"https://oauth2.googleapis.com/tokeninfo?access_token={token}"
-    )
+    try:
+        response = requests.get(
+            f"https://oauth2.googleapis.com/tokeninfo?access_token={token}",
+            timeout=google_tokeninfo_timeout_seconds,
+        )
+    except requests.RequestException as exc:
+        raise fastapi.HTTPException(
+            500, "Couldn't communicate successfully with Google"
+        ) from exc
     if response.status_code // 100 == 4:
         raise fastapi.HTTPException(401, "Couldn't validate access token")
     if response.status_code != 200:


### PR DESCRIPTION
From the retroactive review of #1178.

`get_email_from_token` calls `requests.get` with no timeout, so a Google endpoint that accepts the connection and then never answers holds the request open indefinitely. FastAPI runs this sync route in its threadpool, so each hung call takes a worker out of circulation, and enough of them stop the service answering anything — not just sign-ins.

Five seconds is well clear of a normal tokeninfo round trip while still failing fast enough that a stalled Google cannot accumulate workers. A connection error or timeout maps to the 500 the route already returns when Google answers with something unusable, so the client sees nothing new.

The test asserts the timeout value rather than just the 500, since the failure being guarded against is the argument going missing again. The `requests.get` mocks in `conftest.py` and `test_email.py` now take `timeout` positionally for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)