### PR TITLE
Locate a link-loaded custom script in the editor's block

### DIFF
--- a/react/src/mapper/settings/map-uss.ts
+++ b/react/src/mapper/settings/map-uss.ts
@@ -51,7 +51,8 @@ function parsePreambleCustomNodeAsMapUSS(stmt: UrbanStatsASTStatement): Preamble
 
 export function convertToMapUss(uss: UrbanStatsASTStatement): MapUSS {
     if (uss.type === 'expression' && uss.value.type === 'customNode') {
-        return uss.value
+        // Reparse so the code inside customNode("...") is located in the editor's block, not the enclosing one
+        return parseNoErrorAsCustomNode(uss.value.originalCode, rootBlockIdent)
     }
     if (uss.type === 'statements'
         && uss.result.length === 2

--- a/react/test/mapper-ux_x1.test.ts
+++ b/react/test/mapper-ux_x1.test.ts
@@ -385,6 +385,12 @@ mapper(() => test)('deprecation warning for deprecated weather statistic', { cod
     await t.expect(getErrors()).eql([warning])
 })
 
+mapper(() => test)('deprecation warning is placed in the editor when a custom script is loaded from a link', { code: 'customNode("pMap(data=high_temp_fall, scale=linearScale(), ramp=rampUridis)")' }, async (t) => {
+    const warning = 'Deprecated: Use high_temp_son (Mean high temperature in Sep/Oct/Nov) instead, which uses month-based seasons instead and is valid in the southern hemisphere'
+    await waitForLoading()
+    await t.expect(getErrors()).eql([`${warning} at 1:11-24`])
+})
+
 mapper(() => test)('warning when map label cannot be derived', { code: 'cMap(data=[1], scale=linearScale(), ramp=rampUridis)' }, async (t) => {
     const warning = 'Label could not be derived for map, please pass label="<your label here>" to cMap(...)'
     await waitForLoading()


### PR DESCRIPTION
A deprecation warning in a mapper script had no underline and printed a line:column that pointed at nothing the reader could see — but only when the map was opened from a link, not while editing it.

A custom-script map serializes into its link as `customNode("cMap(...)")`, and the parser gives the code inside that string argument the enclosing block, which for a settings string is the anonymous multi block. The custom editor claims only the errors located in its own block, so the warning fell through to the catch-all results box. Typing in the editor reparsed under the right block and the underline appeared, which is why this only showed on page load.

`convertToMapUss` now reparses under `rootBlockIdent`, the same thing its arbitrary-script branch below already did. That branch is why a bare `cMap(...)` in a link — the form the existing tests use — never hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)