### PR TITLE
refactor of toNumber

### DIFF
--- a/react/src/urban-stats-script/constants/convert.ts
+++ b/react/src/urban-stats-script/constants/convert.ts
@@ -17,7 +17,7 @@ export const toString = {
         return String(arg)
     },
     documentation: {
-        humanReadableName: 'toString',
+        humanReadableName: 'Anything to string',
         category: 'basic',
         longDescription: 'Converts any primitive value (number, boolean, string, null) to its string representation.',
     },
@@ -47,7 +47,7 @@ export const toNumber = {
         return num
     },
     documentation: {
-        humanReadableName: 'toNumber',
+        humanReadableName: 'Anything to Number',
         category: 'basic',
         longDescription: 'Converts any primitive value to a number. Strings are parsed as numbers, booleans become 0 or 1, and numbers are returned as-is.',
     },

--- a/react/src/urban-stats-script/constants/convert.ts
+++ b/react/src/urban-stats-script/constants/convert.ts
@@ -43,7 +43,9 @@ export const toNumber = {
         assert(Object.keys(namedArgs).length === 0, `Expected no named arguments for toNumber, got ${Object.keys(namedArgs).length}`)
         const arg = posArgs[0]
         const num = asNumber(arg as USSPrimitiveRawValue)
-        assert(num !== undefined, `Expected a number, a string that can be converted to one, or a boolean, got ${typeof arg === 'string' ? arg : typeof arg}`)
+        assert(num !== undefined, typeof arg === 'string'
+            ? `Expected a number or a string that can be converted to a number, got ${arg}`
+            : `Expected a number, string, or boolean argument for toNumber, got ${typeof arg}`)
         return num
     },
     documentation: {

--- a/react/src/urban-stats-script/constants/convert.ts
+++ b/react/src/urban-stats-script/constants/convert.ts
@@ -17,11 +17,19 @@ export const toString = {
         return String(arg)
     },
     documentation: {
-        humanReadableName: 'Anything to string',
+        humanReadableName: 'toString',
         category: 'basic',
         longDescription: 'Converts any primitive value (number, boolean, string, null) to its string representation.',
     },
 } satisfies USSValue
+
+/** What toNumber makes of a primitive, or undefined where it makes nothing. */
+function asNumber(value: USSPrimitiveRawValue): number | undefined {
+    if (typeof value === 'number') return value
+    if (typeof value === 'string') return parseNumber(value)
+    if (typeof value === 'boolean') return value ? 1 : 0
+    return undefined
+}
 
 export const toNumber = {
     type: {
@@ -34,21 +42,12 @@ export const toNumber = {
         assert(posArgs.length === 1, `Expected 1 argument for toNumber, got ${posArgs.length}`)
         assert(Object.keys(namedArgs).length === 0, `Expected no named arguments for toNumber, got ${Object.keys(namedArgs).length}`)
         const arg = posArgs[0]
-        if (typeof arg === 'number') {
-            return arg
-        }
-        if (typeof arg === 'string') {
-            const num = parseNumber(arg)
-            assert(num !== undefined, `Expected a number or a string that can be converted to a number, got ${arg}`)
-            return num
-        }
-        if (typeof arg === 'boolean') {
-            return arg ? 1 : 0
-        }
-        throw new Error(`Expected a number, string, or boolean argument for toNumber, got ${typeof arg}`)
+        const num = asNumber(arg as USSPrimitiveRawValue)
+        assert(num !== undefined, `Expected a number, a string that can be converted to one, or a boolean, got ${typeof arg === 'string' ? arg : typeof arg}`)
+        return num
     },
     documentation: {
-        humanReadableName: 'Anything to Number',
+        humanReadableName: 'toNumber',
         category: 'basic',
         longDescription: 'Converts any primitive value to a number. Strings are parsed as numbers, booleans become 0 or 1, and numbers are returned as-is.',
     },


### PR DESCRIPTION
Split off #2373.

`toNumber`'s body asked the same question in three branches and a throw; it now asks `asNumber` once. #2373 exports that helper so a caption can ask it what a script's `toNumber("1000")` works out to, which is how it came up — here it stays local, since an export with no second caller fails `unused-exports`.

No behavior change: the same values convert the same way, and the assertion still names the string that would not parse.

`tsc`, eslint, knip, and the constants tests pass.