### PR TITLE
Count a repeated quiz day once, at its lowest score

### DIFF
--- a/urbanstats-persistent-data/tests/test_friends.py
+++ b/urbanstats-persistent-data/tests/test_friends.py
@@ -1,6 +1,7 @@
 from .utils import (
     associate_email,
     check_infinite_results,
+    check_summary_stats,
     check_todays_score_for,
     create_identity,
     dissociate_email,
@@ -397,6 +398,34 @@ def test_friends_infinite_across_associated_devices(client):
                 "maxScore": 3,
                 "maxScoreSeed": "abc",
                 "maxScoreVersion": 1,
+            }
+        ]
+    }
+
+
+def test_friends_summary_stats_across_associated_devices(client):
+    # a + b are the same person on two devices
+    associate_email(client, identity_a, "email@gmail.com")
+    associate_email(client, identity_b, "email@gmail.com")
+
+    send_friend_request(client, identity_c, "a")
+    send_friend_request(client, identity_b, "c")
+
+    for day in (1, 2, 3):
+        store_juxtastat_stats(client, identity_a, day, [True, True, True, False, False])
+    # Day 2 replayed on the other device, badly
+    store_juxtastat_stats(client, identity_b, 2, [True, False, False, False, False])
+
+    # Day 2 counts once, at its lowest score, so it breaks the streak
+    result = check_summary_stats(client, identity_c, ["a"], "juxtastat")
+    assert result == {
+        "results": [
+            {
+                "friends": True,
+                "meanScore": 2.33,
+                "numPlays": 3,
+                "currentStreak": 1,
+                "maxStreak": 1,
             }
         ]
     }

--- a/urbanstats-persistent-data/tests/utils.py
+++ b/urbanstats-persistent-data/tests/utils.py
@@ -200,3 +200,16 @@ def get_retro_per_question_stats(client, week: str):
     )
     assert response.status_code == 200
     return response.json()
+
+
+def check_summary_stats(
+    client, identity: dict[str, str], requesters: list[str], quiz_kind: str
+):
+    """Check friend summary stats for requesters and return the response."""
+    response = client.post(
+        "/juxtastat/friend_summary_stats",
+        headers=identity,
+        json={"requesters": requesters, "quiz_kind": quiz_kind},
+    )
+    assert response.status_code == 200
+    return response.json()

--- a/urbanstats-persistent-data/urbanstats_persistent_data/db/friends.py
+++ b/urbanstats-persistent-data/urbanstats_persistent_data/db/friends.py
@@ -214,7 +214,7 @@ def _compute_summary_stats(
         )
 
     # Convert to scores (number of correct answers) and track problem identifiers
-    scores, problem_ids = extract_scores_and_problem_ids(quiz_kind, rows)
+    scores, problem_ids = extract_scores_and_problem_ids(rows)
 
     # Calculate statistics
     num_plays = len(scores)
@@ -249,21 +249,19 @@ def compute_streaks(scores: list[int], problem_ids: list[int]) -> tuple[int, int
 
 
 def extract_scores_and_problem_ids(
-    quiz_kind: QuizKind, rows: list[tuple[int, int]]
+    rows: list[tuple[int, int]]
 ) -> tuple[list[int], list[int]]:
-    scores = []
-    problem_ids = []
+    # A user can have several ids, so the same problem can show up more than once.
+    # Keep the lowest score for it, so a duplicate can't inflate a streak.
+    lowest_score: dict[int, int] = {}
     for row in rows:
         problem_id = row[0]
         assert isinstance(problem_id, int)
         corrects = stats.bitvector_to_corrects(row[1])
         score = sum(1 for c in corrects if c)
-        scores.append(score)
-        if quiz_kind == "juxtastat":
-            problem_ids.append(problem_id)
-        else:
-            assert quiz_kind == "retrostat"
-            problem_ids.append(problem_id)
+        if problem_id in lowest_score:
+            score = min(score, lowest_score[problem_id])
+        lowest_score[problem_id] = score
 
-    problem_ids, scores = zip(*sorted(zip(problem_ids, scores)))  # type: ignore
-    return scores, problem_ids
+    problem_ids = sorted(lowest_score)
+    return [lowest_score[p] for p in problem_ids], problem_ids


### PR DESCRIPTION
A user's friend summary stats could count the same day twice. Ids are per-device and joined by email, so replaying a day on a second device stored two rows for it. `compute_streaks` walks a sorted list comparing adjacent problem ids, so the duplicate sat between two real days with a difference of 0 and silently reset the streak — and the day counted twice in `numPlays` and the mean.

Days are now deduplicated by problem id, keeping the lowest score. Lowest rather than highest matches the conservative reading: a day you also failed shouldn't extend a streak. This differs from #2359, which took the *best* infinite run across devices — there the runs are independent attempts at one seed and the best is the achievement; here a day is a single event and the duplicate is noise.

The test drives it through the API: two devices share an email, play days 1–3, and replay day 2 badly. Before the fix that reported 4 plays, mean 2.5, streaks of 2; now 3 plays, mean 2.33, streaks of 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)