### PR TITLE
Drop map-export instrumentation that only feeds a disabled logger

### DIFF
--- a/react/src/components/map-common.tsx
+++ b/react/src/components/map-common.tsx
@@ -99,18 +99,6 @@ function SynchronizeMapWithScreenshots(): ReactNode {
                     }
                 } while (!map.loaded())
                 debugLog('SynchronizeMapWithScreenshots: map is loaded after', frames, 'frame(s), signaling ready')
-                const layersOrder = map.getLayersOrder()
-                debugLog('SynchronizeMapWithScreenshots: layers count=', layersOrder.length)
-                for (const layerId of layersOrder) {
-                    if (!layerId.startsWith(urbanStatsLayerPrefix)) {
-                        continue
-                    }
-                    const layer = map.getLayer(layerId)
-                    const sourceId = layer && 'source' in layer ? layer.source : undefined
-                    const source = typeof sourceId === 'string' ? map.getSource(sourceId) : undefined
-                    const tolerance = source && 'workerOptions' in source ? (source as unknown as { workerOptions?: { geojsonVtOptions?: { tolerance?: number } } }).workerOptions?.geojsonVtOptions?.tolerance : undefined
-                    debugLog('SynchronizeMapWithScreenshots: layer', layerId, 'type=', layer?.type, 'source=', sourceId, 'tolerance=', tolerance)
-                }
             })().then(() => {
                 screenshotCallback()
             })

--- a/react/test/mapper-utils.ts
+++ b/react/test/mapper-utils.ts
@@ -19,7 +19,7 @@ async function checkGeojson(t: TestController, path: string): Promise<void> {
 export async function downloadPNG(t: TestController): Promise<void> {
     await waitForLoading()
     const download = Selector('button:not(:disabled)').withExactText('Export as PNG')
-    await grabDownload(t, download, '.png') // wait for 6 seconds to ensure the download completes
+    await grabDownload(t, download, '.png')
 }
 
 export function checkSelector(label: RegExp): Selector {


### PR DESCRIPTION
Two bits of residue from past flake hunts, both dead.

#2098 added a walk over every layer during the PNG-export wait, logging each layer's type, source and geojson-vt tolerance while chasing map export flakiness. #2110 then turned the `mapExport` category off. `makeDebugLogger` compiles a disabled category down to a no-op, so the walk still runs on every export and still reaches into the source's private `workerOptions` to compute a tolerance that nothing receives. The wait itself is unchanged — only the logging comes out.

The `grabDownload` call in `mapper-utils` carries a comment claiming a six second wait. There isn't one, and as far as I can tell there hasn't been for a while: `waitForDownload` polls the downloads folder until the file appears.

Split out of #2416 so that PR stays about the map-render wait. No behaviour change, so I ran typecheck and lint but not the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)