### PR TITLE
Give async chunks content-hashed names

### DIFF
--- a/react/rspack.config.js
+++ b/react/rspack.config.js
@@ -26,6 +26,8 @@ export default env => ({
     },
     output: {
         filename: '[name].js',
+        // Hashed so a stale index.js can never load a chunk built against different module ids
+        chunkFilename: '[name].[contenthash].js',
         path: path.resolve(import.meta.dirname, '..', 'dist'),
         clean: true,
     },
@@ -84,7 +86,7 @@ export default env => ({
         hints: isProduction ? 'error' : false,
         maxAssetSize: 1_200_000,
         maxEntrypointSize: 1_200_000,
-        assetFilter: asset => asset !== 'quiz_infinite.js' && !asset.endsWith('.map')
+        assetFilter: asset => !asset.startsWith('quiz_infinite.') && !asset.endsWith('.map')
     },
     optimization: {
         splitChunks: {

--- a/react/src/navigation/Navigator.ts
+++ b/react/src/navigation/Navigator.ts
@@ -42,6 +42,25 @@ function loadingStateFromPageState(pageState: PageState): SubsequentLoadingState
     return Date.now() - pageState.loadStartTime >= quickThresholdDuration ? { kind: 'longLoad', updateAt: undefined } : { kind: 'quickLoad', updateAt: pageState.loadStartTime + quickThresholdDuration }
 }
 
+const chunkReloadKey = 'lastChunkReload'
+
+// A deploy replaces the hashed chunk files, so an index.js cached from an earlier one asks for chunks
+// that are gone. Chrome's reload only revalidates the document, so evict that index.js ourselves first.
+async function reloadIfBundleIsStale(error: unknown): Promise<boolean> {
+    if (!(error instanceof Error) || error.name !== 'ChunkLoadError') {
+        return false
+    }
+    const lastReload = Number(sessionStorage.getItem(chunkReloadKey) ?? 0)
+    if (Date.now() - lastReload < 60_000) {
+        return false
+    }
+    sessionStorage.setItem(chunkReloadKey, String(Date.now()))
+    await fetch('/scripts/index.js', { cache: 'reload' }).catch(() => undefined)
+    // eslint-disable-next-line no-restricted-syntax -- The loaded bundle is the thing that's broken, so navigating within it won't help
+    location.reload()
+    return true
+}
+
 export interface NavigationOptions {
     history: 'push' | 'replace' | null // What should we do with this browser history? `null` means nothing, usually you want 'push' or 'replace'
     scroll: { kind: 'none' } // Does not perform any scrolling when navigating, just re-render the page in place (will scroll to anchor if hash is present)
@@ -237,6 +256,9 @@ export class Navigator {
         }
         catch (error) {
             console.error('Error loading page', error)
+            if (await reloadIfBundleIsStale(error)) {
+                return
+            }
             if (this.pageState.kind !== 'loading' || this.pageState.loading.descriptor !== newDescriptor) {
                 // Another load has started, don't race it
                 return

--- a/react/test/stale_bundle.test.ts
+++ b/react/test/stale_bundle.test.ts
@@ -1,0 +1,61 @@
+import { Selector } from 'testcafe'
+
+import { pageDescriptorKind, urbanstatsFixture, withInterceptedRequests } from './test_utils'
+
+urbanstatsFixture('stale bundle', '/', async (t) => {
+    // Chunks served from the browser cache never reach the interceptor
+    await (await t.getCurrentCDPSession()).Network.setCacheDisabled({ cacheDisabled: true })
+})
+
+function isChunk(url: string): boolean {
+    return url.includes('/scripts/') && url.endsWith('.js') && !url.endsWith('/scripts/index.js') && !url.endsWith('/scripts/loading.js')
+}
+
+// The search index HEADs both of these for its cache key, so only loads count
+function loadOf(path: string): (request: { method: string, url: string }) => boolean {
+    return request => request.method === 'GET' && request.url.endsWith(path)
+}
+
+const loadOfEntry = loadOf('/scripts/index.js')
+const loadOfPage = loadOf('/data-credit.html')
+
+test('a chunk that a deploy replaced reloads the page and recovers', async (t) => {
+    let replacedChunk: string | undefined
+    let entryLoads = 0
+    await withInterceptedRequests(t, (request) => {
+        if (loadOfEntry(request)) {
+            entryLoads++
+        }
+        if (replacedChunk === undefined && isChunk(request.url)) {
+            replacedChunk = request.url
+            return 'fail'
+        }
+        return 'continue'
+    }, async () => {
+        await t.navigateTo('/data-credit.html')
+        await t.expect(pageDescriptorKind()).eql('dataCredit', { timeout: 30000 })
+    })
+    await t.expect(replacedChunk).typeOf('string')
+    // The navigation, the refetch that evicts a stale entry from the cache, and the reload
+    await t.expect(entryLoads).eql(3)
+})
+
+test('a chunk that stays broken shows the error instead of reloading forever', async (t) => {
+    let brokenChunk: string | undefined
+    let pageLoads = 0
+    await withInterceptedRequests(t, (request) => {
+        if (loadOfPage(request)) {
+            pageLoads++
+        }
+        if (isChunk(request.url) && (brokenChunk === undefined || request.url === brokenChunk)) {
+            brokenChunk = request.url
+            return 'fail'
+        }
+        return 'continue'
+    }, async () => {
+        await t.navigateTo('/data-credit.html')
+        await t.expect(Selector('h1').withExactText('Error Loading Page').exists).ok({ timeout: 30000 })
+        await t.expect(Selector('code').withText(/ChunkLoadError/).exists).ok()
+    })
+    await t.expect(pageLoads).eql(2)
+})


### PR DESCRIPTION
Returning visitors were hitting `TypeError: Cannot read properties of undefined (reading 'call')` on lazily-loaded pages after a deploy, and a force refresh cleared it. Chunk filenames carried no content hash, and Cloudflare serves `/scripts/*.js` with `max-age=14400` against the HTML's `max-age=600`. A browser could therefore run an `index.js` from the previous deploy and then fetch a chunk under the same URL from the current one; module ids differ between builds, so the runtime called an undefined module factory. Only lazily-loaded pages were affected, since anything in the entry bundle ships as one file.

Hashing the async chunk filenames makes those URLs immutable, so a stale entry can never be handed a chunk built against different module ids. It asks for a URL the new deploy no longer has, which turns silent corruption into a 404 and a named `ChunkLoadError` arriving at a single choke point — the navigator's catch. Recovering there means one reload, rate-limited to once a minute through `sessionStorage` so a genuinely broken deploy cannot reload-loop.

The reload has to be preceded by `fetch('/scripts/index.js', { cache: 'reload' })`. Chrome since 56 only revalidates the main document on a normal reload and serves subresources from the HTTP cache, so a bare `location.reload()` would bring the same stale entry straight back and land on the identical failure.

The performance budget exempted `quiz_infinite.js` by exact name, which stops matching once the file is hashed. That exemption is load-bearing rather than cosmetic: the chunk is 1.7M against a 1.2M `maxAssetSize`, so without the prefix match the production build fails outright.

The entry point itself stays unhashed, so a tab whose `index.js` predates the deploy still takes one `ChunkLoadError` and reloads itself rather than never being stale at all. Closing that window entirely would mean emitting the hashed entry name into the generated HTML, which needs an `onerror` on the script tag to stay safe — a stale HTML requesting a missing entry gets a 404 that no in-page handler can catch, leaving the loading spinner up forever.

## Testing

`react/test/stale_bundle.test.ts` fails the first chunk request after a navigation via CDP interception. One test fails it once and asserts the page still reaches `dataCredit`; the other keeps failing that same URL and asserts the error box appears with `ChunkLoadError` after exactly one reload, which pins the loop guard.

The tests identify the chunk by position rather than by name, so they run against both dev and production builds — production uses numeric chunk ids. Verified against both: the dev server, and a production build served statically. The fixture disables the browser cache, without which the second test's chunks came from cache against a production build and never reached the interceptor.

What the tests cannot cover is the cache eviction itself. They assert the refetch is issued, but no local server reproduces the stale-cache condition, so that part rests on the documented Chrome reload behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)