### PR TITLE
Watch a --docker e2e run over VNC

### DIFF
--- a/react/test/Dockerfile
+++ b/react/test/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get -y update \
     && apt-get -y install \
         chromium=143.* chromium-common=143.* \
         xvfb \
+        # so a --docker run can be watched over VNC
+        x11vnc \
         sqlite3 \
         fluxbox \
         # the checkout step clones inside the container, and the runner diffs against the

--- a/react/test/README.md
+++ b/react/test/README.md
@@ -29,6 +29,13 @@
 
   `npm run test:e2e -- '--test=test/mapper-edit-text-boxes-desktop.test.ts' --docker=host-arch --browser=chromium`
 
+  Any `--docker` run serves its Xvfb display over VNC on a free port of its own, behind a
+  password generated for the run, and on a Mac opens Screen Sharing on it without taking focus,
+  quitting it again when the run ends. Two runs at once each get their own display, but the
+  first to finish quits Screen Sharing for both. Unlike
+  `chrome://inspect` above, this shows the whole display, so native dialogs and window sizing
+  are visible too.
+
 # Docker modes
 
 | Value | Meaning |

--- a/react/test/scripts/run-e2e-tests-docker.ts
+++ b/react/test/scripts/run-e2e-tests-docker.ts
@@ -31,7 +31,7 @@ export async function runE2eTestsDocker(args: string[], hostArch: boolean, docke
             '--mount', 'type=tmpfs,dst=/urbanstats/react/node_modules',
             '-w', '/urbanstats/react',
             ...(['PORT', 'TESTCAFE_PORT'].flatMap(envVar => process.env[envVar] ? ['-e', `${envVar}=${process.env[envVar]}`] : [])),
-            '-e', `URBANSTATS_VNC=${vncPassword}`,
+            '-e', `URBANSTATS_VNC_PASSWORD=${vncPassword}`,
             '-e', `URBANSTATS_VNC_PORT=${vncPort}`,
             imageName,
             ...args,

--- a/react/test/scripts/run-e2e-tests-docker.ts
+++ b/react/test/scripts/run-e2e-tests-docker.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto'
+import net from 'net'
 import os from 'os'
 import path from 'path'
 
@@ -10,9 +12,12 @@ export async function runE2eTestsDocker(args: string[], hostArch: boolean, docke
     const baseImage = `urbanstats-test:${arch}`
     const imageName = `urbanstats-run-e2e-tests-docker:${arch}`
     const repoRoot = path.resolve(process.cwd(), '..')
+    const vncPort = await freePort()
+    // The VNC protocol truncates the password to 8 characters, so there's no point generating more.
+    const vncPassword = crypto.randomBytes(4).toString('hex')
     await execa('docker', ['build', '-f', 'react/test/Dockerfile', '.', '-t', baseImage, '--platform', platform], { stdio: 'inherit', cwd: repoRoot })
     await execa('docker', ['build', '-f', 'react/test/scripts/run-e2e-tests-docker.Dockerfile', '.', '-t', imageName, '--platform', platform, '--build-arg', `BASE_IMAGE=${baseImage}`], { stdio: 'inherit', cwd: repoRoot })
-    const result = await execa(
+    const run = execa(
         'docker',
         [
             'run', '--rm',
@@ -26,10 +31,64 @@ export async function runE2eTestsDocker(args: string[], hostArch: boolean, docke
             '--mount', 'type=tmpfs,dst=/urbanstats/react/node_modules',
             '-w', '/urbanstats/react',
             ...(['PORT', 'TESTCAFE_PORT'].flatMap(envVar => process.env[envVar] ? ['-e', `${envVar}=${process.env[envVar]}`] : [])),
+            '-e', `URBANSTATS_VNC=${vncPassword}`,
+            '-e', `URBANSTATS_VNC_PORT=${vncPort}`,
             imageName,
             ...args,
         ],
         { stdio: 'inherit', reject: false },
     )
+    const viewer = showVncViewer(vncPort, vncPassword, run)
+    const result = await run
+    await viewer
     return result.exitCode
+}
+
+// A port of its own, so parallel runs don't fight over one.
+function freePort(): Promise<number> {
+    return new Promise((resolve) => {
+        const server = net.createServer()
+        server.listen(0, () => {
+            const { port } = server.address() as net.AddressInfo
+            server.close(() => { resolve(port) })
+        })
+    })
+}
+
+// The container shares the host's network, so x11vnc's display is on localhost.
+async function showVncViewer(vncPort: number, password: string, run: Promise<unknown>): Promise<void> {
+    if (os.platform() !== 'darwin') {
+        console.warn(`Connect a VNC client to localhost:${vncPort}, password ${password}, to watch the tests`)
+        return
+    }
+    let running = true
+    void run.then(() => { running = false })
+    while (running) {
+        if (await portIsOpen(vncPort)) {
+            // Leave a session the user opened themselves alone when we're done
+            const wasOpen = await screenSharingIsOpen()
+            // -g so the tests don't steal focus, which is the point of running them in Docker
+            await execa('open', ['-g', `vnc://:${password}@localhost:${vncPort}`], { reject: false })
+            await run
+            if (!wasOpen) {
+                // Screen Sharing has no window-level scripting, so it's the whole app or nothing
+                await execa('osascript', ['-e', 'quit app "Screen Sharing"'], { reject: false })
+            }
+            return
+        }
+        await new Promise(resolve => setTimeout(resolve, 500))
+    }
+}
+
+async function screenSharingIsOpen(): Promise<boolean> {
+    const { exitCode } = await execa('pgrep', ['-x', 'Screen Sharing'], { reject: false })
+    return exitCode === 0
+}
+
+function portIsOpen(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+        const socket = net.connect({ port, host: 'localhost' })
+        socket.on('connect', () => { socket.destroy(); resolve(true) })
+        socket.on('error', () => { socket.destroy(); resolve(false) })
+    })
 }

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -66,7 +66,7 @@ if (options.headless) {
     void execa('bash', ['-c', 'fluxbox >/dev/null 2>&1'])
     if (process.env.URBANSTATS_VNC) {
         // Retries because Xvfb above may not be listening yet
-        void execa('bash', ['-c', 'until x11vnc -display :10 -rfbport "$URBANSTATS_VNC_PORT" -passwd "$URBANSTATS_VNC" -forever -shared -quiet; do sleep 0.2; done'])
+        void execa('bash', ['-c', 'until x11vnc -display :10 -rfbport "$URBANSTATS_VNC_PORT" -passwd "$URBANSTATS_VNC" -localhost -forever -shared -quiet; do sleep 0.2; done'])
     }
 }
 

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -64,9 +64,9 @@ if (options.headless) {
     void execa('Xvfb', [':10', '-ac'])
     process.env.DISPLAY = ':10'
     void execa('bash', ['-c', 'fluxbox >/dev/null 2>&1'])
-    if (process.env.URBANSTATS_VNC) {
+    if (process.env.URBANSTATS_VNC_PASSWORD) {
         // Retries because Xvfb above may not be listening yet
-        void execa('bash', ['-c', 'until x11vnc -display :10 -rfbport "$URBANSTATS_VNC_PORT" -passwd "$URBANSTATS_VNC" -localhost -forever -shared -quiet; do sleep 0.2; done'])
+        void execa('bash', ['-c', 'until x11vnc -display :10 -rfbport "$URBANSTATS_VNC_PORT" -passwd "$URBANSTATS_VNC_PASSWORD" -localhost -forever -shared -quiet; do sleep 0.2; done'])
     }
 }
 

--- a/react/test/scripts/run-e2e-tests.ts
+++ b/react/test/scripts/run-e2e-tests.ts
@@ -64,6 +64,10 @@ if (options.headless) {
     void execa('Xvfb', [':10', '-ac'])
     process.env.DISPLAY = ':10'
     void execa('bash', ['-c', 'fluxbox >/dev/null 2>&1'])
+    if (process.env.URBANSTATS_VNC) {
+        // Retries because Xvfb above may not be listening yet
+        void execa('bash', ['-c', 'until x11vnc -display :10 -rfbport "$URBANSTATS_VNC_PORT" -passwd "$URBANSTATS_VNC" -forever -shared -quiet; do sleep 0.2; done'])
+    }
 }
 
 if (options.proxy) {


### PR DESCRIPTION
`chrome://inspect` shows the page but not the display around it, so native dialogs and window-sizing behaviour — exactly the class of thing that only breaks in the container — were invisible while debugging a Docker-only failure.

Two macOS quirks shaped the approach. Screen Sharing refuses VNC's "no authentication" security type and falls back to prompting for a password that doesn't exist, so `-nopw` is out and each run generates one to pass in the `vnc://` URL. And Screen Sharing has no window-level scripting — `get name of every window` errors — so closing the viewer means quitting the app. Quitting is skipped when it was already running, so a session opened by hand survives; the cost is that overlapping runs share one app and the first to finish closes it for both. Their displays are independent, at least, since the port comes from the OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)