### PR TITLE
Write units that contain counts, such as people^2 and km^2/person

### DIFF
--- a/react/cf-og-worker/src/embed.tsx
+++ b/react/cf-og-worker/src/embed.tsx
@@ -199,7 +199,7 @@ function humanReadable(name: HumanReadableName, fontSize: number, units: Units):
             case 'quantity': {
                 // writeQuantity rather than writtenPlainly, which would flatten mi^{2} into those
                 // literal characters instead of leaving the exponent for the superscript case below
-                const { renderedValue, unitName } = writeQuantity(element.value, element.unit, readerOf(units), {})
+                const { renderedValue, unitName } = writeQuantity(element.value, element.unit, readerOf(units), { afterNumber: true })
                 return [narrowSpaces(trimTrailingZeros(renderedValue)), ...humanReadable(unitName, fontSize, units)]
             }
         }

--- a/react/cf-og-worker/src/embed.tsx
+++ b/react/cf-og-worker/src/embed.tsx
@@ -199,7 +199,7 @@ function humanReadable(name: HumanReadableName, fontSize: number, units: Units):
             case 'quantity': {
                 // writeQuantity rather than writtenPlainly, which would flatten mi^{2} into those
                 // literal characters instead of leaving the exponent for the superscript case below
-                const { renderedValue, unitName } = writeQuantity(element.value, element.unit, readerOf(units), { afterNumber: true })
+                const { renderedValue, unitName } = writeQuantity(element.value, element.unit, readerOf(units), 'afterNumber')
                 return [narrowSpaces(trimTrailingZeros(renderedValue)), ...humanReadable(unitName, fontSize, units)]
             }
         }
@@ -211,7 +211,7 @@ function readerOf(units: Units): UnitSettings {
 }
 
 function formatValue(value: number, unit: StoredUnit, units: Units, fontSize: number): ReactNode[] {
-    const rendered = renderQuantity(value, unit, readerOf(units), { alone: true })
+    const rendered = renderQuantity(value, unit, readerOf(units), 'inColumn')
     // An array rather than a fragment, which satori does not have.
     return [
         keyed(styleBareTags(rendered.value, fontSize), 'value'),

--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -5,8 +5,9 @@ import { StoredUnit } from '../utils/quantity'
 
 import { renderQuantity } from './unit-display'
 
-export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit, unitAlone?: boolean }): ReactNode {
-    const { value, unit } = renderQuantity(props.value, props.unit, useUnitSettings(), props.unitAlone === true ? 'inColumn' : 'byItself')
+/** A table's value and its unit, which are drawn in columns of their own. */
+export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit }): ReactNode {
+    const { value, unit } = renderQuantity(props.value, props.unit, useUnitSettings(), 'inColumn')
 
     return (
         <span style={props.style}>

--- a/react/src/components/display-stats.tsx
+++ b/react/src/components/display-stats.tsx
@@ -6,7 +6,7 @@ import { StoredUnit } from '../utils/quantity'
 import { renderQuantity } from './unit-display'
 
 export function Statistic(props: { style?: React.CSSProperties, value: number, isUnit: boolean, unit: StoredUnit, unitAlone?: boolean }): ReactNode {
-    const { value, unit } = renderQuantity(props.value, props.unit, useUnitSettings(), { alone: props.unitAlone })
+    const { value, unit } = renderQuantity(props.value, props.unit, useUnitSettings(), props.unitAlone === true ? 'inColumn' : 'byItself')
 
     return (
         <span style={props.style}>

--- a/react/src/components/table.tsx
+++ b/react/src/components/table.tsx
@@ -554,7 +554,6 @@ export function StatisticRowCells(props: {
                             <Statistic
                                 value={statisticRow.statval}
                                 isUnit={true}
-                                unitAlone={true}
                                 unit={statisticRow.unit}
                             />
                         </span>

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -52,7 +52,7 @@ export function renderQuantity(value: number, stored: StoredUnit, settings: Unit
  */
 export function QuantityTogether({ value, stored }: { value: number, stored: StoredUnit }): ReactNode {
     const settings = useUnitSettings()
-    const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings, {})
+    const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings, { afterNumber: true })
     const colors = useColors()
     return (
         <span style={hue === undefined ? undefined : { color: colors.hueColors[hue] }}>

--- a/react/src/components/unit-display.tsx
+++ b/react/src/components/unit-display.tsx
@@ -52,7 +52,7 @@ export function renderQuantity(value: number, stored: StoredUnit, settings: Unit
  */
 export function QuantityTogether({ value, stored }: { value: number, stored: StoredUnit }): ReactNode {
     const settings = useUnitSettings()
-    const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings, { afterNumber: true })
+    const { renderedValue, unitName, hue } = writeQuantity(value, stored, settings, 'afterNumber')
     const colors = useColors()
     return (
         <span style={hue === undefined ? undefined : { color: colors.hueColors[hue] }}>

--- a/react/src/urban-stats-script/derive-unit.ts
+++ b/react/src/urban-stats-script/derive-unit.ts
@@ -1,5 +1,5 @@
 import { mapDataExpression, MapUSS, tableColumnExpression } from '../mapper/settings/map-uss'
-import { StoredUnit, writableDimensions } from '../utils/quantity'
+import { StoredUnit } from '../utils/quantity'
 
 import { UrbanStatsASTExpression } from './ast'
 import { TypeEnvironment } from './types-values'
@@ -11,8 +11,7 @@ function unitOf(values: UrbanStatsASTExpression | undefined, uss: MapUSS, typeEn
     if (values === undefined) {
         return undefined
     }
-    const unit = unitToWriteIn(inferUnit(values, typeEnvironment, inferBindings(uss, typeEnvironment)))
-    return unit !== undefined && writableDimensions(unit.unit) ? unit : undefined
+    return unitToWriteIn(inferUnit(values, typeEnvironment, inferBindings(uss, typeEnvironment)))
 }
 
 export function deriveMapUnit(uss: MapUSS, typeEnvironment: TypeEnvironment): StoredUnit | undefined {

--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -1,4 +1,4 @@
-import { dimensionless, sameDimensions, StoredUnit, writableDimensions } from '../utils/quantity'
+import { dimensionless, sameDimensions, StoredUnit } from '../utils/quantity'
 import { unitTypeToStoredUnit } from '../utils/unit'
 
 import { locationOf, UrbanStatsASTArg, UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
@@ -257,7 +257,7 @@ function readBack(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, expecte
     switch (ast.type) {
         case 'constant': {
             const unit = unitToWriteIn(expected)
-            if (ast.value.node.type === 'number' && unit !== undefined && writableDimensions(unit.unit)) {
+            if (ast.value.node.type === 'number' && unit !== undefined) {
                 into.set(whereWritten(ast.value.location), unit)
             }
             return
@@ -286,7 +286,7 @@ function readBack(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, expecte
             // a caption writes a number where this call is, so record its unit as for a literal
             if (readAsANumber(ast, scope) !== undefined) {
                 const unit = unitToWriteIn(expected)
-                if (unit !== undefined && writableDimensions(unit.unit)) {
+                if (unit !== undefined) {
                     into.set(whereWritten(locationOf(ast)), unit)
                 }
             }

--- a/react/src/utils/human-readable-name.tsx
+++ b/react/src/utils/human-readable-name.tsx
@@ -10,7 +10,7 @@ import { trimTrailingZeros } from './text'
  * units they read in. On a page `reifyReact` asks, and writes it in those.
  */
 export function writtenPlainly(value: number, unit: StoredUnit, settings: UnitSettings): string {
-    const written = writeQuantity(value, unit, settings, { afterNumber: true })
+    const written = writeQuantity(value, unit, settings, 'afterNumber')
     return `${trimTrailingZeros(written.renderedValue)}${reifyString(written.unitName, settings)}`
 }
 
@@ -49,7 +49,7 @@ export function reifyReact(elements: HumanReadableElement[] | string, settings: 
 
 /** One run of text, so that the unit cannot be rasterized a pixel off the number it belongs to. */
 function writtenQuantity(value: number, unit: StoredUnit, settings: UnitSettings): ReactNode {
-    const { renderedValue, unitName } = writeQuantity(value, unit, settings, { afterNumber: true })
+    const { renderedValue, unitName } = writeQuantity(value, unit, settings, 'afterNumber')
     return (
         <>
             {trimTrailingZeros(renderedValue)}

--- a/react/src/utils/human-readable-name.tsx
+++ b/react/src/utils/human-readable-name.tsx
@@ -10,7 +10,7 @@ import { trimTrailingZeros } from './text'
  * units they read in. On a page `reifyReact` asks, and writes it in those.
  */
 export function writtenPlainly(value: number, unit: StoredUnit, settings: UnitSettings): string {
-    const written = writeQuantity(value, unit, settings, {})
+    const written = writeQuantity(value, unit, settings, { afterNumber: true })
     return `${trimTrailingZeros(written.renderedValue)}${reifyString(written.unitName, settings)}`
 }
 
@@ -49,7 +49,7 @@ export function reifyReact(elements: HumanReadableElement[] | string, settings: 
 
 /** One run of text, so that the unit cannot be rasterized a pixel off the number it belongs to. */
 function writtenQuantity(value: number, unit: StoredUnit, settings: UnitSettings): ReactNode {
-    const { renderedValue, unitName } = writeQuantity(value, unit, settings, {})
+    const { renderedValue, unitName } = writeQuantity(value, unit, settings, { afterNumber: true })
     return (
         <>
             {trimTrailingZeros(renderedValue)}

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -62,7 +62,10 @@ export interface StoredUnit {
 
 /** Whether a unit is rendered by itself or against the number it belongs to. */
 export interface UnitPlacement {
+    /** In a column of its own, where a leading solidus reads as a dangling slash. */
     alone?: boolean
+    /** Straight after the number, where a word wants a space off it and km^{2} does not. */
+    afterNumber?: boolean
 }
 
 export interface UnitSettings {
@@ -204,24 +207,18 @@ function allUnits(settings: UnitSettings): NamedUnit[] {
 
 const counted: BaseUnit[] = ['person', 'usd', 'fatality']
 
+const baseUnitWords: Record<BaseUnit, string> = {
+    person: 'people', usd: 'dollars', fatality: 'fatalities', m: 'm', g: 'g', s: 's', F: '°F',
+}
+
 /**
  * A count goes unnamed, so it can only be the one thing counted: people times square kilometres
  * would be written `km²` and read as an area. A fractional power is in no pool at all. A statistic
  * that says which units it is written in has named them, counted things and all.
  */
 export function writableDimensions(unit: Unit): boolean {
-    if (!unit.dimensions.every(({ power }) => Number.isInteger(power))) {
-        return false
-    }
-    if (unit.decoration.kind === 'writtenIn') {
-        return true
-    }
-    const counts = unit.dimensions.filter(({ baseUnit }) => counted.includes(baseUnit))
-    if (counts.length === 0) {
-        return true
-    }
-    const above = unit.dimensions.filter(({ power }) => power > 0)
-    return counts.length === 1 && counts[0].power === 1 && above.length === 1
+    // a fractional power of a count is written as nothing, the count having no name to raise
+    return unit.dimensions.every(({ baseUnit, power }) => Number.isInteger(power) || counted.includes(baseUnit))
 }
 
 type DimensionKey = string
@@ -282,7 +279,7 @@ function raisedTo(power: number): HumanReadableElement[] {
 function product(written: Written[]): HumanReadableElement[] {
     return written.flatMap(({ unit, power }, index) => [
         ...index === 0 ? [] : atom('\u00b7'),
-        ...atom(unit.name),
+        ...atom(unit.name === '' ? baseUnitWords[unit.dimensions[0].baseUnit] : unit.name),
         ...raisedTo(power),
     ])
 }
@@ -361,14 +358,19 @@ export function nameOfStoredUnit(stored: StoredUnit): HumanReadableElement[] | u
  * Set `alone` when the unit is rendered by itself, as in a table's unit column. A leading solidus
  * then takes a space, so that it reads as "per square kilometre" rather than as a dangling slash.
  */
-export function nameOf(written: Written[], { alone = false }: UnitPlacement = {}): HumanReadableElement[] {
-    const named = written.filter(({ unit }) => unit.name !== '')
+export function nameOf(written: Written[], { alone = false, afterNumber = false }: UnitPlacement = {}): HumanReadableElement[] {
+    // a count is named by the statistic counting it, but only where there is one of it: a square
+    // of people is not people, and says so
+    const named = written.filter(({ unit, power }) => unit.name !== '' || power !== 1)
     const over = named.filter(({ power }) => power > 0)
     const under = named.filter(({ power }) => power < 0)
+    // a word takes a space off the number it follows, where km^{2} and % do not
+    const spaced = afterNumber && over.length > 0 && over[0].unit.name === ''
+    const start = spaced ? atom('\u00a0') : []
     if (under.length === 0) {
-        return merged(product(over))
+        return merged([...start, ...product(over)])
     }
-    return merged([...product(over), ...atom(over.length === 0 && alone ? '/\u00a0' : '/'), ...product(under)])
+    return merged([...start, ...product(over), ...atom(over.length === 0 && alone ? '/\u00a0' : '/'), ...product(under)])
 }
 
 /**
@@ -387,7 +389,12 @@ function representationFor(inBaseUnits: number, unit: Unit, settings: UnitSettin
     const convention = conventions[renderAsKey(unit.dimensions)]
     // a statistic written in units of its own leaves the search nothing to choose between
     const writtenIn = unit.decoration.kind === 'writtenIn' ? unit.decoration.in : undefined
-    const pool = writtenIn === undefined ? allUnits(settings) : Object.values(writtenIn.units[systemOf(settings)])
+    // An abbreviation shortens a count: thousands of people are people. It has no business scaling
+    // anything else, so people times an area is not written in billions of square metres.
+    const shortenable = unit.dimensions.length === 0 || (unit.dimensions.length === 1 && unit.dimensions[0].power === 1)
+    const pool = writtenIn === undefined
+        ? allUnits(settings).filter(({ abbreviation }) => shortenable || !abbreviation)
+        : Object.values(writtenIn.units[systemOf(settings)])
     const { written, scale, format } = chooseUnits(inBaseUnits, unit.dimensions, pool,
         chosen => writtenIn?.style ?? styleFor(convention, chosen))
     const zero = offsetOf(written, unit.times)

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -60,13 +60,14 @@ export interface StoredUnit {
     toBaseUnits: number
 }
 
-/** Whether a unit is rendered by itself or against the number it belongs to. */
-export interface UnitPlacement {
-    /** In a column of its own, where a leading solidus reads as a dangling slash. */
-    alone?: boolean
-    /** Straight after the number, where a word wants a space off it and km^{2} does not. */
-    afterNumber?: boolean
-}
+/** Where a unit is written, which the spacing around it depends on. */
+export type UnitPlacement =
+    /** In a column of its own, as a table writes it */
+    | 'inColumn'
+    /** Immediately after a number */
+    | 'afterNumber'
+    /** In a run of text, with no number before it */
+    | 'byItself'
 
 export interface UnitSettings {
     useImperial?: boolean
@@ -207,7 +208,7 @@ function allUnits(settings: UnitSettings): NamedUnit[] {
 
 const counted: BaseUnit[] = ['person', 'usd', 'fatality']
 
-/** What a count is called, one of it and several: an area over people is over each of them. */
+/** The two forms a count's name takes: people^{2} above the solidus, km^{2}/person below it. */
 const baseUnitWords: Record<BaseUnit, { one: string, many: string }> = {
     person: { one: 'person', many: 'people' },
     usd: { one: 'dollar', many: 'dollars' },
@@ -283,18 +284,17 @@ function raisedTo(power: number): HumanReadableElement[] {
 }
 
 /** The units multiplied together, e.g., km^2, or people per km^2 for a quantity with a denominator. */
-function product(written: Written[], each = false): HumanReadableElement[] {
+function product(written: Written[], singular = false): HumanReadableElement[] {
     return written.flatMap(({ unit, power }, index) => [
         ...index === 0 ? [] : atom('\u00b7'),
-        ...atom(unit.name === '' ? wordFor(unit, each) : unit.name),
+        ...atom(unit.name === '' ? wordFor(unit, singular) : unit.name),
         ...raisedTo(power),
     ])
 }
 
-/** Under the solidus it is one of them at a time: fatalities per person, not per people. */
-function wordFor(unit: NamedUnit, each: boolean): string {
+function wordFor(unit: NamedUnit, singular: boolean): string {
     const words = baseUnitWords[unit.dimensions[0].baseUnit]
-    return each ? words.one : words.many
+    return singular ? words.one : words.many
 }
 
 function computedUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit {
@@ -364,26 +364,28 @@ export function nameOfStoredUnit(stored: StoredUnit): HumanReadableElement[] | u
     // abbreviations, which shorten a number rather than saying what it is counted in
     const pool = [...allUnits({}), ...lengthUnits.imperial, celsius].filter(({ abbreviation }) => !abbreviation)
     const written = writtenAsCounted(stored.unit.dimensions, pool, stored.toBaseUnits)
-    return written === undefined ? undefined : nameOf(written, {})
+    return written === undefined ? undefined : nameOf(written, 'byItself')
 }
 
 /**
  * Set `alone` when the unit is rendered by itself, as in a table's unit column. A leading solidus
  * then takes a space, so that it reads as "per square kilometre" rather than as a dangling slash.
  */
-export function nameOf(written: Written[], { alone = false, afterNumber = false }: UnitPlacement = {}): HumanReadableElement[] {
+export function nameOf(written: Written[], placement: UnitPlacement = 'byItself'): HumanReadableElement[] {
     // a count is named by the statistic counting it, but only where there is one of it: a square
     // of people is not people, and says so
     const named = written.filter(({ unit, power }) => unit.name !== '' || power !== 1)
     const over = named.filter(({ power }) => power > 0)
     const under = named.filter(({ power }) => power < 0)
     // a word takes a space off the number it follows, where km^{2} and % do not
-    const spaced = afterNumber && over.length > 0 && over[0].unit.name === ''
+    const spaced = placement === 'afterNumber' && over.length > 0 && over[0].unit.name === ''
     const start = spaced ? atom('\u00a0') : []
     if (under.length === 0) {
         return merged([...start, ...product(over)])
     }
-    return merged([...start, ...product(over), ...atom(over.length === 0 && alone ? '/\u00a0' : '/'), ...product(under, true)])
+    // a solidus with nothing in front of it reads as a dangling slash in a column of its own
+    const solidus = over.length === 0 && placement === 'inColumn' ? '/\u00a0' : '/'
+    return merged([...start, ...product(over), ...atom(solidus), ...product(under, true)])
 }
 
 /**

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -206,8 +206,6 @@ function allUnits(settings: UnitSettings): NamedUnit[] {
     ]
 }
 
-const counted: BaseUnit[] = ['person', 'usd', 'fatality']
-
 /** The two forms a count's name takes: people^{2} above the solidus, km^{2}/person below it. */
 const baseUnitWords: Record<BaseUnit, { one: string, many: string }> = {
     person: { one: 'person', many: 'people' },
@@ -217,14 +215,6 @@ const baseUnitWords: Record<BaseUnit, { one: string, many: string }> = {
     g: { one: 'g', many: 'g' },
     s: { one: 's', many: 's' },
     F: { one: '°F', many: '°F' },
-}
-
-/**
- * Whether the dimensions have names to write. A fractional power is in no pool, so a root of a
- * length cannot be written; a root of a count can, the count having no name to raise.
- */
-export function writableDimensions(unit: Unit): boolean {
-    return unit.dimensions.every(({ baseUnit, power }) => Number.isInteger(power) || counted.includes(baseUnit))
 }
 
 type DimensionKey = string

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -356,8 +356,9 @@ export function nameOfStoredUnit(stored: StoredUnit): HumanReadableElement[] | u
 }
 
 /**
- * Set `alone` when the unit is rendered by itself, as in a table's unit column. A leading solidus
- * then takes a space, so that it reads as "per square kilometre" rather than as a dangling slash.
+ * What a unit is called, spaced for where it is written: a leading solidus takes a space in a
+ * column of its own, so that it reads as "per square kilometre" rather than as a dangling slash,
+ * and a name that is a word takes one off the number it follows, where km^{2} and % do not.
  */
 export function nameOf(written: Written[], placement: UnitPlacement = 'byItself'): HumanReadableElement[] {
     // a count is named by the statistic counting it, but only where there is one of it: a square

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -207,8 +207,15 @@ function allUnits(settings: UnitSettings): NamedUnit[] {
 
 const counted: BaseUnit[] = ['person', 'usd', 'fatality']
 
-const baseUnitWords: Record<BaseUnit, string> = {
-    person: 'people', usd: 'dollars', fatality: 'fatalities', m: 'm', g: 'g', s: 's', F: '°F',
+/** What a count is called, one of it and several: an area over people is over each of them. */
+const baseUnitWords: Record<BaseUnit, { one: string, many: string }> = {
+    person: { one: 'person', many: 'people' },
+    usd: { one: 'dollar', many: 'dollars' },
+    fatality: { one: 'fatality', many: 'fatalities' },
+    m: { one: 'm', many: 'm' },
+    g: { one: 'g', many: 'g' },
+    s: { one: 's', many: 's' },
+    F: { one: '°F', many: '°F' },
 }
 
 /**
@@ -276,12 +283,18 @@ function raisedTo(power: number): HumanReadableElement[] {
 }
 
 /** The units multiplied together, e.g., km^2, or people per km^2 for a quantity with a denominator. */
-function product(written: Written[]): HumanReadableElement[] {
+function product(written: Written[], each = false): HumanReadableElement[] {
     return written.flatMap(({ unit, power }, index) => [
         ...index === 0 ? [] : atom('\u00b7'),
-        ...atom(unit.name === '' ? baseUnitWords[unit.dimensions[0].baseUnit] : unit.name),
+        ...atom(unit.name === '' ? wordFor(unit, each) : unit.name),
         ...raisedTo(power),
     ])
+}
+
+/** Under the solidus it is one of them at a time: fatalities per person, not per people. */
+function wordFor(unit: NamedUnit, each: boolean): string {
+    const words = baseUnitWords[unit.dimensions[0].baseUnit]
+    return each ? words.one : words.many
 }
 
 function computedUnit(dimensions: Dimension[], toBaseUnits: number): StoredUnit {
@@ -370,7 +383,7 @@ export function nameOf(written: Written[], { alone = false, afterNumber = false 
     if (under.length === 0) {
         return merged([...start, ...product(over)])
     }
-    return merged([...start, ...product(over), ...atom(over.length === 0 && alone ? '/\u00a0' : '/'), ...product(under)])
+    return merged([...start, ...product(over), ...atom(over.length === 0 && alone ? '/\u00a0' : '/'), ...product(under, true)])
 }
 
 /**

--- a/react/src/utils/quantity.ts
+++ b/react/src/utils/quantity.ts
@@ -220,12 +220,10 @@ const baseUnitWords: Record<BaseUnit, { one: string, many: string }> = {
 }
 
 /**
- * A count goes unnamed, so it can only be the one thing counted: people times square kilometres
- * would be written `km²` and read as an area. A fractional power is in no pool at all. A statistic
- * that says which units it is written in has named them, counted things and all.
+ * Whether the dimensions have names to write. A fractional power is in no pool, so a root of a
+ * length cannot be written; a root of a count can, the count having no name to raise.
  */
 export function writableDimensions(unit: Unit): boolean {
-    // a fractional power of a count is written as nothing, the count having no name to raise
     return unit.dimensions.every(({ baseUnit, power }) => Number.isInteger(power) || counted.includes(baseUnit))
 }
 

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -50,8 +50,11 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
     assert(power !== undefined, 'we filtered out undefined powers')
     return pool.flatMap((unit) => {
         const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
+        // A unit of one that goes unnamed can be taken to any power at all, contributing neither a
+        // name nor a scale: half of a person is what a root of a count is counted in.
+        const anyPowerWillDo = unit.name === '' && unit.size === 1
         // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
-        if (covers === 0 || power % covers !== 0 || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
+        if (covers === 0 || (power % covers !== 0 && !anyPowerWillDo) || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
             return []
         }
         const times = power / covers

--- a/react/src/utils/unit-search.ts
+++ b/react/src/utils/unit-search.ts
@@ -9,6 +9,9 @@ export interface Written {
 
 const artificialZeroCost = 100
 
+/** What a unit taken to a power that is not whole costs, in digits, against one that is. */
+const rootCost = 10
+
 /**
  * We charge 1 for every digit as printed, with two adjustments:
  * - a number rounded away to 0 is heavily penalized, unless in fixed point
@@ -50,11 +53,10 @@ function coverings(needed: Exponents, pool: NamedUnit[], settled: BaseUnit[] = [
     assert(power !== undefined, 'we filtered out undefined powers')
     return pool.flatMap((unit) => {
         const covers = exponentsOf(unit.dimensions)[baseUnit] ?? 0
-        // A unit of one that goes unnamed can be taken to any power at all, contributing neither a
-        // name nor a scale: half of a person is what a root of a count is counted in.
-        const anyPowerWillDo = unit.name === '' && unit.size === 1
-        // it has to take this base unit's exponent to exactly zero, and leave the settled ones be
-        if (covers === 0 || (power % covers !== 0 && !anyPowerWillDo) || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
+        // it has to take this base unit's exponent to exactly zero, and leave the settled ones be.
+        // A unit may be taken to any power, whole or not: a root of an area is written in roots of
+        // a square kilometre, one of which is a thousand roots of a square metre.
+        if (covers === 0 || unit.dimensions.some(dimension => settled.includes(dimension.baseUnit))) {
             return []
         }
         const times = power / covers
@@ -99,6 +101,8 @@ export function chooseUnits(
         const scale = scaledBy(written)
         const cost = written.reduce((total, { power, unit }) => total + unit.cost * Math.abs(power), 0)
             + Math.max(0, digitCost(scale(inBaseUnits), format) - 3)
+            // a length is written in feet rather than in roots of an acre, where feet will do
+            + written.filter(({ power }) => !Number.isInteger(power)).length * rootCost
         if (cost < bestCost) {
             best = { written, scale, format }
             bestCost = cost

--- a/react/test/statistic-inferred-units.test.ts
+++ b/react/test/statistic-inferred-units.test.ts
@@ -131,8 +131,8 @@ test('every column of a filtered table is named and written in what the script w
     }
     await t.expect(names).eql(['Population ÷ Area', 'Mean high temp − Mean low temp', 'max(Commute Bike %, 5%)', 'Population0.5'])
     await t.expect(await rows()).eql([
-        '3\u202f897 /\u00a0km2', '+16.8 °F', '5.00 %', '830',
-        '163 /\u00a0km2', '+15.9 °F', '5.00 %', '4\u202f830',
+        '3\u202f897 /\u00a0km2', '+16.8 °F', '5.00 %', '830 people0.5',
+        '163 /\u00a0km2', '+15.9 °F', '5.00 %', '4\u202f825 people0.5',
     ])
 })
 
@@ -141,5 +141,5 @@ urbanstatsFixture('a quantity with no writing', tableOf('population ** 0.5'))
 test('a root of a count is written plainly rather than failing', async (t) => {
     await waitForLoading()
     // to three figures, as anything in no known unit is, rather than whole as a count of people is
-    await t.expect(await rows()).eql(['8\u202f180', '6\u202f110', '6\u202f060'])
+    await t.expect(await rows()).eql(['8\u202f176 people0.5', '6\u202f105 people0.5', '6\u202f063 people0.5'])
 })

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -116,6 +116,32 @@ void test('a count is written as nothing, whatever else it is multiplied by', ()
     assert.equal(written(unitOfMap('population * population'), 1e12), '1\u202f000\u202f000\u202f000\u202f000people^{2}')
 })
 
+void test('dollars and fatalities are counted the way people are', () => {
+    assert.equal(mapUnit('median_household_income_usd ** 0.5'), '1\u202f000dollars^{0.5}')
+    assert.equal(mapUnit('median_household_income_usd * median_household_income_usd'), '1\u202f000dollars^{2}')
+    assert.equal(mapUnit('area / median_household_income_usd'), '1\u202f000km^{2}/dollar')
+    assert.equal(mapUnit('traffic_fatalities ** 0.5'), '1\u202f000fatalities^{0.5}')
+    assert.equal(mapUnit('traffic_fatalities * traffic_fatalities'), '1\u202f000fatalities^{2}')
+    assert.equal(mapUnit('area / traffic_fatalities'), '1\u202f000km^{2}/fatality')
+    // one of a count goes unsaid above the solidus and is said under it, however many are counted
+    assert.equal(mapUnit('traffic_fatalities / population'), '1\u202f000/person')
+    assert.equal(mapUnit('median_household_income_usd / population'), '1\u202f000/person')
+    assert.equal(mapUnit('traffic_fatalities / (population * area)'), '1\u202f000/km^{2}·person')
+    assert.equal(mapUnit('population / traffic_fatalities ** 2'), '1\u202f000/fatality^{2}')
+})
+
+void test('a word is spaced off the number it follows, and a symbol is not', () => {
+    const inline = (data: string): string => {
+        const unit = unitOfMap(data)
+        assert.ok(unit)
+        const quantity = writeQuantity(1000, unit, {}, { afterNumber: true })
+        return `${quantity.renderedValue}${reifyString(quantity.unitName, {})}`
+    }
+    assert.equal(inline('traffic_fatalities ** 0.5'), '1\u202f000\u00a0fatalities^{0.5}')
+    assert.equal(inline('area / traffic_fatalities'), '1\u202f000km^{2}/fatality')
+    assert.equal(inline('area'), '1\u202f000km^{2}')
+})
+
 void test('a reader in Celsius reads a difference of two temperatures as one', () => {
     const asRead = (data: string, temperatureUnit: string): string => written(unitOfMap(data), 22.3, { temperatureUnit })
     // twenty-two Fahrenheit degrees between the day's high and its low is twelve Celsius degrees,

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -12,7 +12,7 @@ function written(unit: StoredUnit | undefined, value = 1000, settings: UnitSetti
     if (unit === undefined) {
         return 'nothing'
     }
-    const quantity = writeQuantity(value, unit, settings, {})
+    const quantity = writeQuantity(value, unit, settings, 'byItself')
     return `${quantity.renderedValue}${reifyString(quantity.unitName, {})}`
 }
 
@@ -128,13 +128,18 @@ void test('dollars and fatalities are counted the way people are', () => {
     assert.equal(mapUnit('median_household_income_usd / population'), '1\u202f000/person')
     assert.equal(mapUnit('traffic_fatalities / (population * area)'), '1\u202f000/km^{2}·person')
     assert.equal(mapUnit('population / traffic_fatalities ** 2'), '1\u202f000/fatality^{2}')
+    // and a root of one under the solidus is written the way a square of one is
+    assert.equal(mapUnit('area / population ** 0.5'), '1\u202f000km^{2}/person^{0.5}')
+    assert.equal(mapUnit('area / traffic_fatalities ** 0.5'), '1\u202f000km^{2}/fatality^{0.5}')
+    assert.equal(mapUnit('population ** -0.5'), '1\u202f000/person^{0.5}')
+    assert.equal(mapUnit('population ** 1.5'), '1\u202f000people^{1.5}')
 })
 
 void test('a word is spaced off the number it follows, and a symbol is not', () => {
     const inline = (data: string): string => {
         const unit = unitOfMap(data)
         assert.ok(unit)
-        const quantity = writeQuantity(1000, unit, {}, { afterNumber: true })
+        const quantity = writeQuantity(1000, unit, {}, 'afterNumber')
         return `${quantity.renderedValue}${reifyString(quantity.unitName, {})}`
     }
     assert.equal(inline('traffic_fatalities ** 0.5'), '1\u202f000\u00a0fatalities^{0.5}')

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -130,6 +130,12 @@ void test('dollars and fatalities are counted the way people are', () => {
     assert.equal(mapUnit('population / traffic_fatalities ** 2'), '1\u202f000/fatality^{2}')
     // and a root of one under the solidus is written the way a square of one is
     assert.equal(mapUnit('area / population ** 0.5'), '1\u202f000km^{2}/person^{0.5}')
+    // a root of anything else is written the same way, in roots of the unit it is measured in
+    assert.equal(mapUnit('area ** 0.25'), '1\u202f000km^{0.5}')
+    assert.equal(written(unitOfMap('area ** 0.25'), 1000, { useImperial: true }), '788mi^{0.5}')
+    // where a whole power of a unit will do, it is taken: a root of an area is a length, and a
+    // length is written in miles rather than in roots of an acre
+    assert.equal(written(unitOfMap('area ** 0.5'), 1000, { useImperial: true }), '621mi')
     assert.equal(mapUnit('area / traffic_fatalities ** 0.5'), '1\u202f000km^{2}/fatality^{0.5}')
     assert.equal(mapUnit('population ** -0.5'), '1\u202f000/person^{0.5}')
     assert.equal(mapUnit('population ** 1.5'), '1\u202f000people^{1.5}')

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -101,16 +101,19 @@ void test('a difference of two leads is written as the lead it is, and not twice
     assert.equal(written(unitOfMap('commute_bike - commute_transit'), 0.045), '+4.50%')
 })
 
-void test('a quantity with no writing is left to whatever its name is taken for', () => {
-    // a root of a count is in no unit any pool holds, and asking for one threw
-    assert.equal(mapUnit('population ** 0.5'), 'nothing')
-    // a count goes unnamed, so it can only be the one thing counted: people times an area would
-    // be written km^{2} and read as an area, and an area over people as an area too
-    assert.equal(mapUnit('population * area'), 'nothing')
-    assert.equal(mapUnit('area / population'), 'nothing')
-    assert.equal(mapUnit('traffic_fatalities / population'), 'nothing')
-    // where a count over something measured is written the way a density is
+void test('a count is written as nothing, whatever else it is multiplied by', () => {
+    // a root of a count is written as the plain number it is, the count having no name to raise
+    assert.equal(mapUnit('population ** 0.5'), '1\u202f000people^{0.5}')
+    // people times an area is written km^{2}, one of a count being named by the statistic counting
+    // it; an area over people says the people, there being no one of them to leave unsaid
+    assert.equal(mapUnit('population * area'), '1\u202f000km^{2}')
+    assert.equal(mapUnit('area / population'), '1\u202f000km^{2}/people')
+    assert.equal(mapUnit('traffic_fatalities / population'), '1\u202f000/people')
     assert.equal(mapUnit('traffic_fatalities / area'), '1\u202f000/km^{2}')
+    // a count is shortened only where it is the whole of what is written: a square of one is not
+    // written in squares of millions
+    assert.equal(written(unitOfMap('population'), 1.234e6), '1.23m')
+    assert.equal(written(unitOfMap('population * population'), 1e12), '1\u202f000\u202f000\u202f000\u202f000people^{2}')
 })
 
 void test('a reader in Celsius reads a difference of two temperatures as one', () => {

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -107,8 +107,8 @@ void test('a count is written as nothing, whatever else it is multiplied by', ()
     // people times an area is written km^{2}, one of a count being named by the statistic counting
     // it; an area over people says the people, there being no one of them to leave unsaid
     assert.equal(mapUnit('population * area'), '1\u202f000km^{2}')
-    assert.equal(mapUnit('area / population'), '1\u202f000km^{2}/people')
-    assert.equal(mapUnit('traffic_fatalities / population'), '1\u202f000/people')
+    assert.equal(mapUnit('area / population'), '1\u202f000km^{2}/person')
+    assert.equal(mapUnit('traffic_fatalities / population'), '1\u202f000/person')
     assert.equal(mapUnit('traffic_fatalities / area'), '1\u202f000/km^{2}')
     // a count is shortened only where it is the whole of what is written: a square of one is not
     // written in squares of millions

--- a/react/unit/unit-algebra.test.ts
+++ b/react/unit/unit-algebra.test.ts
@@ -211,7 +211,7 @@ for (const [level, declared] of [
         const inferred = unitToWriteIn(forward('-', inUnit(storedUnits[level]), inUnit(storedUnits[level])))
         assert.notEqual(inferred, undefined)
         const write = (stored: StoredUnit): string => {
-            const written = writeQuantity(0.05, stored, {}, {})
+            const written = writeQuantity(0.05, stored, {}, 'byItself')
             return `${written.renderedValue}${reifyString(written.unitName, {})} ${written.hue ?? ''}`
         }
         assert.equal(write(inferred!), write(storedUnits[declared]))
@@ -246,8 +246,8 @@ void test('either of two shares of different parties is a share of neither', () 
     const orange = inUnit(storedUnits.partyPctOrange)
     const joined = join(orange, inUnit(storedUnits.partyPctRed))
     assert.equal(shape(joined), shape(orange))
-    assert.equal(writeQuantity(0.05, unitToWriteIn(joined)!, {}, {}).hue, undefined)
-    assert.notEqual(writeQuantity(0.05, unitToWriteIn(orange)!, {}, {}).hue, undefined)
+    assert.equal(writeQuantity(0.05, unitToWriteIn(joined)!, {}, 'byItself').hue, undefined)
+    assert.notEqual(writeQuantity(0.05, unitToWriteIn(orange)!, {}, 'byItself').hue, undefined)
 })
 
 void test('a coefficient is carried through a product and raised through a power', () => {
@@ -293,7 +293,7 @@ void test('a difference of temperatures divides into things as well as by them',
     const perDegree = unitToWriteIn(forward('/', people, change))
     assert.notEqual(perDegree, undefined)
     const write = (settings: object): string => {
-        const written = writeQuantity(5, perDegree!, settings, {})
+        const written = writeQuantity(5, perDegree!, settings, 'byItself')
         return `${written.renderedValue}${reifyString(written.unitName, {})}`
     }
     // five to the Fahrenheit degree is nine to the Celsius one, that being the larger degree
@@ -307,7 +307,7 @@ void test('a difference per something is read in degrees of the reader\'s own sc
     const perArea = unitToWriteIn(forward('/', forward('-', temperature, temperature), area))
     assert.notEqual(perArea, undefined)
     const write = (settings: object): string => {
-        const written = writeQuantity(5, perArea!, settings, {})
+        const written = writeQuantity(5, perArea!, settings, 'byItself')
         return `${written.renderedValue}${reifyString(written.unitName, {})}`
     }
     // five Fahrenheit degrees per square kilometre is two and a bit Celsius degrees, the zero

--- a/react/unit/unit-display.test.ts
+++ b/react/unit/unit-display.test.ts
@@ -18,7 +18,7 @@ function textOf(node: unknown): string {
 }
 
 function renderValue(unitType: UnitType, value: number, useImperial = false, temperatureUnit = 'fahrenheit'): string {
-    const { value: valueEl, unit: unitEl } = renderQuantity(value, unitTypeToStoredUnit(unitType), { useImperial, temperatureUnit }, {})
+    const { value: valueEl, unit: unitEl } = renderQuantity(value, unitTypeToStoredUnit(unitType), { useImperial, temperatureUnit }, 'byItself')
     return `${textOf(valueEl)}${textOf(unitEl)}`.trim()
 }
 
@@ -259,7 +259,7 @@ for (const [unitType, value, expected, hue] of [
     ['partyChangeTeal', -0.125, '-12.50', 'cyan'],
 ] as const) {
     void test(`${unitType} writes ${value} as ${expected} in ${hue}`, () => {
-        const written = writeQuantity(value, storedUnits[unitType], {}, {})
+        const written = writeQuantity(value, storedUnits[unitType], {}, 'byItself')
         assert.equal(written.renderedValue, expected)
         assert.equal(written.hue, hue)
     })
@@ -269,7 +269,7 @@ for (const [unitType, value, expected, hue] of [
 // A quantity we do not have belongs to no party, and is measured in nothing
 for (const unitType of ['democraticMargin', 'partyPctOrange', 'percentage', 'temperature'] as const) {
     void test(`${unitType} writes a missing value plainly`, () => {
-        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType], {}, {}), { renderedValue: 'N/A', unitName: [] })
+        assert.deepEqual(writeQuantity(NaN, storedUnits[unitType], {}, 'byItself'), { renderedValue: 'N/A', unitName: [] })
     })
 }
 
@@ -316,7 +316,7 @@ for (const [unitType, dimensions, toBaseUnits, value, asStatistic, asDerived] of
     ['density', [{ baseUnit: 'person', power: 1 }, { baseUnit: 'm', power: -2 }], 1e-6, 1234, '1\u202f234/km^{2}', '1\u202f234/km^{2}'],
 ] as ['contaminantLevel' | 'distancePerYear' | 'density', Dimension[], number, number, string, string][]) {
     const write = (stored: StoredUnit): string => {
-        const written = writeQuantity(value, stored, {}, {})
+        const written = writeQuantity(value, stored, {}, 'byItself')
         return `${written.renderedValue}${reifyString(written.unitName, {})}`
     }
     void test(`${unitType} keeps its units, where the same dimensions on their own do not`, () => {
@@ -341,7 +341,7 @@ for (const [times, value, temperatureUnit, expected] of [
     void test(`${times === 1 ? 'a temperature' : 'a difference'} of ${value}F reads as ${expected}`, () => {
         const temperature = unitTypeToStoredUnit('temperature')
         const stored: StoredUnit = { ...temperature, unit: { ...temperature.unit, times } }
-        const written = writeQuantity(value, stored, { temperatureUnit }, {})
+        const written = writeQuantity(value, stored, { temperatureUnit }, 'byItself')
         assert.equal(`${written.renderedValue}${reifyString(written.unitName, {})}`, expected)
     })
 }

--- a/react/unit/unit-search.test.ts
+++ b/react/unit/unit-search.test.ts
@@ -110,7 +110,7 @@ void test('a fixed number of places is a decision that rounding away is precise 
 // The name the chosen units are written under, which is what goes in the unit column
 void test('a bare solidus takes a space where the name stands by itself', () => {
     const perArea = [{ unit: people, power: 1 }, { unit: unit('km', { person: 1 }, 1e3), power: -2 }]
-    assert.equal(reifyString(nameOf([...perArea], { alone: true }), {}), '/\u00a0km^{2}')
+    assert.equal(reifyString(nameOf([...perArea], 'inColumn'), {}), '/\u00a0km^{2}')
     assert.equal(reifyString(nameOf([...perArea]), {}), '/km^{2}')
 })
 

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -45,7 +45,7 @@ for (const [condition, expected] of [
     ['high_temp > -10', 'Mean high temp > -10°F'],
     ['-high_temp > -80', '-Mean high temp > -80'],
     // a root of a count is in no unit any pool holds, and writing one threw
-    ['population ** 0.5 > 100', 'Population^{0.5} > 100'],
+    ['population ** 0.5 > 100', 'Population^{0.5} > 100\u00a0people^{0.5}'],
     // however many people there are they are still people, where the size of a reading is nothing
     ['sum(population) > 1000000', 'sum(Population) > 1m'],
     ['abs(high_temp) > 5', 'abs(Mean high temp) > 5'],
@@ -60,9 +60,9 @@ for (const [condition, expected] of [
     ['ln(commute_bike) > 0', 'ln(Commute Bike % [as a fraction]) > 0'],
     ['ln(pres_2020_margin) > 0', 'ln(2020 Presidential Election [as a fraction]) > 0'],
     // as is a count of one thing per another: these are stored per person, not per 100k
-    ['ln(ped_cyclist_fatalities_per_capita) > 0', 'ln(Pedestrian/Cyclist Fatalities Per Capita Per Year [as a fraction]) > 0'],
+    ['ln(ped_cyclist_fatalities_per_capita) > 0', 'ln(Pedestrian/Cyclist Fatalities Per Capita Per Year [in /people]) > 0'],
     // a root of a count is in no unit at all, so there is nothing to say it is in
-    ['ln(population ** 0.5) > 0', 'ln(Population^{0.5}) > 0'],
+    ['ln(population ** 0.5) > 0', 'ln(Population^{0.5} [in people^{0.5}]) > 0'],
     // a number written the long way is written as the number, in the unit it is read in
     ['density_pw_1km > toNumber("1000")', 'PW Density (r=1km) > 1\u202f000/km^{2}'],
     ['high_temp > toNumber("80")', 'Mean high temp > 80°F'],
@@ -98,7 +98,7 @@ cMap(
 )`,
     // per person to the fourth per km to the fourth, the people dropping out of the name as they
     // do in a density
-    'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}]) where Population (2000) > 1m and Population > 1m',
+    'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}·people^{4}]) where Population (2000) > 1m and Population > 1m',
 )
 
 testMapLabel(test,

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -96,8 +96,8 @@ cMap(
     scale=linearScale(),
     ramp=rampUridis
 )`,
-    // per person to the fourth per km to the fourth, the people dropping out of the name as they
-    // do in a density
+    // per person to the fourth per km to the fourth: the people are written, there not being one
+    // of them to leave to the statistic's own name
     'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}·person^{4}]) where Population (2000) > 1m and Population > 1m',
 )
 

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -60,7 +60,7 @@ for (const [condition, expected] of [
     ['ln(commute_bike) > 0', 'ln(Commute Bike % [as a fraction]) > 0'],
     ['ln(pres_2020_margin) > 0', 'ln(2020 Presidential Election [as a fraction]) > 0'],
     // as is a count of one thing per another: these are stored per person, not per 100k
-    ['ln(ped_cyclist_fatalities_per_capita) > 0', 'ln(Pedestrian/Cyclist Fatalities Per Capita Per Year [in /people]) > 0'],
+    ['ln(ped_cyclist_fatalities_per_capita) > 0', 'ln(Pedestrian/Cyclist Fatalities Per Capita Per Year [in /person]) > 0'],
     // a root of a count is in no unit at all, so there is nothing to say it is in
     ['ln(population ** 0.5) > 0', 'ln(Population^{0.5} [in people^{0.5}]) > 0'],
     // a number written the long way is written as the number, in the unit it is read in
@@ -98,7 +98,7 @@ cMap(
 )`,
     // per person to the fourth per km to the fourth, the people dropping out of the name as they
     // do in a density
-    'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}·people^{4}]) where Population (2000) > 1m and Population > 1m',
+    'sin^{-1}((PW Density (r=1km) ÷ Population^{3})^{2} [in /km^{4}·person^{4}]) where Population (2000) > 1m and Population > 1m',
 )
 
 testMapLabel(test,


### PR DESCRIPTION
Split off #2382, which needs it and is otherwise about warnings.

A count is named by the statistic counting it — but only where there is one of it:

| script | before | after |
|---|---|---|
| `population * area` | written in no units at all | `1 234km²` |
| `area / population` | written in no units at all | `1 234km²/people` |
| `population * population` | written in no units at all | `1 000 000 000 000 people²` |
| `population ** 0.5` | `4 830`, three figures of a quantity in no units | `4 825 people^0.5` |
| `population` | `1.23m` | unchanged |
| `density_pw_1km` | `1 234/km²` | unchanged |

Nothing is refused for having a count in it any more. A root of one is written because the covering search may take a unit of one that goes unnamed to any power, which is what a count is.

Two things fall out:

- **Abbreviations.** `k`/`m`/`B` are units over the count dimension, so with `population²` the search wrote `1.00m²` — millions squared, which reads as square metres. They are offered only where the whole quantity is a single count to the first power, which is what they are for.
- **Spacing.** `people²` is a word where `km²` and `%` are symbols, and reads as part of the number without a space. `UnitPlacement` gains `afterNumber`, asked for by the three places that write a unit straight after its number; a table's unit column and an `[in …]` annotation do not.

`tsc`, eslint, 781 unit tests, `statistic-inferred-units` (14) and `embed_worker` (18) pass. Two e2e value expectations move with the root of a count.