### PR TITLE
Let a USS documentation category describe itself with hre

### DIFF
--- a/react/src/uss-documentation.tsx
+++ b/react/src/uss-documentation.tsx
@@ -18,6 +18,7 @@ import { DocumentationTable, renderType, USSDocumentedType } from './urban-stats
 import { constantsDocumentationData } from './uss-documentation-routing'
 import { codeStyle } from './utils/code-style'
 import { assert } from './utils/defensive'
+import { HumanReadableName } from './utils/human-readable-element'
 import { reifyReact } from './utils/human-readable-name'
 import { useHeaderTextClass } from './utils/responsive'
 
@@ -628,6 +629,7 @@ function ConstantsCategoryPageView(props: {
 }
 
 function DocumentationForCategory(props: { category: ConstantCategory, constants: [string, USSDocumentedType][] }): ReactNode {
+    const unitSettings = useUnitSettings()
     const withoutTable: [string, USSDocumentedType][] = []
     const categoryTables = new Map<DocumentationTable, [string, USSDocumentedType][]>()
     for (const [name, value] of props.constants) {
@@ -647,7 +649,7 @@ function DocumentationForCategory(props: { category: ConstantCategory, constants
 
     return (
         <>
-            <p style={{ marginLeft: '20px' }}>{getCategoryDescription(props.category)}</p>
+            <p style={{ marginLeft: '20px' }}>{reifyReact(getCategoryDescription(props.category), unitSettings)}</p>
             {withoutTable.map(([name, value]) => (
                 <LongFormDocumentation key={name} name={name} value={value} />
             ))}
@@ -782,7 +784,7 @@ function getCategoryTitle(category: ConstantCategory): string {
     }
 }
 
-function getCategoryDescription(category: ConstantCategory): string {
+function getCategoryDescription(category: ConstantCategory): HumanReadableName {
     switch (category) {
         case 'logic':
             return 'Boolean values and control flow constants.'


### PR DESCRIPTION
A category description on the USS documentation page can now carry code spans, subscripts and superscripts, the way the individual constants already can through `longDescription`. `getCategoryDescription` returns a `HumanReadableName` instead of a `string`, and the single call site renders it through `reifyReact`.

Nothing uses that yet. Every case still returns a plain string, which `reifyReact` passes through untouched, so no description renders differently and no reference screenshot moves. Splitting it out this way keeps the mechanical change separate from the wording it was wanted for — the string operations documentation in the branch above, where `Regex`, `lower` and a doubled backslash are all things a reader has to type exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)