### PR TITLE
Restart the persistent data server if it dies

### DIFF
--- a/urbanstats-persistent-data/run.sh
+++ b/urbanstats-persistent-data/run.sh
@@ -11,4 +11,8 @@ rm -r venv
 virtualenv -p /root/.pyenv/versions/3.10.*/bin/python venv
 source venv/bin/activate
 pip3 install -r requirements.txt
-uvicorn --ssl-certfile $certificate --ssl-keyfile $key --host 0.0.0.0 --port 443 urbanstats_persistent_data.main:app
+while true; do
+    uvicorn --ssl-certfile $certificate --ssl-keyfile $key --host 0.0.0.0 --port 443 urbanstats_persistent_data.main:app
+    echo "server exited with $?, restarting in 5s"
+    sleep 5
+done


### PR DESCRIPTION
The persistent data server currently stays down until someone notices and reruns `run.sh`. Looping on the uvicorn invocation brings it back on its own, and the 5s sleep keeps a crash-on-startup from spinning.

The tradeoff is that Ctrl-C now restarts the server instead of stopping the script, so taking it down means killing `run.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)