### PR TITLE
Let a USS documentation category describe itself with markup

### DIFF
--- a/react/src/uss-documentation.tsx
+++ b/react/src/uss-documentation.tsx
@@ -782,7 +782,7 @@ function getCategoryTitle(category: ConstantCategory): string {
     }
 }
 
-function getCategoryDescription(category: ConstantCategory): string {
+function getCategoryDescription(category: ConstantCategory): ReactNode {
     switch (category) {
         case 'logic':
             return 'Boolean values and control flow constants.'


### PR DESCRIPTION
`getCategoryDescription` returns a `ReactNode` instead of a `string`, so a category description on the USS documentation page can set a function name in `code`, or break its rules into a list rather than running them together with semicolons.

Nothing uses that yet. Every case still returns a plain string, which is already a `ReactNode`, so no description renders differently and no reference screenshot moves. Splitting it out keeps the type change separate from the wording it was wanted for — the string operations documentation in the branch above.

`ReactNode` rather than `HumanReadableName`: a category description is body text rendered in exactly one place, never reified to a plain-text string and never rasterized into a link-preview card, so the two things `HumanReadableName` offers over JSX — `reifyString` and reader-dependent quantities — have no consumer here. `HumanReadableName` is also a vocabulary of inline elements for *names*, and the list this was wanted for is block-level document structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)