### PR TITLE
Check React keys in the production build

### DIFF
--- a/react/eslint.config.mjs
+++ b/react/eslint.config.mjs
@@ -73,7 +73,7 @@ export default tseslint.config(
         },
     },
     {
-        ignores: ['**/*.{js,mjs}', 'src/utils/protos.d.ts', 'src/utils/urbanstats-persistent-data.d.ts', 'src/utils/google-drive.d.ts', 'src/data/**', 'cf-og-worker/.wrangler/**'],
+        ignores: ['**/*.{js,cjs,mjs}', 'src/utils/protos.d.ts', 'src/utils/urbanstats-persistent-data.d.ts', 'src/utils/google-drive.d.ts', 'src/data/**', 'cf-og-worker/.wrangler/**'],
     },
     {
         rules: {

--- a/react/rspack.config.js
+++ b/react/rspack.config.js
@@ -32,6 +32,9 @@ export default env => ({
         clean: true,
     },
     resolve: {
+        alias: {
+            react$: path.resolve(import.meta.dirname, 'src/react-duplicate-keys.cjs'),
+        },
         // Add '.ts' and '.tsx' as resolvable extensions.
         extensions: ['', '.webpack.js', '.web.js', '.ts', '.tsx', '.js'],
         extensionAlias: {

--- a/react/src/react-duplicate-keys.cjs
+++ b/react/src/react-duplicate-keys.cjs
@@ -1,0 +1,44 @@
+// Aliased over `react` by rspack.config.js, so every element passes through here.
+// React only checks keys in its development build.
+const React = require('../node_modules/react/index.js') // By path, since `react` resolves back to this file
+
+const elementType = Symbol.for('react.element')
+
+// One report per list, so a long list can't flood the console on every render
+function checkKeys(children) {
+    const seen = new Set()
+    let reported = false
+    for (const child of children) {
+        if (Array.isArray(child)) {
+            // React keys a nested array by its position, so its keys are a separate scope
+            checkKeys(child)
+            continue
+        }
+        if (reported || child?.$$typeof !== elementType) {
+            continue
+        }
+        const name = typeof child.type === 'string' ? child.type : (child.type?.displayName ?? child.type?.name ?? 'component')
+        if (child.key === null) {
+            console.error(`[failtest] Each child in a list should have a unique "key" prop, but a <${name}> has none\n${new Error().stack}`)
+            reported = true
+        }
+        else if (seen.has(child.key)) {
+            console.error(`[failtest] Encountered two children with the same key, \`${child.key}\`\n${new Error().stack}`)
+            reported = true
+        }
+        seen.add(child.key)
+    }
+}
+
+module.exports = {
+    ...React,
+    createElement(type, props, ...children) {
+        // Without positional children, React renders props.children instead
+        for (const child of children.length > 0 ? children : [props?.children]) {
+            if (Array.isArray(child)) {
+                checkKeys(child)
+            }
+        }
+        return React.createElement(type, props, ...children)
+    },
+}

--- a/react/src/react-duplicate-keys.cjs
+++ b/react/src/react-duplicate-keys.cjs
@@ -4,6 +4,10 @@ const React = require('../node_modules/react/index.js') // By path, since `react
 
 const elementType = Symbol.for('react.element')
 
+// React keys positional children by position and never asks them for a key of their own, even
+// once they have become the array that `<div {...props} />` passes on
+const positional = new WeakSet()
+
 // One report per list, so a long list can't flood the console on every render
 function checkKeys(children) {
     const seen = new Set()
@@ -17,12 +21,15 @@ function checkKeys(children) {
         if (reported || child?.$$typeof !== elementType) {
             continue
         }
-        const name = typeof child.type === 'string' ? child.type : (child.type?.displayName ?? child.type?.name ?? 'component')
         if (child.key === null) {
-            console.error(`[failtest] Each child in a list should have a unique "key" prop, but a <${name}> has none\n${new Error().stack}`)
-            reported = true
+            if (!positional.has(child)) {
+                const name = typeof child.type === 'string' ? child.type : (child.type?.displayName ?? child.type?.name ?? 'component')
+                console.error(`[failtest] Each child in a list should have a unique "key" prop, but a <${name}> has none\n${new Error().stack}`)
+                reported = true
+            }
+            continue
         }
-        else if (seen.has(child.key)) {
+        if (seen.has(child.key)) {
             console.error(`[failtest] Encountered two children with the same key, \`${child.key}\`\n${new Error().stack}`)
             reported = true
         }
@@ -37,6 +44,9 @@ module.exports = {
         for (const child of children.length > 0 ? children : [props?.children]) {
             if (Array.isArray(child)) {
                 checkKeys(child)
+            }
+            else if (child?.$$typeof === elementType) {
+                positional.add(child)
             }
         }
         return React.createElement(type, props, ...children)

--- a/react/src/utils/TestUtils.ts
+++ b/react/src/utils/TestUtils.ts
@@ -1,7 +1,9 @@
 import type maplibregl from 'maplibre-gl'
+import type { ReactElement } from 'react'
 
 import { keptByNoBasemap } from '../components/map-common-utils'
 
+import { elementsWithBadKeys } from './bad-keys'
 import { makeDebugLogger } from './debug-logging'
 
 /**
@@ -99,6 +101,11 @@ export class TestUtils {
                 await new Promise(resolve => requestAnimationFrame(resolve))
             } while (!map._removed && !map.loaded() && Date.now() < deadline)
         }))
+    }
+
+    /** Only the bundled build routes `react` through the key checking, so an e2e test triggers it here */
+    createElementsWithBadKeys(): ReactElement[] {
+        return elementsWithBadKeys()
     }
 
     disableBasemapLayers(): void {

--- a/react/src/utils/bad-keys.tsx
+++ b/react/src/utils/bad-keys.tsx
@@ -1,0 +1,10 @@
+import React, { type ReactElement } from 'react'
+
+export function elementsWithBadKeys(): ReactElement[] {
+    /* eslint-disable react/jsx-key -- the point of these elements is that their keys are wrong */
+    return [
+        <div>{[<div key="a" />, <div key="a" />]}</div>,
+        <div>{[<div />]}</div>,
+    ]
+    /* eslint-enable react/jsx-key */
+}

--- a/react/test/key-checking.test.ts
+++ b/react/test/key-checking.test.ts
@@ -1,0 +1,18 @@
+import { ClientFunction } from 'testcafe'
+
+import type { TestWindow } from '../src/utils/TestUtils'
+
+import { takeFailTestConsoleMessages, target, urbanstatsFixture } from './test_utils'
+
+urbanstatsFixture('key checking', `${target}/`)
+
+// The checking lives in an rspack alias over `react`, so only the served bundle exercises it
+test('bad keys fail a test', async (t) => {
+    await ClientFunction(() => {
+        (window as unknown as TestWindow).testUtils.createElementsWithBadKeys()
+    })()
+    const messages = await takeFailTestConsoleMessages(t, 2)
+    await t.expect(messages.length).eql(2)
+    await t.expect(messages[0]).contains('Encountered two children with the same key, `a`')
+    await t.expect(messages[1]).contains('Each child in a list should have a unique "key" prop')
+})

--- a/react/test/test_utils.ts
+++ b/react/test/test_utils.ts
@@ -363,10 +363,7 @@ async function printConsoleMessages(t: TestController): Promise<void> {
     consoleEnabled.add(cdp)
     cdp.Console.on('messageAdded', (event) => {
         const timestamp = new Date().toISOString()
-        if (
-            event.message.text.includes('[failtest]')
-            || event.message.text.includes('Encountered two children with the same key') // This React error only shows up in dev mode, but it's helpful to catch when running tests locally.
-        ) {
+        if (event.message.text.includes('[failtest]')) {
             failTestConsoleMessages.push(event.message.text)
         }
         let text: string
@@ -383,6 +380,17 @@ async function printConsoleMessages(t: TestController): Promise<void> {
         console.warn(chalkTemplate`{gray ${timestamp} From Browser:} ${text}`)
     })
     await cdp.Console.enable()
+}
+
+/** Takes the messages that would otherwise fail the test, for a test that means to provoke one */
+export async function takeFailTestConsoleMessages(t: TestController, expected: number): Promise<string[]> {
+    const deadline = Date.now() + 5000
+    while (failTestConsoleMessages.length < expected && Date.now() < deadline) {
+        await t.wait(100)
+    }
+    const messages = failTestConsoleMessages
+    failTestConsoleMessages = []
+    return messages
 }
 
 async function throwIfTestFailFromConsole(t: TestController): Promise<void> {


### PR DESCRIPTION
React validates keys only in its development build, so a duplicate or missing key ships to the live site with nothing to report it. This aliases `react` to a shim that inspects each array child as it is created, which puts the same check in both builds. The messages carry `[failtest]`, so the e2e harness fails on them — including missing keys, which have never failed a test here: `test_utils` matched React's own duplicate-key message, and that one only exists in development. That match is now gone, since the shim covers both builds.

The shim reports one problem per list, so a long list can't flood the console on every render, and it stays quiet for the cases React scopes by position: a nested array and a separate positional child each get a key of their own.

Two things to expect. The first CI run may turn up pre-existing missing keys that nothing has been catching. And the check costs a `Set` per array child per render; if that ever shows up in a profile, gate it on a flag read once at module load.

`react-duplicate-keys.cjs` is CommonJS because it re-exports everything React exports, which ESM can't do statically over a CJS module, and it reaches React by path because the alias would otherwise point back at itself. `.cjs` joins `.js` and `.mjs` in the eslint ignore list, since a file whose types come from an untyped CJS module can't satisfy the type-aware rules.

The e2e test triggers the failure through JSX, in `bad-keys.tsx` — it is what real code compiles to, and it is the only way to confirm the alias is live in the served bundle rather than just testing the checking function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)