### PR TITLE
Underline warnings in orange, not red

### DIFF
--- a/react/src/urban-stats-script/editor-utils.tsx
+++ b/react/src/urban-stats-script/editor-utils.tsx
@@ -176,7 +176,7 @@ function getContainerOffset(node: Node, position: number): [Node, number] {
     return [node, position - offset]
 }
 
-function spanFactory(colors: Colors): (token: AnnotatedToken['token'] | ParseError, content: (Node | string)[]) => HTMLSpanElement {
+function spanFactory(colors: Colors): (token: AnnotatedToken['token'] | EditorError, content: (Node | string)[]) => HTMLSpanElement {
     const brackets = new DefaultMap<string, number>(() => 0)
 
     const basicConstants = ['true', 'false', 'null']
@@ -229,7 +229,7 @@ function spanFactory(colors: Colors): (token: AnnotatedToken['token'] | ParseErr
                 break
             case 'error':
                 // Safari doesn't support the shorthand 🙄
-                style['text-decoration-color'] = colors.hueColors.red
+                style['text-decoration-color'] = 'kind' in token && token.kind === 'warning' ? colors.hueColors.orange : colors.hueColors.red
                 style['text-decoration-style'] = 'wavy'
                 style['text-decoration-line'] = 'underline'
                 style['text-decoration-skip-ink'] = 'none'


### PR DESCRIPTION
Deprecated identifiers were underlined identically to hard errors, so a script that runs fine looked broken. The wavy-underline branch in the span factory is shared by lexer error tokens and by editor errors, so the fix was to widen its parameter to `EditorError` and pick the color from `kind`; lexer error tokens stay red.

The issue asked for yellow, but orange is what the results indicator already uses for warnings, so the two now agree.

Fixes #2389

🤖 Generated with [Claude Code](https://claude.com/claude-code)