### PR TITLE
Give the sign in outcome 30s to appear, since Google Drive can be slow

### DIFF
--- a/react/test/quiz_auth_test_utils.ts
+++ b/react/test/quiz_auth_test_utils.ts
@@ -39,9 +39,9 @@ const pageURL = ClientFunction(() => window.location.href)
 const pageText = ClientFunction(() => document.body.innerText.replace(/\s+/g, ' ').slice(0, 300))
 
 // Google's interstitials look much alike in the error screenshot; the URL is what tells them apart.
-async function expectOrWarn(t: TestController, selector: Selector, what: string): Promise<void> {
+async function expectOrWarn(t: TestController, selector: Selector, what: string, timeout?: number): Promise<void> {
     try {
-        await t.expect(selector.exists).ok()
+        await t.expect(selector.exists).ok({ timeout })
     }
     catch (error) {
         console.warn(`${what}, at ${await pageURL()}`)
@@ -204,8 +204,9 @@ async function signInPopup(t: TestController, enableDrive: boolean): Promise<voi
     while (await continueButton.exists) {
         await t.click(continueButton)
     }
-    // Waiting on the outcome first, since waitForLoading needs the callback page to have replaced Google's
-    await expectOrWarn(t, Selector('h1').withText(/Signed In!|Sign In Failed/), 'Sign in popup ended on neither Signed In! nor Sign In Failed')
+    // Waiting on the outcome first, since waitForLoading needs the callback page to have replaced Google's.
+    // Google Drive has taken 5s to answer during sign in, well past the default assertion timeout.
+    await expectOrWarn(t, Selector('h1').withText(/Signed In!|Sign In Failed/), 'Sign in popup ended on neither Signed In! nor Sign In Failed', 30000)
     await waitForLoading()
 }
 


### PR DESCRIPTION
The `quiz_auth` tests intermittently fail with the sign-in popup showing neither "Signed In!" nor "Sign In Failed". The step logging from #2351 shows the sign-in was never stuck. On [run 33137477101](https://github.com/kavigupta/urbanstats/actions/runs/33137477101) the Drive upload took 4767 ms against an 830–1030 ms baseline, so `completeSignIn` took 5095 ms rather than its usual 1240–1681 ms:

```
03:05:36.659  drive upload .../upload/drive/v3/files?uploadType=multipart: started
03:05:41.426  drive upload ...: finished after 4767 ms
03:05:41.429  completeSignIn sync profile: finished after 5095 ms
03:05:41.429  oauth callback: rendering success
03:05:42.912  Sign in popup ended on neither Signed In! nor Sign In Failed
```

TestCafe allows 3 s by default, which is less than a slow but healthy sign-in needs, so the assertion gave up on a flow that went on to succeed.

Bounding the Drive call instead would turn a slow sign-in into a failed one, which is worse than waiting for it. Only this one assertion gets the longer timeout, so every other assertion still fails fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)