### PR TITLE
Cancel superseded CI runs by run id

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,11 +28,14 @@ jobs:
       actions: write
     steps:
       - name: Cancel this branch's older runs
+        # A run that finishes between the listing and the cancel returns 409, which is
+        # fine; anything else, a bad token above all, should still fail this job.
         run: |
           gh api --paginate "repos/$GITHUB_REPOSITORY/actions/workflows/check.yml/runs?event=pull_request&per_page=100" \
             | jq -r --arg branch "$BRANCH" --arg repo "$GITHUB_REPOSITORY" --argjson id "$GITHUB_RUN_ID" \
               '.workflow_runs[] | select(.head_branch == $branch and .head_repository.full_name == $repo and .status != "completed" and .id < $id) | .id' \
-            | xargs -r -I{} gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/{}/cancel"
+            | xargs -r -I{} sh -c 'gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$1/cancel" \
+                || gh api "repos/$GITHUB_REPOSITORY/actions/runs/$1" --jq .status | grep -qx completed' _ {}
         env:
           BRANCH: ${{ github.head_ref }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,16 +28,39 @@ jobs:
       actions: write
     steps:
       - name: Cancel this branch's older runs
-        # A run that finishes between the listing and the cancel returns 409, which is
-        # fine; anything else, a bad token above all, should still fail this job.
-        run: |
-          gh api --paginate "repos/$GITHUB_REPOSITORY/actions/workflows/check.yml/runs?event=pull_request&per_page=100" \
-            | jq -r --arg branch "$BRANCH" --arg repo "$GITHUB_REPOSITORY" --argjson id "$GITHUB_RUN_ID" \
-              '.workflow_runs[] | select(.head_branch == $branch and .head_repository.full_name == $repo and .status != "completed" and .id < $id) | .id' \
-            | xargs -r -I{} sh -c 'gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$1/cancel" \
-                || gh api "repos/$GITHUB_REPOSITORY/actions/runs/$1" --jq .status | grep -qx completed' _ {}
-        env:
-          BRANCH: ${{ github.head_ref }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'check.yml',
+              event: 'pull_request',
+              branch: context.payload.pull_request.head.ref,
+              per_page: 100
+            });
+
+            // A fork's runs live in this repo too, and its branch can share our name.
+            const superseded = runs.filter(run =>
+              run.id < context.runId
+              && run.status !== 'completed'
+              && run.head_repository?.full_name === `${context.repo.owner}/${context.repo.repo}`
+            );
+
+            for (const run of superseded) {
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id
+                });
+              } catch (error) {
+                // The run finished between the listing and the cancel.
+                if (error.status !== 409) {
+                  throw error;
+                }
+              }
+            }
 
   build-and-push-common-image:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Cancel this branch's older runs
         run: |
           gh api --paginate "repos/$GITHUB_REPOSITORY/actions/workflows/check.yml/runs?event=pull_request&per_page=100" \
-            --jq ".workflow_runs[] | select(.head_branch == \"$BRANCH\" and .status != \"completed\" and .id < $GITHUB_RUN_ID) | .id" \
+            | jq -r --arg branch "$BRANCH" --arg repo "$GITHUB_REPOSITORY" --argjson id "$GITHUB_RUN_ID" \
+              '.workflow_runs[] | select(.head_branch == $branch and .head_repository.full_name == $repo and .status != "completed" and .id < $id) | .id' \
             | xargs -r -I{} gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/{}/cancel"
         env:
           BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,13 +4,6 @@ on:
     branches:
       - main
   pull_request:
-concurrency:
-  # Grouping by PR means a push supersedes whatever that PR was already running. It also
-  # collapses the two identical runs a stacked push produces, since a PR above the bottom
-  # one gets a synchronize event for its base branch as well as for its own head.
-  group: check-${{ github.event.pull_request.number || github.sha }}
-  # Label a PR `keep-ci` to let its in-flight runs finish instead of being superseded.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'keep-ci') }}
 env:
   # This is used in ci_proxy, do not remove. It is necessary so that
   # we can test against non-production data
@@ -22,6 +15,26 @@ env:
     !outputs/*
     /*
 jobs:
+  supersede-older-runs:
+    runs-on: ubuntu-22.04
+    # This replaces `concurrency: cancel-in-progress`. A stacked push gives a PR above the
+    # bottom one two identical pull_request events, and Github picked arbitrarily which of
+    # the resulting runs to cancel. Cancelling the newer one leaves a check suite that
+    # never reports tests-passed, which branch protection reads as a check still pending.
+    # Ordering by run id instead means the newest run always survives.
+    # Forks get a read-only token, so they can't cancel anything.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'keep-ci') }}
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel this branch's older runs
+        run: |
+          gh api --paginate "repos/$GITHUB_REPOSITORY/actions/workflows/check.yml/runs?event=pull_request&per_page=100" \
+            --jq ".workflow_runs[] | select(.head_branch == \"$BRANCH\" and .status != \"completed\" and .id < $GITHUB_RUN_ID) | .id" \
+            | xargs -r -I{} gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/{}/cancel"
+        env:
+          BRANCH: ${{ github.head_ref }}
+
   build-and-push-common-image:
     runs-on: ubuntu-22.04
     outputs:


### PR DESCRIPTION
`cancel-in-progress` can leave a PR permanently unmergeable. #2428 is stuck this way now.

A stacked push delivers two identical `pull_request` events to every PR above the bottom one, so two runs start on the same head sha and Github picks arbitrarily which to cancel. Killing the older one is harmless. Killing the newer one leaves a check suite that completed as `cancelled` having created no check runs at all, and branch protection reads the newest suite per app, so `tests-passed` sits at "Expected, waiting for status to be reported" indefinitely. The older, fully green suite does not count.

Run ids are totally ordered, so cancelling by id has no race: every run kills strictly older in-flight runs of its branch and the newest always survives. This also subsumes the old concurrency group, since a run superseded by a later push is older by id too.

Costs a runner minute per run that Github used to absorb, and fork PRs lose superseding because their token cannot cancel runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)