### PR TITLE
Call the settings that pick a unit UnitSettings

### DIFF
--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode } from 'react'
 
-import { useReaderSettings } from '../page_template/settings'
+import { useUnitSettings } from '../page_template/settings'
 import { StoredUnit } from '../utils/quantity'
 
 import { renderQuantity } from './unit-display'
 
 export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit, unitAlone?: boolean }): ReactNode {
-    const { value, unit } = renderQuantity(props.value, props.unit, useReaderSettings(), { alone: props.unitAlone })
+    const { value, unit } = renderQuantity(props.value, props.unit, useUnitSettings(), { alone: props.unitAlone })
 
     return (
         <span style={props.style}>

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -1,10 +1,10 @@
 import React, { CSSProperties, ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
-import { useReaderSettings } from '../page_template/settings'
+import { useUnitSettings } from '../page_template/settings'
 import { HumanReadableElement } from '../utils/human-readable-element'
 import { reifyReact } from '../utils/human-readable-name'
-import { Hue, ReaderSettings, StoredUnit, Unit, UnitPlacement, writeQuantity } from '../utils/quantity'
+import { Hue, UnitSettings, StoredUnit, Unit, UnitPlacement, writeQuantity } from '../utils/quantity'
 import { UnitType } from '../utils/unit'
 
 /** A quantity as it is displayed: the number and its unit, which sit in separate columns. */
@@ -37,7 +37,7 @@ function InParty({ value, hue }: { value: string, hue: Hue }): ReactNode {
     return <span style={spanStyle}>{value}</span>
 }
 
-export function renderQuantity(value: number, stored: StoredUnit, settings: ReaderSettings, placement: UnitPlacement): DisplayedQuantity {
+export function renderQuantity(value: number, stored: StoredUnit, settings: UnitSettings, placement: UnitPlacement): DisplayedQuantity {
     const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings, placement)
     return {
         value: hue === undefined ? <span>{renderedValue}</span> : <InParty value={renderedValue} hue={hue} />,
@@ -51,7 +51,7 @@ export function renderQuantity(value: number, stored: StoredUnit, settings: Read
  * unit a pixel off the number. The zero width space is where the line may still break.
  */
 export function QuantityTogether({ value, stored }: { value: number, stored: StoredUnit }): ReactNode {
-    const { renderedValue, unitName, hue } = writeQuantity(value, stored, useReaderSettings(), {})
+    const { renderedValue, unitName, hue } = writeQuantity(value, stored, useUnitSettings(), {})
     const colors = useColors()
     return (
         <span style={hue === undefined ? undefined : { color: colors.hueColors[hue] }}>

--- a/react/src/page_template/settings.ts
+++ b/react/src/page_template/settings.ts
@@ -6,7 +6,7 @@ import stat_path_list from '../data/statistic_path_list'
 import { dataSources } from '../data/statistics_tree'
 import article_types_other from '../data/type_to_type_category'
 import { DefaultMap } from '../utils/DefaultMap'
-import type { ReaderSettings } from '../utils/quantity'
+import type { UnitSettings } from '../utils/quantity'
 import { useObserverSets } from '../utils/useObserverSets'
 
 import { Theme } from './color-themes'
@@ -185,8 +185,8 @@ export class Settings {
         return Object.fromEntries(keys.map(key => [key, this.get(key)])) as Pick<SettingsDictionary, Keys[number]>
     }
 
-    /** The same two settings `useReaderSettings` reads, for a caller with no hooks to read them. */
-    readerSettings(): ReaderSettings {
+    /** The same two settings `useUnitSettings` reads, for a caller with no hooks to read them. */
+    unitSettings(): UnitSettings {
         const { use_imperial: useImperial, temperature_unit: temperatureUnit } = this.getMultiple(['use_imperial', 'temperature_unit'])
         return { useImperial, temperatureUnit }
     }
@@ -332,7 +332,7 @@ export function useIsStaged(): boolean {
 }
 
 /** The units the person looking at the page reads in. */
-export function useReaderSettings(): ReaderSettings {
+export function useUnitSettings(): UnitSettings {
     const [useImperial] = useSetting('use_imperial')
     const [temperatureUnit] = useSetting('temperature_unit')
     // memoized, so that a caller putting it in a dependency array does not rebuild every render

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -65,7 +65,7 @@ export interface UnitPlacement {
     alone?: boolean
 }
 
-export interface ReaderSettings {
+export interface UnitSettings {
     useImperial?: boolean
     temperatureUnit?: string
 }
@@ -134,7 +134,7 @@ const metersPerInch = 0.0254
 const metersPerFoot = 12 * metersPerInch
 const metersPerMile = 5280 * metersPerFoot
 
-function systemOf(settings: ReaderSettings): 'metric' | 'imperial' {
+function systemOf(settings: UnitSettings): 'metric' | 'imperial' {
     return settings.useImperial === true ? 'imperial' : 'metric'
 }
 
@@ -186,7 +186,7 @@ const lengthUnits: Record<'metric' | 'imperial', NamedUnit[]> = {
  * The units there are to write a quantity in, whatever dimensions it turns out to have. A count is
  * named by the statistic counting it, so the unit it is counted in has no name to show.
  */
-function allUnits(settings: ReaderSettings): NamedUnit[] {
+function allUnits(settings: UnitSettings): NamedUnit[] {
     return [
         scaling('person', '', 1, 0),
         ...abbreviationsOf('person'),
@@ -365,7 +365,7 @@ function offsetOf(written: Written[], times: Coefficient): number {
     return times === 1 ? written.reduce((total, { unit, power }) => total + (unit.offset ?? 0) * power, 0) : 0
 }
 
-function representationFor(inBaseUnits: number, unit: Unit, settings: ReaderSettings, placement: UnitPlacement): Representation {
+function representationFor(inBaseUnits: number, unit: Unit, settings: UnitSettings, placement: UnitPlacement): Representation {
     if (unit.decoration.kind === 'percent') {
         // a lead is given more digits the closer it is, since that is what is being read off it
         return unit.decoration.party?.kind === 'lead' ? margin : percent
@@ -403,7 +403,7 @@ export interface WrittenQuantity {
     hue?: Hue
 }
 
-export function writeQuantity(value: number, stored: StoredUnit, settings: ReaderSettings, placement: UnitPlacement): WrittenQuantity {
+export function writeQuantity(value: number, stored: StoredUnit, settings: UnitSettings, placement: UnitPlacement): WrittenQuantity {
     if (!isFinite(value)) {
         return { renderedValue: missingValue, unitName: [] }
     }

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -5,10 +5,10 @@ import { defaultTypeEnvironment } from '../src/mapper/context'
 import { mapUSSFromString } from '../src/mapper/settings/map-uss'
 import { deriveMapUnit, deriveTableColumnUnit } from '../src/urban-stats-script/derive-unit'
 import { reifyString } from '../src/utils/human-readable-name'
-import { ReaderSettings, StoredUnit, writeQuantity } from '../src/utils/quantity'
+import { UnitSettings, StoredUnit, writeQuantity } from '../src/utils/quantity'
 
 /** A quantity of the base units, written the way the map's ramp would write it. */
-function written(unit: StoredUnit | undefined, value = 1000, settings: ReaderSettings = {}): string {
+function written(unit: StoredUnit | undefined, value = 1000, settings: UnitSettings = {}): string {
     if (unit === undefined) {
         return 'nothing'
     }


### PR DESCRIPTION
`ReaderSettings` named whose settings they are rather than what they decide, next to `UnitPlacement` in the same file, which is named the other way round. Renamed throughout:

- `ReaderSettings` → `UnitSettings`
- `useReaderSettings` → `useUnitSettings`
- `Settings.readerSettings()` → `Settings.unitSettings()`

Rename only — five files, seventeen occurrences, no behavior change. Doing it now, while #2348 is the only branch carrying more uses of the name.

`tsc`, eslint, and 762 unit tests pass.