### PR TITLE
exact unit inference (try 1)

### DIFF
--- a/react/src/urban-stats-script/derive-unit.ts
+++ b/react/src/urban-stats-script/derive-unit.ts
@@ -4,14 +4,19 @@ import { StoredUnit } from '../utils/quantity'
 import { UrbanStatsASTExpression } from './ast'
 import { TypeEnvironment } from './types-values'
 import { unitToWriteIn } from './unit-algebra'
-import { inferBindings, inferUnit } from './unit-inference'
+import { inferBindings, inferConstantUnits, inferUnit } from './unit-inference'
 
-/** Read against the whole script, so that a name the script assigned is followed. */
+/**
+ * Read against the whole script, so that a name the script assigned is followed, and against what
+ * the backward pass made of its literals, so that a * 1 is read in whatever unit makes the rest
+ * work, as the caption writes it.
+ */
 function unitOf(values: UrbanStatsASTExpression | undefined, uss: MapUSS, typeEnvironment: TypeEnvironment): StoredUnit | undefined {
     if (values === undefined) {
         return undefined
     }
-    return unitToWriteIn(inferUnit(values, typeEnvironment, inferBindings(uss, typeEnvironment)))
+    const named = inferBindings(uss, typeEnvironment)
+    return unitToWriteIn(inferUnit(values, typeEnvironment, named, inferConstantUnits(uss, typeEnvironment)))
 }
 
 export function deriveMapUnit(uss: MapUSS, typeEnvironment: TypeEnvironment): StoredUnit | undefined {

--- a/react/src/urban-stats-script/unit-algebra.ts
+++ b/react/src/urban-stats-script/unit-algebra.ts
@@ -165,6 +165,11 @@ function addedForward(form: { combine: (left: number, right: number) => number }
     if (!sameDimensions(left.unit, right.unit)) {
         return { kind: 'none' }
     }
+    // the values added are the ones the statistics are stored as, so two areas add only where they
+    // are stored the same way: square kilometres and square metres are areas both, and do not add
+    if (!sameSize(left.unit.toBaseUnits, right.unit.toBaseUnits)) {
+        return { kind: 'none' }
+    }
     return written(
         left.unit,
         combined(left.unit.unit.times, right.unit.unit.times, form.combine),

--- a/react/src/urban-stats-script/unit-inference.ts
+++ b/react/src/urban-stats-script/unit-inference.ts
@@ -23,6 +23,8 @@ export type Bindings = Map<string, Inferred>
 interface Scope {
     typeEnvironment: TypeEnvironment
     named: Bindings
+    /** What the backward pass made of each literal, where it has run and a caller wants it read. */
+    constants?: ConstantUnits
 }
 
 /** A block is worth as much as its last statement, and an empty one as much as nothing said. */
@@ -154,8 +156,15 @@ function infer(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, scope: Sco
             return block(ast.rest, scope)
         case 'identifier':
             return identifier(ast.name.node, scope)
-        case 'constant':
-            return ast.value.node.type === 'number' ? constant(ast.value.node.value) : anything
+        case 'constant': {
+            if (ast.value.node.type !== 'number') {
+                return anything
+            }
+            // a literal is in whatever unit the script reads it in, where the backward pass has
+            // said: the 1 of area + population * 1 is a number of square kilometres per person
+            const unit = scope.constants?.get(whereWritten(ast.value.location))
+            return unit === undefined ? constant(ast.value.node.value) : inUnit(unit)
+        }
         case 'unaryOperator':
             return forwardUnary(ast.operator.node, quantity(infer(ast.expr, scope)))
         case 'binaryOperator':
@@ -335,8 +344,8 @@ export function inferConstantUnits(program: UrbanStatsASTStatement | UrbanStatsA
 }
 
 /** The unit an expression works out to, where reading it determines one. */
-export function inferUnit(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment, named: Bindings = new Map()): AbstractInterpValue {
-    return quantity(infer(ast, { typeEnvironment, named }))
+export function inferUnit(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment, named: Bindings = new Map(), constants?: ConstantUnits): AbstractInterpValue {
+    return quantity(infer(ast, { typeEnvironment, named, constants }))
 }
 
 export function inferBindings(program: UrbanStatsASTStatement | UrbanStatsASTExpression, typeEnvironment: TypeEnvironment): Bindings {

--- a/react/unit/derive-unit.test.ts
+++ b/react/unit/derive-unit.test.ts
@@ -37,6 +37,24 @@ void test('a map is written in the units of what it maps', () => {
     assert.equal(mapUnit('high_temp - low_temp'), '+1\u202f000.0°F')
 })
 
+void test('two quantities add only where they are stored the same way', () => {
+    // the values added are the ones the statistics are stored as: kilometres and metres are both
+    // lengths, and adding the numbers adds nothing
+    assert.equal(mapUnit('hospital_mean_dist + elevation'), 'nothing')
+    // an area over a count of people is an area, and one made of a rainfall and a length of time
+    // is an area too, in units nothing else is stored in
+    assert.equal(mapUnit('population * area / population - (2 * rainfall * sunny_hours) ** 2'), 'nothing')
+    assert.equal(mapUnit('area + area'), '1\u202f000km^{2}')
+})
+
+void test('a literal is read in whatever unit makes the rest of the expression work', () => {
+    // people are no area, but a number multiplying them may be an area over each of them
+    assert.equal(mapUnit('area + population * 1'), '1\u202f000km^{2}')
+    assert.equal(mapUnit('area + population'), 'nothing')
+    // and where nothing can be read into it, as inside a logarithm, which makes a number of anything
+    assert.equal(mapUnit('area + ln(population * 1)'), 'nothing')
+})
+
 void test('a map of what no unit can be read off says nothing', () => {
     assert.equal(mapUnit('population + area'), 'nothing')
     assert.equal(mapUnit('high_temp + low_temp'), 'nothing')


### PR DESCRIPTION
Split off #2382, which is about warnings and needs both of these.

**Two quantities add only where they are stored the same way.** The values a script adds are the ones the statistics are stored as, so `hospital_mean_dist + elevation` adds a kilometre number to a metre number and means nothing, though both are lengths. `addedForward` now compares stored scales as well as dimensions, which the rule for the arms of an `if` already did.

**A literal is read in whatever unit the backward pass gave it.** `area + population * 1` is an area: the `1` is a number of square kilometres per person, which is what the caption has written it as all along — the forward pass just disagreed. `Scope` carries the constants the backward pass worked out, and `deriveMapUnit` and `deriveTableColumnUnit` read against them.

That makes `* 1` an escape hatch for a script whose units do not otherwise line up, which is deliberate. It balances the units by assumption rather than by changing the arithmetic, so a caption can show a factor the script does not apply — `hospital_mean_dist > elevation * 1` writes the 1 as `1 000`.

Where nothing can be read into the literal it is still nothing: the `1` inside `ln(population * 1)` cannot make a logarithm into an area, a logarithm making a plain number of whatever it is given.

`tsc`, eslint, 785 unit tests including both rules, `statistic-inferred-units` (14) and `mapper-condition` (10) pass.