### PR TITLE
Say what a logarithm read its argument in

### DIFF
--- a/react/cf-og-worker/src/embed.tsx
+++ b/react/cf-og-worker/src/embed.tsx
@@ -16,7 +16,7 @@ import { Inset } from '../../src/urban-stats-script/constants/insets'
 import { mixWithBackground } from '../../src/utils/color'
 import { computeAspectRatioForInsets } from '../../src/utils/coordinates'
 import { HumanReadableName } from '../../src/utils/human-readable-element'
-import { nameOfUnit, reifyString } from '../../src/utils/human-readable-name'
+import { reifyString } from '../../src/utils/human-readable-name'
 import { UnitSettings, StoredUnit, writeQuantity } from '../../src/utils/quantity'
 import { trimTrailingZeros } from '../../src/utils/text'
 import { unitForStatistic, unitTypeToStoredUnit } from '../../src/utils/unit'
@@ -202,8 +202,6 @@ function humanReadable(name: HumanReadableName, fontSize: number, units: Units):
                 const { renderedValue, unitName } = writeQuantity(element.value, element.unit, readerOf(units), {})
                 return [narrowSpaces(trimTrailingZeros(renderedValue)), ...humanReadable(unitName, fontSize, units)]
             }
-            case 'unitName':
-                return humanReadable(nameOfUnit(element.unit, readerOf(units)), fontSize, units)
         }
     })
 }

--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -1,9 +1,9 @@
 import { editableMapData, MapUSS, mapUssParser, read, tableColumnExpression } from '../mapper/settings/map-uss'
 import { assert } from '../utils/defensive'
 import { HumanReadableElement, HumanReadableName } from '../utils/human-readable-element'
-import { joinHumanReadableNames, nameOfUnit } from '../utils/human-readable-name'
+import { joinHumanReadableNames } from '../utils/human-readable-name'
 import { parseHumanReadableTemplate } from '../utils/human-readable-template'
-import { StoredUnit } from '../utils/quantity'
+import { nameOfStoredUnit, StoredUnit } from '../utils/quantity'
 import { abbreviate, formatToSignificantFigures, separateNumber, trimTrailingZeros } from '../utils/text'
 
 import { locationOf, UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
@@ -315,12 +315,14 @@ export function deriveTableLabel(uss: MapUSS, typeEnvironment: TypeEnvironment, 
 }
 
 /**
- * The elements followed by the unit they are read in, as in "[in /km^{2}]". A count has no name in
- * any units, being named by the statistic counting it, and gets nothing.
+ * The elements followed by what the numbers behind them are counted in, as in "[in /km^{2}]". The
+ * reader's units are not it: a logarithm is of the number a script computed with, whatever units
+ * the reader has the same number written to them in. A count gets nothing, having no name.
  */
 function inUnitWritten(written: HumanReadableElement[], unit: StoredUnit | undefined): HumanReadableElement[] {
-    if (unit === undefined || nameOfUnit(unit, {}).length === 0) return written
-    return [...written, { type: 'atom', value: ' [in ' }, { type: 'unitName', unit }, { type: 'atom', value: ']' }]
+    const name = unit === undefined ? undefined : nameOfStoredUnit(unit)
+    if (name === undefined || name.length === 0) return written
+    return [...written, { type: 'atom', value: ' [in ' }, ...name, { type: 'atom', value: ']' }]
 }
 
 function formatNumber(number: number, unit?: StoredUnit): HumanReadableElement[] {

--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -320,7 +320,12 @@ export function deriveTableLabel(uss: MapUSS, typeEnvironment: TypeEnvironment, 
  * the reader has the same number written to them in. A count gets nothing, having no name.
  */
 function inUnitWritten(written: HumanReadableElement[], unit: StoredUnit | undefined): HumanReadableElement[] {
-    const name = unit === undefined ? undefined : nameOfStoredUnit(unit)
+    if (unit === undefined) return written
+    // a share is stored as the fraction it is, whatever percentage it is written as
+    if (unit.unit.decoration.kind === 'percent') {
+        return [...written, { type: 'atom', value: ' [as a fraction]' }]
+    }
+    const name = nameOfStoredUnit(unit)
     if (name === undefined || name.length === 0) return written
     return [...written, { type: 'atom', value: ' [in ' }, ...name, { type: 'atom', value: ']' }]
 }

--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -11,7 +11,7 @@ import * as l from './literal-parser'
 import { noLocation } from './location'
 import { expressionOperatorMap } from './operators'
 import { TypeEnvironment } from './types-values'
-import { ConstantUnits, inferConstantUnits, readAsANumber, whereWritten } from './unit-inference'
+import { ConstantUnits, inferConstantUnits, readAsANumber, unitsReadAndDropped, whereWritten } from './unit-inference'
 
 function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment, units: ConstantUnits): HumanReadableElement[] | undefined {
     switch (ast.type) {
@@ -134,16 +134,17 @@ function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTState
                 // whatever encloses this sees a call, so -toNumber(a + b) would read -a + b
                 const isOperator = readNumber.read.type === 'binaryOperator' || readNumber.read.type === 'unaryOperator'
                 const inner: HumanReadableElement[] = isOperator ? [{ type: 'parens', value: written }] : written
-                // a count has no name in any units, being named by the statistic counting it
-                if (unit === undefined || nameOfUnit(unit, {}).length === 0) return inner
-                return [...inner, { type: 'atom', value: ' [in ' }, { type: 'unitName', unit }, { type: 'atom', value: ']' }]
+                return inUnitWritten(inner, unit)
             }
             const fn = humanReadableElements(ast.fn, typeEnvironment, units)
             if (fn === undefined) return
+            // ln of a density is a number, so the caption says what the density was read in
+            const dropped = unitsReadAndDropped(ast, { typeEnvironment, named: new Map() })
             const args: HumanReadableElement[][] = []
-            for (const arg of ast.args) {
-                const humanArg = humanReadableElements(arg.value, typeEnvironment, units)
-                if (humanArg === undefined) return
+            for (const [index, arg] of ast.args.entries()) {
+                const written = humanReadableElements(arg.value, typeEnvironment, units)
+                if (written === undefined) return
+                const humanArg = inUnitWritten(written, dropped?.[index])
                 switch (arg.type) {
                     case 'named':
                         args.push([{ type: 'atom', value: `${arg.name.node} = ` }, ...humanArg])
@@ -311,6 +312,15 @@ export function deriveTableLabel(uss: MapUSS, typeEnvironment: TypeEnvironment, 
     const withTableCallReplacedByDataLabel = result.edit({ type: 'constant', value: { node: { type: 'humanReadableElements', value: joinHumanReadableNames(columnNames) }, location: noLocation } })
     assert(withTableCallReplacedByDataLabel !== undefined, 'should not happen')
     return humanReadableElements(withTableCallReplacedByDataLabel, typeEnvironment, units)
+}
+
+/**
+ * The elements followed by the unit they are read in, as in "[in /km^{2}]". A count has no name in
+ * any units, being named by the statistic counting it, and gets nothing.
+ */
+function inUnitWritten(written: HumanReadableElement[], unit: StoredUnit | undefined): HumanReadableElement[] {
+    if (unit === undefined || nameOfUnit(unit, {}).length === 0) return written
+    return [...written, { type: 'atom', value: ' [in ' }, { type: 'unitName', unit }, { type: 'atom', value: ']' }]
 }
 
 function formatNumber(number: number, unit?: StoredUnit): HumanReadableElement[] {

--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -321,11 +321,13 @@ export function deriveTableLabel(uss: MapUSS, typeEnvironment: TypeEnvironment, 
  */
 function inUnitWritten(written: HumanReadableElement[], unit: StoredUnit | undefined): HumanReadableElement[] {
     if (unit === undefined) return written
-    // a share is stored as the fraction it is, whatever percentage it is written as
-    if (unit.unit.decoration.kind === 'percent') {
+    const name = nameOfStoredUnit(unit)
+    // A share is stored as the fraction it is, whatever percentage it is written as, and so is a
+    // count of one thing per another: fatalities per capita are stored per person, not per 100k.
+    const perSomething = unit.unit.dimensions.some(({ power }) => power < 0)
+    if (unit.unit.decoration.kind === 'percent' || (name?.length === 0 && perSomething)) {
         return [...written, { type: 'atom', value: ' [as a fraction]' }]
     }
-    const name = nameOfStoredUnit(unit)
     if (name === undefined || name.length === 0) return written
     return [...written, { type: 'atom', value: ' [in ' }, ...name, { type: 'atom', value: ']' }]
 }

--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -229,6 +229,15 @@ export function readAsANumber(ast: UrbanStatsASTExpression, scope: Scope): { val
     return { value: literal === undefined ? undefined : asNumber(literal), read }
 }
 
+/**
+ * The unit each argument of a call is in, where the call reads a quantity and gives back a plain
+ * number: a logarithm of a density is a number, and the caption has to say of what.
+ */
+export function unitsReadAndDropped(ast: UrbanStatsASTExpression, scope: Scope): (StoredUnit | undefined)[] | undefined {
+    if (ast.type !== 'call' || propagationOf(ast.fn, scope)?.kind !== 'number') return undefined
+    return ast.args.map(arg => unitToWriteIn(quantity(infer(arg.value, scope))))
+}
+
 function pushedInto(propagation: UnitPropagation | undefined, expected: Expected, args: UrbanStatsASTArg[], index: number, scope: Scope): Expected {
     if (propagation?.kind === 'unchanged') {
         return expected

--- a/react/src/utils/human-readable-element.ts
+++ b/react/src/utils/human-readable-element.ts
@@ -3,8 +3,6 @@ import type { StoredUnit } from './quantity'
 export type HumanReadableElement = { type: 'atom', value: string } | { type: 'code', value: string } | { type: 'where' | 'superscript' | 'subscript' | 'parens', value: HumanReadableElement[] }
     /** Written where the name is, so that it is written in the units of whoever is reading. */
     | { type: 'quantity', value: number, unit: StoredUnit }
-    /** The name of a unit with no quantity of it to write, as in "in km^{2}". */
-    | { type: 'unitName', unit: StoredUnit }
 
 export type HumanReadableName = string | HumanReadableElement[]
 

--- a/react/src/utils/human-readable-name.tsx
+++ b/react/src/utils/human-readable-name.tsx
@@ -43,18 +43,8 @@ export function reifyReact(elements: HumanReadableElement[] | string, settings: 
                 )
             case 'quantity':
                 return <React.Fragment key={index}>{writtenQuantity(element.value, element.unit, settings)}</React.Fragment>
-            case 'unitName':
-                return <React.Fragment key={index}>{reifyReact(nameOfUnit(element.unit, settings), settings)}</React.Fragment>
         }
     })
-}
-
-/**
- * What a unit is called to whoever is reading, taken off a quantity of one of it, since which of
- * several units a quantity is written in depends on how large it is.
- */
-export function nameOfUnit(unit: StoredUnit, settings: UnitSettings): HumanReadableElement[] {
-    return writeQuantity(1, unit, settings, {}).unitName
 }
 
 /** One run of text, so that the unit cannot be rasterized a pixel off the number it belongs to. */
@@ -86,8 +76,6 @@ export function reifyString(elements: HumanReadableElement[] | string, settings:
                 return `(${reifyString(element.value, settings)})`
             case 'quantity':
                 return writtenPlainly(element.value, element.unit, settings)
-            case 'unitName':
-                return reifyString(nameOfUnit(element.unit, settings), settings)
         }
     }).join('')
 }

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -2,7 +2,7 @@ import { HueColors } from '../page_template/color-themes'
 
 import { atom, HumanReadableElement } from './human-readable-element'
 import { formatNumber, hoursAndMinutes, NumberFormat } from './text'
-import { chooseUnits, Written } from './unit-search'
+import { chooseUnits, Written, writtenAsCounted } from './unit-search'
 
 export type Hue = keyof HueColors
 
@@ -341,6 +341,20 @@ export function unitPower(stored: StoredUnit, exponent: number): StoredUnit | un
     }
     const raised = stored.unit.dimensions.map(({ baseUnit, power }) => ({ baseUnit, power: power * exponent }))
     return computedUnit(gathered(raised), Math.pow(stored.toBaseUnits, exponent))
+}
+
+/**
+ * What the numbers a statistic is stored as are counted in, which is what a script computes with:
+ * rainfall is stored per metre though it is read per centimetre, and a share is stored as a
+ * fraction though it is read as a percentage. Empty where nothing names it, a fraction and a count
+ * having no name, and undefined where no unit is exactly it.
+ */
+export function nameOfStoredUnit(stored: StoredUnit): HumanReadableElement[] | undefined {
+    // both systems, since the unit a statistic is stored in is not the reader's to choose, and no
+    // abbreviations, which shorten a number rather than saying what it is counted in
+    const pool = [...allUnits({}), ...lengthUnits.imperial, celsius].filter(({ abbreviation }) => !abbreviation)
+    const written = writtenAsCounted(stored.unit.dimensions, pool, stored.toBaseUnits)
+    return written === undefined ? undefined : nameOf(written, {})
 }
 
 /**

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -68,6 +68,19 @@ function scaledBy(written: Written[]): (value: number) => number {
 }
 
 /**
+ * The way of writing these dimensions in which one of the unit is exactly one -- the unit a stored
+ * value is counted in, rather than whichever unit its magnitude reads best in.
+ */
+export function writtenAsCounted(scales: Dimension[], pool: NamedUnit[], oneInBaseUnits: number): Written[] | undefined {
+    for (const written of coverings(exponentsOf(scales), pool)) {
+        if (Math.abs(scaledBy(written)(oneInBaseUnits) - 1) < 1e-9) {
+            return written
+        }
+    }
+    return undefined
+}
+
+/**
  * The cheapest way of writing a value of these dimensions
  */
 export function chooseUnits(

--- a/react/test/statistic-inferred-units.test.ts
+++ b/react/test/statistic-inferred-units.test.ts
@@ -77,6 +77,20 @@ test('what a regression did not expect is a difference of shares', async (t) => 
     await t.expect(await rows()).eql(['+9.92 %', '+3.26 %', '+3.21 %'])
 })
 
+urbanstatsFixture('a logarithm of a quantity', tableOf('ln(high_temp)'))
+
+test('a logarithm names what its argument was read in', async (t) => {
+    await waitForLoading()
+    await t.expect(Selector('[data-test-id="statistic-link"]').innerText).eql('ln(Mean high temp [in °F])')
+})
+
+test('and names it in the units the reader reads', async (t) => {
+    await waitForLoading()
+    const temperatures = Selector('[data-test-id=temperature_select]')
+    await t.click(temperatures).click(temperatures.find('option').withText(/C/))
+    await t.expect(Selector('[data-test-id="statistic-link"]').innerText).eql('ln(Mean high temp [in °C])')
+})
+
 urbanstatsFixture('a column named after what it is measured against', tableOf('maximum(high_temp, 80)'))
 
 const columnName = Selector('[data-test-id="statistic-link"]')

--- a/react/test/statistic-inferred-units.test.ts
+++ b/react/test/statistic-inferred-units.test.ts
@@ -84,11 +84,11 @@ test('a logarithm names what its argument was read in', async (t) => {
     await t.expect(Selector('[data-test-id="statistic-link"]').innerText).eql('ln(Mean high temp [in °F])')
 })
 
-test('and names it in the units the reader reads', async (t) => {
+test('and keeps naming it that to a reader in Celsius, the logarithm being of the Fahrenheit number', async (t) => {
     await waitForLoading()
     const temperatures = Selector('[data-test-id=temperature_select]')
     await t.click(temperatures).click(temperatures.find('option').withText(/C/))
-    await t.expect(Selector('[data-test-id="statistic-link"]').innerText).eql('ln(Mean high temp [in °C])')
+    await t.expect(Selector('[data-test-id="statistic-link"]').innerText).eql('ln(Mean high temp [in °F])')
 })
 
 urbanstatsFixture('a column named after what it is measured against', tableOf('maximum(high_temp, 80)'))

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -54,6 +54,12 @@ for (const [condition, expected] of [
     ['ln(density_pw_1km) > 0', 'ln(PW Density (r=1km) [in /km^{2}]) > 0'],
     ['ln(population) > 10', 'ln(Population) > 10'],
     ['ln(density_pw_1km / density_pw_2km) > 0', 'ln(PW Density (r=1km) ÷ PW Density (r=2km)) > 0'],
+    // what the script computes with, which is not what a reader is shown: rainfall reads in cm/yr
+    ['ln(rainfall) > 0', 'ln(Rainfall [in m/yr]) > 0'],
+    // and a share is stored as the fraction it is, which nothing names
+    ['ln(commute_bike) > 0', 'ln(Commute Bike %) > 0'],
+    // a root of a count is in no unit at all, so there is nothing to say it is in
+    ['ln(population ** 0.5) > 0', 'ln(Population^{0.5}) > 0'],
     // a number written the long way is written as the number, in the unit it is read in
     ['density_pw_1km > toNumber("1000")', 'PW Density (r=1km) > 1\u202f000/km^{2}'],
     ['high_temp > toNumber("80")', 'Mean high temp > 80°F'],
@@ -87,7 +93,8 @@ cMap(
     scale=linearScale(),
     ramp=rampUridis
 )`,
-    // a number made of a quantity says what the quantity was read in, counts having no name to give
+    // per person to the fourth per km to the fourth, the people dropping out of the name as they
+    // do in a density
     'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}]) where Population (2000) > 1m and Population > 1m',
 )
 

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -59,6 +59,8 @@ for (const [condition, expected] of [
     // and a share is stored as the fraction it is, whatever percentage it is written as
     ['ln(commute_bike) > 0', 'ln(Commute Bike % [as a fraction]) > 0'],
     ['ln(pres_2020_margin) > 0', 'ln(2020 Presidential Election [as a fraction]) > 0'],
+    // as is a count of one thing per another: these are stored per person, not per 100k
+    ['ln(ped_cyclist_fatalities_per_capita) > 0', 'ln(Pedestrian/Cyclist Fatalities Per Capita Per Year [as a fraction]) > 0'],
     // a root of a count is in no unit at all, so there is nothing to say it is in
     ['ln(population ** 0.5) > 0', 'ln(Population^{0.5}) > 0'],
     // a number written the long way is written as the number, in the unit it is read in

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -50,6 +50,10 @@ for (const [condition, expected] of [
     ['sum(population) > 1000000', 'sum(Population) > 1m'],
     ['abs(high_temp) > 5', 'abs(Mean high temp) > 5'],
     ['ln(1000) > 0', 'ln(1\u202f000) > 0'],
+    // a logarithm of a quantity is a number, so the caption says what the quantity was read in
+    ['ln(density_pw_1km) > 0', 'ln(PW Density (r=1km) [in /km^{2}]) > 0'],
+    ['ln(population) > 10', 'ln(Population) > 10'],
+    ['ln(density_pw_1km / density_pw_2km) > 0', 'ln(PW Density (r=1km) ÷ PW Density (r=2km)) > 0'],
     // a number written the long way is written as the number, in the unit it is read in
     ['density_pw_1km > toNumber("1000")', 'PW Density (r=1km) > 1\u202f000/km^{2}'],
     ['high_temp > toNumber("80")', 'Mean high temp > 80°F'],
@@ -83,7 +87,8 @@ cMap(
     scale=linearScale(),
     ramp=rampUridis
 )`,
-    'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2}) where Population (2000) > 1m and Population > 1m',
+    // a number made of a quantity says what the quantity was read in, counts having no name to give
+    'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}]) where Population (2000) > 1m and Population > 1m',
 )
 
 testMapLabel(test,

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -56,8 +56,9 @@ for (const [condition, expected] of [
     ['ln(density_pw_1km / density_pw_2km) > 0', 'ln(PW Density (r=1km) ÷ PW Density (r=2km)) > 0'],
     // what the script computes with, which is not what a reader is shown: rainfall reads in cm/yr
     ['ln(rainfall) > 0', 'ln(Rainfall [in m/yr]) > 0'],
-    // and a share is stored as the fraction it is, which nothing names
-    ['ln(commute_bike) > 0', 'ln(Commute Bike %) > 0'],
+    // and a share is stored as the fraction it is, whatever percentage it is written as
+    ['ln(commute_bike) > 0', 'ln(Commute Bike % [as a fraction]) > 0'],
+    ['ln(pres_2020_margin) > 0', 'ln(2020 Presidential Election [as a fraction]) > 0'],
     // a root of a count is in no unit at all, so there is nothing to say it is in
     ['ln(population ** 0.5) > 0', 'ln(Population^{0.5}) > 0'],
     // a number written the long way is written as the number, in the unit it is read in


### PR DESCRIPTION
`ln(density_pw_1km)` captioned as `ln(PW Density (r=1km))`, which says nothing about which density — per square kilometre or per square mile changes the number the logarithm is of. Now:

| script | caption |
|---|---|
| `ln(density_pw_1km)` | `ln(PW Density (r=1km) [in /km²])` |
| `ln(rainfall)` | `ln(Rainfall [in m/yr])` |
| `ln(high_temp)` | `ln(Mean high temp [in °F])` |
| `ln(commute_bike)` | `ln(Commute Bike % [as a fraction])` |
| `ln(ped_cyclist_fatalities_per_capita)` | `ln(… Per Capita Per Year [as a fraction])` |
| `ln(population)` | `ln(Population)` |

It applies to every function whose `unitPropagation` is `{ kind: 'number' }` — the logarithms, the trigonometry, `exp`, `sign` — which is exactly the set that reads a quantity and hands back a plain number. `toNumber`'s existing `[in …]` suffix goes through the same helper and gains the same corrections.

**The unit named is the one the script computes in, not the one the reader is shown.** A logarithm is taken of the stored number, so a reader in Celsius still reads `[in °F]`: saying `[in °C]` would claim the logarithm was of a Celsius value. Finding that unit means asking which unit is *exactly* the stored scale, rather than which reads best at that magnitude — rainfall is stored per metre and displayed per centimetre, `distanceInKm` is stored in km and would otherwise name itself `m`. The count abbreviations (`k`, `m`, `B`) are kept out of that pool: they shorten a number rather than saying what it is counted in, and with them in, `(density / population³)²` came out as `/m⁴·k⁴`.

Where the stored scale is a bare ratio there is no unit to name, and the number still needs explaining, so it says `[as a fraction]`: a share is stored as 0.05 and written as 5%, and fatalities per capita are stored per person and written per hundred thousand. A count says nothing, being named by the statistic counting it, and neither does an expression no unit is exactly — `ln(population ** 0.5)`.

Two e2e tests read a column header back off the page, one of them after switching the reader to Celsius; both fail against main. Unit rows cover each row of the table above. `tsc`, eslint, knip, 778 unit tests, `statistic-inferred-units` and `embed_worker` pass.