### PR TITLE
Stop the auth state machine from swallowing its own failures

### DIFF
--- a/react/src/quiz/AuthenticationStateMachine.ts
+++ b/react/src/quiz/AuthenticationStateMachine.ts
@@ -85,6 +85,8 @@ export class AuthenticationStateMachine {
 
     private setState(newState: State): void {
         this._state = newState
+        // Whatever we could not read before, we know what the state is now
+        this.stateIsReadable = true
         localStorage.setItem(localStorageKey, JSON.stringify(newState))
         this.stateObservers.forEach((observer) => { observer() })
     }

--- a/react/src/quiz/AuthenticationStateMachine.ts
+++ b/react/src/quiz/AuthenticationStateMachine.ts
@@ -49,24 +49,35 @@ const googleClient = new OAuth2Client({
 
 const redirectUri = urlFromPageDescriptor({ kind: 'oauthCallback', params: {} }).toString()
 
-function loadState(): State {
+// undefined when there is a stored state that we cannot read, which is not the same thing as being
+// signed out, and which the caller must not act on as though the user had signed out deliberately.
+function loadState(): State | undefined {
     const item = localStorage.getItem(localStorageKey)
-    if (item !== null) {
-        const parseResult = stateSchema.safeParse(JSON.parse(item))
-        if (parseResult.success) {
-            return parseResult.data
-        }
-        else {
-            console.error(`Failed to parse ${localStorageKey}, using default state`, parseResult.error)
-        }
+    if (item === null) {
+        return { state: 'signedOut', email: null }
     }
-    return { state: 'signedOut', email: null }
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(item)
+    }
+    catch (e) {
+        console.error(`Failed to parse ${localStorageKey}, using default state`, e)
+        return undefined
+    }
+    const parseResult = stateSchema.safeParse(parsed)
+    if (parseResult.success) {
+        return parseResult.data
+    }
+    console.error(`Failed to parse ${localStorageKey}, using default state`, parseResult.error)
+    return undefined
 }
 
 export class AuthenticationStateMachine {
     static shared = new AuthenticationStateMachine()
 
     private _state: State
+
+    private stateIsReadable: boolean
 
     get state(): State {
         return this._state
@@ -90,45 +101,59 @@ export class AuthenticationStateMachine {
     private isSyncing = false
 
     private constructor() {
-        this._state = loadState()
+        const loaded = loadState()
+        this.stateIsReadable = loaded !== undefined
+        this._state = loaded ?? { state: 'signedOut', email: null }
         addEventListener('storage', (event) => {
             if (event.key === localStorageKey) {
-                this._state = loadState()
+                const reloaded = loadState()
+                this.stateIsReadable = reloaded !== undefined
+                this._state = reloaded ?? { state: 'signedOut', email: null }
                 this.stateObservers.forEach((observer) => { observer() })
             }
         })
 
-        QuizModel.shared.uniquePersistentId.observers.add(() => this.syncEmailAssociation())
+        QuizModel.shared.uniquePersistentId.observers.add(() => { this.syncEmailAssociationInBackground() })
 
-        void this.syncEmailAssociation()
+        this.syncEmailAssociationInBackground()
 
         let syncTimeout: ReturnType<typeof setTimeout> | undefined
         const syncDelay = 1000
 
-        const obeserver = (): void => {
+        const observer = (): void => {
             if (!this.isSyncing) {
                 clearTimeout(syncTimeout)
-                syncTimeout = setTimeout(() => this.syncProfile(), syncDelay)
+                syncTimeout = setTimeout(() => { this.syncProfileInBackground() }, syncDelay)
             }
         }
 
-        QuizModel.shared.history.observers.add(obeserver)
-        QuizModel.shared.friends.observers.add(obeserver)
+        QuizModel.shared.history.observers.add(observer)
+        QuizModel.shared.friends.observers.add(observer)
 
-        window.addEventListener('focus', obeserver)
+        window.addEventListener('focus', observer)
 
-        void this.syncProfile().catch((e: unknown) => {
+        this.syncProfileInBackground()
+    }
+
+    private syncProfileInBackground(): void {
+        this.syncProfile().catch((e: unknown) => {
             console.error('Error syncing profile', e)
+        })
+    }
+
+    private syncEmailAssociationInBackground(): void {
+        this.syncEmailAssociation().catch((e: unknown) => {
+            console.error('Error syncing email association', e)
         })
     }
 
     private async syncProfile(token?: string): Promise<void> {
         TestUtils.shared.testSyncing = true
-        token ??= await this.getAccessToken()
-        if (token === undefined) {
-            return
-        }
         try {
+            token ??= await this.getAccessToken()
+            if (token === undefined) {
+                return
+            }
             this.isSyncing = true
             await syncWithGoogleDrive(token)
         }
@@ -153,6 +178,11 @@ export class AuthenticationStateMachine {
         const { data } = await persistentClient.GET('/juxtastat/email', { params: { header: QuizModel.shared.userHeaders() } })
         if (data) {
             if (data.email !== null && this._state.state === 'signedOut') {
+                if (!this.stateIsReadable) {
+                    // We could not read our own sign-in state, so dropping the server's record of
+                    // this device would be guessing. Leave it for a load that can read the state.
+                    return
+                }
                 await this.userSignOut() // dissociates email
                 return
             }
@@ -254,9 +284,10 @@ export class AuthenticationStateMachine {
         const { error } = await persistentClient.POST('/juxtastat/dissociate_email', {
             params: { header: QuizModel.shared.userHeaders() },
         })
-        if (!error) {
-            this.setState({ state: 'signedOut', email: null })
+        if (error) {
+            throw new Error('Could not sign out. Check your connection and try again.')
         }
+        this.setState({ state: 'signedOut', email: null })
     }
 
     async getAccessToken(): Promise<string | undefined> {

--- a/react/src/quiz/SignedOutPanel.tsx
+++ b/react/src/quiz/SignedOutPanel.tsx
@@ -21,7 +21,14 @@ export function SignedOutPanel(): ReactNode {
             <button style={{ margin: '1em', padding: '0.5em 1em' }} onClick={() => { startSignIn?.() }}>
                 Sign In
             </button>
-            <button style={{ margin: '1em', padding: '0.5em 1em' }} onClick={() => { void AuthenticationStateMachine.shared.userSignOut() }}>
+            <button
+                style={{ margin: '1em', padding: '0.5em 1em' }}
+                onClick={() => {
+                    AuthenticationStateMachine.shared.userSignOut().catch((error: unknown) => {
+                        alert(error instanceof Error ? error.message : 'Could not sign out')
+                    })
+                }}
+            >
                 Sign Out
             </button>
         </ErrorBox>

--- a/react/src/quiz/quiz-components.tsx
+++ b/react/src/quiz/quiz-components.tsx
@@ -95,7 +95,9 @@ export function QuizAuthStatus(): ReactNode {
     else {
         const signOut = (e: React.MouseEvent): void => {
             e.preventDefault()
-            void AuthenticationStateMachine.shared.userSignOut()
+            AuthenticationStateMachine.shared.userSignOut().catch((error: unknown) => {
+                alert(error instanceof Error ? error.message : 'Could not sign out')
+            })
         }
 
         return (

--- a/react/test/quiz_auth_x0.test.ts
+++ b/react/test/quiz_auth_x0.test.ts
@@ -3,9 +3,9 @@ import { Selector } from 'testcafe'
 // eslint-disable-next-line no-restricted-syntax -- One of the two auth files
 import { corruptTokens, email, quizAuthFixture, signInLink, signOutLink, urbanStatsGoogleSignIn, waitForSync } from './quiz_auth_test_utils'
 import { addFriend, createUser, restoreUser, startingState } from './quiz_friends_test_utils'
-import { exampleQuizHistory } from './quiz_test_template'
+import { exampleQuizHistory, runQuery } from './quiz_test_template'
 import { clickButtons, friendsText, withMockedClipboard } from './quiz_test_utils'
-import { safeClearLocalStorage, safeReload, target } from './test_utils'
+import { safeClearLocalStorage, safeReload, target, withInterceptedRequests } from './test_utils'
 
 quizAuthFixture('existing state', `${target}/quiz.html#enableAuth=true`, {
     quiz_history: JSON.stringify(exampleQuizHistory(600, 650)),
@@ -147,4 +147,33 @@ test('paste friend email link', async (t) => {
     const friends = await friendsText()
     await t.expect(friends.length).eql(2)
     await t.expect(friends[1]).eql('spudwaffleAsk\u00a0spudwaffle\u00a0to add youRemove')
+})
+
+test('a sign out the server never receives says so, rather than looking like it worked', async (t) => {
+    await urbanStatsGoogleSignIn(t)
+    await t.setNativeDialogHandler(() => true)
+    await withInterceptedRequests(t, request => request.url.includes('/juxtastat/dissociate_email') ? 'fail' : 'continue', async () => {
+        await t.click(signOutLink)
+        await t.expect(Selector('div').withText(`Signed in with ${email}.`).exists).ok()
+    })
+    await t.expect((await t.getNativeDialogHistory()).map(dialog => dialog.type)).eql(['alert'])
+})
+
+test('a stored sign-in state we cannot read leaves the email association alone', async (t) => {
+    await urbanStatsGoogleSignIn(t)
+    await t.expect(await runQuery(t, 'SELECT email FROM EmailUsers')).eql(`${email}\n`)
+
+    // Valid JSON of the wrong shape, which is what changing the stored schema would produce
+    await t.eval(() => { localStorage.setItem('quizAuthenticationState', '{}') })
+    await safeReload(t)
+    await waitForSync(t)
+    await t.expect(signInLink.exists).ok()
+    await t.expect(await runQuery(t, 'SELECT email FROM EmailUsers')).eql(`${email}\n`)
+
+    // Not JSON at all, which used to throw out of the state machine's constructor
+    await t.eval(() => { localStorage.setItem('quizAuthenticationState', 'not json') })
+    await safeReload(t)
+    await waitForSync(t)
+    await t.expect(signInLink.exists).ok()
+    await t.expect(await runQuery(t, 'SELECT email FROM EmailUsers')).eql(`${email}\n`)
 })


### PR DESCRIPTION
From the retroactive review of #1178. Four ways `AuthenticationStateMachine` currently fails quietly.

**`testSyncing` leaks.** `syncProfile` sets the flag before working out whether it has a token, then returns without clearing it when it doesn't. `waitForSync` spins on that flag, so any e2e test that reaches a signed-out sync hangs until the test times out. Setting the flag before the token lookup is deliberate — a refresh round trip is part of the sync — so the lookup moves inside the `try`.

**Three background calls dropped their rejections**: the `uniquePersistentId` observer, the initial `syncEmailAssociation`, and the debounced `syncProfile` timer. The last matters most, because `syncProfile` rethrows after handling `AuthenticationError`, so every failed background sync was an unhandled rejection. They now go through the same `console.error` the constructor's own sync call already used.

**A failed sign out looked like a successful one.** `userSignOut` only moved to the signed-out state when the dissociate request came back clean, and did nothing at all otherwise — the user clicks Sign Out, nothing happens, no error anywhere. It now throws, and the two Sign Out controls tell the user.

**An unreadable stored state was treated as a deliberate sign-out.** `loadState` returned the signed-out state when it could not parse what was stored, which `syncEmailAssociation` responds to by dissociating the device on the server. So a change to the stored schema would not just log people out, it would drop their devices off the account. `loadState` now reports that it could not read the state and the dissociation is skipped; a non-JSON value also no longer throws out of the singleton's constructor.

The e2e test for the last one doubles as the test for the `testSyncing` leak — it reloads into a signed-out state, which is exactly the sync `waitForSync` used to hang on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)