### PR TITLE
Let a local e2e run pass options through to `docker run`

### DIFF
--- a/react/test/README.md
+++ b/react/test/README.md
@@ -51,8 +51,3 @@ four cores, so capping the container's is a way to tell whether a failure is tim
 
 Write each option in its `--flag value` form. `zodcli` drops everything after a second `=`, so
 `--docker-options=--cpus=2` silently arrives as `--cpus` alone.
-
-`--docker-option` passes an option through to `docker run`, and may be repeated. GitHub's runners
-have four cores, so `--docker-option=--cpus=2` is a way to see whether a failure is timing-dependent:
-
-`npm run test:e2e -- '--test=test/mapper-ux_x1.test.ts' --docker=host-arch --browser=chromium --docker-option=--cpus=2`

--- a/react/test/README.md
+++ b/react/test/README.md
@@ -43,3 +43,16 @@ antialiases a handful of pixels differently, well below what anyone would notice
 
 TestCafe ships no `arm64` build of the helper binaries behind `t.resizeWindow` and friends, so those
 run as `i386` binaries under emulation. Chromium and Node, where the time goes, run natively.
+
+`--docker-options` passes whitespace-separated options through to `docker run`. GitHub's runners have
+four cores, so capping the container's is a way to tell whether a failure is timing-dependent:
+
+`npm run test:e2e -- '--test=test/mapper-ux_x1.test.ts' --docker=host-arch --browser=chromium --docker-options='--cpus 2'`
+
+Write each option in its `--flag value` form. `zodcli` drops everything after a second `=`, so
+`--docker-options=--cpus=2` silently arrives as `--cpus` alone.
+
+`--docker-option` passes an option through to `docker run`, and may be repeated. GitHub's runners
+have four cores, so `--docker-option=--cpus=2` is a way to see whether a failure is timing-dependent:
+
+`npm run test:e2e -- '--test=test/mapper-ux_x1.test.ts' --docker=host-arch --browser=chromium --docker-option=--cpus=2`

--- a/react/test/scripts/run-e2e-tests-docker.ts
+++ b/react/test/scripts/run-e2e-tests-docker.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { execa } from 'execa'
 
-export async function runE2eTestsDocker(args: string[], hostArch: boolean): Promise<number> {
+export async function runE2eTestsDocker(args: string[], hostArch: boolean, dockerOptions: string[]): Promise<number> {
     const arch = hostArch && os.arch() === 'arm64' ? 'arm64' : 'amd64'
     const platform = `linux/${arch}`
     // Tagged per architecture so switching modes doesn't clobber the other mode's image
@@ -17,6 +17,7 @@ export async function runE2eTestsDocker(args: string[], hostArch: boolean): Prom
         [
             'run', '--rm',
             '--platform', platform,
+            ...dockerOptions,
             '--network', 'host',
             ...process.stdout.isTTY ? ['-it'] : [],
             '-v', `${repoRoot}:/urbanstats`,

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -35,12 +35,15 @@ const options = argumentParser({
             z.null().transform(() => 'ci' as const),
         ])).default('none'),
         remoteDebuggingPort: z.optional(z.coerce.number().int()), // Connect with `chrome://inspect` in your browser.
+        // Whitespace-separated options for `docker run`. `zodcli` eats everything after a second
+        // `=`, so write them in the form `--docker-options='--cpus 2'`, not `--cpus=2`.
+        dockerOptions: z.optional(z.string()).default(''),
     }).strict(),
 }).parse(process.argv.slice(2))
 
 if (options.docker !== 'none') {
-    const argsWithoutDocker = process.argv.slice(2).filter(arg => !/--docker($|=)/.test(arg))
-    const exitCode = await runE2eTestsDocker(argsWithoutDocker, options.docker === 'host-arch')
+    const argsWithoutDocker = process.argv.slice(2).filter(arg => !/--docker(-options)?($|=)/.test(arg))
+    const exitCode = await runE2eTestsDocker(argsWithoutDocker, options.docker === 'host-arch', options.dockerOptions.split(/\s+/).filter(option => option !== ''))
     process.exit(exitCode)
 }
 


### PR DESCRIPTION
Reproducing a timing-dependent CI failure needs the container to be slower than the host. `--docker-options` is how you ask for that — `--docker-options='--cpus 2'` against GitHub's four-core runners — rather than loading the whole machine with busy work and hoping the container loses the race. It takes arbitrary options, so constraining memory or anything else next needs no further change here.

It is one whitespace-separated string rather than a repeatable flag for an unpleasant reason: `zodcli` drops everything after a second `=`, so `--docker-option=--cpus=2` arrives as `--cpus` with no value and no complaint. Requiring the `--flag value` form sidesteps that, and the README says so.

Verified by running `checkbox_bug` under `--docker-options='--cpus 2'`.

Split out of #2368, which is the flake this was built to chase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)