### PR TITLE
Share the mapper inset test helpers

### DIFF
--- a/react/test/mapper-edit-insets.ts
+++ b/react/test/mapper-edit-insets.ts
@@ -2,8 +2,8 @@ import { ClientFunction, Selector } from 'testcafe'
 
 import { TestWindow } from '../src/utils/TestUtils'
 
-import { drag, toggleCustomScript, urlFromCode } from './mapper-utils'
-import { screencap, urbanstatsFixture } from './test_utils'
+import { drag, editInsetsButton, handle, map, numMaps, toggleCustomScript, urlFromCode } from './mapper-utils'
+import { screencap, urbanstatsFixture, wheel } from './test_utils'
 
 export function runTests(platform: 'desktop' | 'mobile', shard = 0, numShards = 1): void {
     urbanstatsFixture(`default map`, '/mapper.html', async (t) => {
@@ -11,18 +11,6 @@ export function runTests(platform: 'desktop' | 'mobile', shard = 0, numShards = 
             await t.resizeWindow(400, 800)
         }
     })
-
-    function numMaps(): Promise<number> {
-        return Selector('[id^="map-"]').count
-    }
-
-    function map(n: number): string {
-        return `[id^="map-${n}"]`
-    }
-
-    function handle(mapNumber: number, pos: 'move' | 'topRight' | 'bottomRight' | 'bottomLeft' | 'topLeft' | 'duplicate' | 'delete' | 'add' | 'moveUp' | 'moveDown'): string {
-        return `${map(mapNumber)} [data-test="${pos}"]`
-    }
 
     interface Bounds { n: number, e: number, s: number, w: number }
 
@@ -66,19 +54,6 @@ export function runTests(platform: 'desktop' | 'mobile', shard = 0, numShards = 
         }, { dependencies: { selector, map0 } })()
     }
 
-    async function wheel(t: TestController, selector: string, deltaY: number, offset: { x: number, y: number }): Promise<void> {
-        return ClientFunction(() => {
-            const element = document.querySelector(`${selector} .maplibregl-canvas-container`)!
-            const elementRect = element.getBoundingClientRect()
-            const eventLocation = {
-                clientX: ((elementRect.left + elementRect.right) / 2) + offset.x,
-                clientY: ((elementRect.bottom + elementRect.top) / 2) + offset.y,
-            }
-            // Magic constant simulates a scroll wheel so our events are processed properly
-            element.dispatchEvent(new WheelEvent('wheel', { deltaY: deltaY * 4.000244140625, ...eventLocation }))
-        }, { dependencies: { selector, deltaY, offset } })()
-    }
-
     type MapPositions = { frame: Rect | undefined, bounds: Bounds | undefined }[]
 
     function mapPositionsEqual(a: MapPositions, b: MapPositions): boolean {
@@ -101,8 +76,6 @@ export function runTests(platform: 'desktop' | 'mobile', shard = 0, numShards = 
             )
         })
     }
-
-    const editInsetsButton = Selector('button[data-test=edit-insets]')
 
     let insetsEditIndex = 0
 

--- a/react/test/mapper-utils.ts
+++ b/react/test/mapper-utils.ts
@@ -135,3 +135,17 @@ export function testCode(testFn: () => TestFn, geographyKind: string, universe: 
         await downloadPNG(t)
     })
 }
+
+export const editInsetsButton = Selector('button[data-test=edit-insets]')
+
+export function numMaps(): Promise<number> {
+    return Selector('[id^="map-"]').count
+}
+
+export function map(n: number): string {
+    return `[id^="map-${n}"]`
+}
+
+export function handle(mapNumber: number, pos: 'move' | 'topRight' | 'bottomRight' | 'bottomLeft' | 'topLeft' | 'duplicate' | 'delete' | 'add' | 'moveUp' | 'moveDown'): string {
+    return `${map(mapNumber)} [data-test="${pos}"]`
+}

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -698,3 +698,16 @@ export async function withInterceptedRequests(t: TestController, requestHandler:
         await cdp.Fetch.disable()
     }
 }
+
+export async function wheel(t: TestController, selector: string, deltaY: number, offset: { x: number, y: number }): Promise<void> {
+    return ClientFunction(() => {
+        const element = document.querySelector(`${selector} .maplibregl-canvas-container`)!
+        const elementRect = element.getBoundingClientRect()
+        const eventLocation = {
+            clientX: ((elementRect.left + elementRect.right) / 2) + offset.x,
+            clientY: ((elementRect.bottom + elementRect.top) / 2) + offset.y,
+        }
+        // Magic constant simulates a scroll wheel so our events are processed properly
+        element.dispatchEvent(new WheelEvent('wheel', { deltaY: deltaY * 4.000244140625, ...eventLocation }))
+    }, { dependencies: { selector, deltaY, offset } })()
+}


### PR DESCRIPTION
Pure test refactor, split off #1785's implementation so that PR only carries behavior.

The inset editor tests are gaining a second file, and the map, handle and `numMaps` selectors it needs were defined inside `runTests`'s closure in `mapper-edit-insets.ts`. They move to `mapper-utils.ts`, and the synthetic `wheel` event helper moves to `test_utils.ts` alongside the other event helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)