### PR TITLE
Read the reader's units through one accessor

### DIFF
--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -1,15 +1,20 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useMemo } from 'react'
 
 import { useSetting } from '../page_template/settings'
-import { StoredUnit } from '../utils/quantity'
+import { ReaderSettings, StoredUnit } from '../utils/quantity'
 
 import { renderQuantity } from './unit-display'
 
-export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit, unitAlone?: boolean }): ReactNode {
+/** The units the person looking at the page reads in. */
+export function useReaderSettings(): ReaderSettings {
     const [useImperial] = useSetting('use_imperial')
     const [temperatureUnit] = useSetting('temperature_unit')
+    // memoized, so that a caller putting it in a dependency array does not rebuild every render
+    return useMemo(() => ({ useImperial, temperatureUnit }), [useImperial, temperatureUnit])
+}
 
-    const { value, unit } = renderQuantity(props.value, props.unit, { useImperial, temperatureUnit }, { alone: props.unitAlone })
+export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit, unitAlone?: boolean }): ReactNode {
+    const { value, unit } = renderQuantity(props.value, props.unit, useReaderSettings(), { alone: props.unitAlone })
 
     return (
         <span style={props.style}>

--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -1,17 +1,9 @@
-import React, { ReactNode, useMemo } from 'react'
+import React, { ReactNode } from 'react'
 
-import { useSetting } from '../page_template/settings'
-import { ReaderSettings, StoredUnit } from '../utils/quantity'
+import { useReaderSettings } from '../page_template/settings'
+import { StoredUnit } from '../utils/quantity'
 
 import { renderQuantity } from './unit-display'
-
-/** The units the person looking at the page reads in. */
-export function useReaderSettings(): ReaderSettings {
-    const [useImperial] = useSetting('use_imperial')
-    const [temperatureUnit] = useSetting('temperature_unit')
-    // memoized, so that a caller putting it in a dependency array does not rebuild every render
-    return useMemo(() => ({ useImperial, temperatureUnit }), [useImperial, temperatureUnit])
-}
 
 export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit, unitAlone?: boolean }): ReactNode {
     const { value, unit } = renderQuantity(props.value, props.unit, useReaderSettings(), { alone: props.unitAlone })

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,12 +1,11 @@
 import React, { CSSProperties, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
+import { useReaderSettings } from '../page_template/settings'
 import { HumanReadableElement } from '../utils/human-readable-element'
 import { reifyReact } from '../utils/human-readable-name'
 import { Hue, ReaderSettings, StoredUnit, Unit, UnitPlacement, writeQuantity } from '../utils/quantity'
 import { UnitType } from '../utils/unit'
-
-import { useReaderSettings } from './display-stats'
 
 /** A quantity as it is displayed: the number and its unit, which sit in separate columns. */
 export interface DisplayedQuantity {

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,11 +1,12 @@
 import React, { CSSProperties, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
-import { useSetting } from '../page_template/settings'
 import { HumanReadableElement } from '../utils/human-readable-element'
 import { reifyReact } from '../utils/human-readable-name'
 import { Hue, ReaderSettings, StoredUnit, Unit, UnitPlacement, writeQuantity } from '../utils/quantity'
 import { UnitType } from '../utils/unit'
+
+import { useReaderSettings } from './display-stats'
 
 /** A quantity as it is displayed: the number and its unit, which sit in separate columns. */
 export interface DisplayedQuantity {
@@ -51,9 +52,7 @@ export function renderQuantity(value: number, stored: StoredUnit, settings: Read
  * unit a pixel off the number. The zero width space is where the line may still break.
  */
 export function QuantityTogether({ value, stored }: { value: number, stored: StoredUnit }): ReactNode {
-    const [useImperial] = useSetting('use_imperial')
-    const [temperatureUnit] = useSetting('temperature_unit')
-    const { renderedValue, unitName, hue } = writeQuantity(value, stored, { useImperial, temperatureUnit }, {})
+    const { renderedValue, unitName, hue } = writeQuantity(value, stored, useReaderSettings(), {})
     const colors = useColors()
     return (
         <span style={hue === undefined ? undefined : { color: colors.hueColors[hue] }}>

--- a/react/src/page_template/settings.ts
+++ b/react/src/page_template/settings.ts
@@ -330,3 +330,11 @@ export function settingValue<K extends keyof SettingsDictionary>(info: SettingIn
 export function useIsStaged(): boolean {
     return useStagedSettingKeys() !== undefined
 }
+
+/** The units the person looking at the page reads in. */
+export function useReaderSettings(): ReaderSettings {
+    const [useImperial] = useSetting('use_imperial')
+    const [temperatureUnit] = useSetting('temperature_unit')
+    // memoized, so that a caller putting it in a dependency array does not rebuild every render
+    return useMemo(() => ({ useImperial, temperatureUnit }), [useImperial, temperatureUnit])
+}

--- a/react/src/page_template/settings.ts
+++ b/react/src/page_template/settings.ts
@@ -6,6 +6,7 @@ import stat_path_list from '../data/statistic_path_list'
 import { dataSources } from '../data/statistics_tree'
 import article_types_other from '../data/type_to_type_category'
 import { DefaultMap } from '../utils/DefaultMap'
+import type { ReaderSettings } from '../utils/quantity'
 import { useObserverSets } from '../utils/useObserverSets'
 
 import { Theme } from './color-themes'
@@ -182,6 +183,12 @@ export class Settings {
 
     getMultiple<const Keys extends readonly (keyof SettingsDictionary)[]>(keys: Keys): Pick<SettingsDictionary, Keys[number]> {
         return Object.fromEntries(keys.map(key => [key, this.get(key)])) as Pick<SettingsDictionary, Keys[number]>
+    }
+
+    /** The same two settings `useReaderSettings` reads, for a caller with no hooks to read them. */
+    readerSettings(): ReaderSettings {
+        const { use_imperial: useImperial, temperature_unit: temperatureUnit } = this.getMultiple(['use_imperial', 'temperature_unit'])
+        return { useImperial, temperatureUnit }
     }
 
     // Singular settings means we can use observers


### PR DESCRIPTION
`Statistic` and `QuantityTogether` each called `useSetting('use_imperial')` and `useSetting('temperature_unit')` and assembled `{ useImperial, temperatureUnit }` themselves. `useReaderSettings()` does it once, memoized on the two values so a caller can put it in a dependency array. `Settings.readerSettings()` does the same for a caller that has the settings object but no hooks to read it with — the router, which titles a page.

Split off #2348, which threads the reader's units through every place a script-derived name is written and wants both of these.

No behavior change. `tsc`, eslint, knip, and 762 unit tests pass.