### PR TITLE
Show USS warnings as warnings, in the right place

### DIFF
--- a/react/src/mapper/settings/map-uss.ts
+++ b/react/src/mapper/settings/map-uss.ts
@@ -51,7 +51,8 @@ function parsePreambleCustomNodeAsMapUSS(stmt: UrbanStatsASTStatement): Preamble
 
 export function convertToMapUss(uss: UrbanStatsASTStatement): MapUSS {
     if (uss.type === 'expression' && uss.value.type === 'customNode') {
-        return uss.value
+        // Reparse so the code inside customNode("...") is located in the editor's block, not the enclosing one
+        return parseNoErrorAsCustomNode(uss.value.originalCode, rootBlockIdent)
     }
     if (uss.type === 'statements'
         && uss.result.length === 2

--- a/react/src/urban-stats-script/editor-utils.tsx
+++ b/react/src/urban-stats-script/editor-utils.tsx
@@ -176,7 +176,7 @@ function getContainerOffset(node: Node, position: number): [Node, number] {
     return [node, position - offset]
 }
 
-function spanFactory(colors: Colors): (token: AnnotatedToken['token'] | ParseError, content: (Node | string)[]) => HTMLSpanElement {
+function spanFactory(colors: Colors): (token: AnnotatedToken['token'] | EditorError, content: (Node | string)[]) => HTMLSpanElement {
     const brackets = new DefaultMap<string, number>(() => 0)
 
     const basicConstants = ['true', 'false', 'null']
@@ -229,7 +229,7 @@ function spanFactory(colors: Colors): (token: AnnotatedToken['token'] | ParseErr
                 break
             case 'error':
                 // Safari doesn't support the shorthand 🙄
-                style['text-decoration-color'] = colors.hueColors.red
+                style['text-decoration-color'] = 'kind' in token && token.kind === 'warning' ? colors.hueColors.orange : colors.hueColors.red
                 style['text-decoration-style'] = 'wavy'
                 style['text-decoration-line'] = 'underline'
                 style['text-decoration-skip-ink'] = 'none'

--- a/react/test/mapper-ux_x1.test.ts
+++ b/react/test/mapper-ux_x1.test.ts
@@ -385,6 +385,12 @@ mapper(() => test)('deprecation warning for deprecated weather statistic', { cod
     await t.expect(getErrors()).eql([warning])
 })
 
+mapper(() => test)('deprecation warning is placed in the editor when a custom script is loaded from a link', { code: 'customNode("pMap(data=high_temp_fall, scale=linearScale(), ramp=rampUridis)")' }, async (t) => {
+    const warning = 'Deprecated: Use high_temp_son (Mean high temperature in Sep/Oct/Nov) instead, which uses month-based seasons instead and is valid in the southern hemisphere'
+    await waitForLoading()
+    await t.expect(getErrors()).eql([`${warning} at 1:11-24`])
+})
+
 mapper(() => test)('warning when map label cannot be derived', { code: 'cMap(data=[1], scale=linearScale(), ramp=rampUridis)' }, async (t) => {
     const warning = 'Label could not be derived for map, please pass label="<your label here>" to cMap(...)'
     await waitForLoading()


### PR DESCRIPTION
Two display bugs made a deprecation warning in a mapper script look like a broken script.

A deprecated identifier was underlined in the same red as a hard error, so a script that runs fine looked like it had failed. Warnings now use the orange that the results indicator already uses for them. Fixes #2389.

The second bug is why the underline was often missing entirely. A custom-script map serializes into its link as `customNode("cMap(...)")`, and the parser gives the code inside that string argument the enclosing block — for a settings string, the anonymous multi block. The custom editor claims only the errors located in its own block, so a warning from a link-loaded script fell through to the catch-all results box: no underline, and a line:column in the message that pointed at nothing the reader could see. Editing the script reparsed it under the right block and the underline appeared, which is why this only showed on page load. `convertToMapUss` now reparses under `rootBlockIdent`, the same thing its arbitrary-script branch already did — which is why a bare `cMap(...)` in a link, the form the existing tests use, never hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)