### PR TITLE
Group a category's pie-chart statistics under a subcategory

### DIFF
--- a/react/src/components/ArticleWarnings.tsx
+++ b/react/src/components/ArticleWarnings.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react'
 
 import { useMissingGroupReasonsOfEveryGroup, useMissingGroups, useSelectedGroups } from '../page_template/statistic-settings'
-import { Category, Group, GroupIdentifier, StatPath, statPathToOrder } from '../page_template/statistic-tree'
+import { Category, Group, GroupIdentifier, StatPath, statPathToOrder, Subcategory } from '../page_template/statistic-tree'
 
 import { useScreenshotMode } from './screenshot'
 import { warningMessage } from './warning-message'
@@ -66,7 +66,7 @@ export function useWarningsByGroup(): Map<GroupIdentifier, ReactNode> {
     return result
 }
 
-function firstStatOrder(groupOrCategory: Group | Category): number {
+function firstStatOrder(groupOrCategory: Group | Subcategory | Category): number {
     return Math.min(...Array.from(groupOrCategory.statPaths).map(path => statPathToOrder.get(path)!))
 }
 

--- a/react/src/components/edit-table.tsx
+++ b/react/src/components/edit-table.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, ReactNode, useMemo, useState } from 'react'
 
 import { useColors } from '../page_template/colors'
 import { checkboxCategoryName, sourceEnabledKey, useIsStaged, useUnitSettings } from '../page_template/settings'
-import { ExpansionState, GroupTreeState, useAvailableYears, useCategoriesMatchingSearch, useCategoryTreeState, useDataSourceCheckboxes, useExpansionState } from '../page_template/statistic-settings'
+import { ExpansionState, GroupTreeState, SectionTreeState, useAvailableYears, useCategoriesMatchingSearch, useCategoryTreeState, useDataSourceCheckboxes, useExpansionState } from '../page_template/statistic-settings'
 import { Category, statParents } from '../page_template/statistic-tree'
 import { Universe } from '../universe'
 import { HumanReadableName } from '../utils/human-readable-element'
@@ -76,9 +76,10 @@ export function editRowsByGroup(
     return result
 }
 
-interface EditGroupHeaderSpec {
-    kind: 'group-header'
+interface EditHeaderSpec {
+    kind: 'header'
     key: string
+    indent: number
     highlight: boolean
     enabled: boolean
     checkbox: ReactNode
@@ -97,7 +98,7 @@ interface EditStatSpec {
     checkbox: { kind: 'own', node: ReactNode } | { kind: 'headers', id: string }
 }
 
-type EditBodyRow = EditGroupHeaderSpec | EditStatSpec
+type EditBodyRow = EditHeaderSpec | EditStatSpec
 
 function EditCheckboxLabel(props: {
     highlight: boolean
@@ -185,34 +186,67 @@ function AnimatedCollapse({ expanded, children }: { expanded: boolean, children:
  * checkbox and no value. It exists for this geography, so dropping it from the tree would
  * leave no way to reach it; its warning stands where the value would be.
  */
-function categoryBodyRows(groups: GroupTreeState[], rowsByGroup: Map<string, EditRow[]>, warningsByGroup: Map<string, ReactNode>): EditBodyRow[] {
-    return groups.flatMap(({ group, enabled, setEnabled, highlight }): EditBodyRow[] => {
-        const groupRows = rowsByGroup.get(group.id) ?? []
-        const checkboxId = `edit-checkbox-${group.id}`
-        const checkbox = (
-            <EditCheckbox
-                id={checkboxId}
-                checked={enabled}
-                onChange={setEnabled}
-                testId={`edit_group_${group.id}`}
-                highlight={highlight}
-            />
-        )
-        const statSpec = (editRow: EditRow, indent: number, whoseCheckbox: EditStatSpec['checkbox']): EditStatSpec => ({
-            kind: 'stat',
-            key: `stat-${editRow.row.statpath}`,
-            highlight,
-            indent,
-            enabled,
-            editRow,
-            checkbox: whoseCheckbox,
-        })
-        if (groupRows.length === 1) {
-            return [statSpec(groupRows[0], 1, { kind: 'own', node: checkbox })]
+function groupBodyRows(
+    { group, enabled, setEnabled, highlight }: GroupTreeState,
+    indent: number,
+    rowsByGroup: Map<string, EditRow[]>,
+    warningsByGroup: Map<string, ReactNode>,
+): EditBodyRow[] {
+    const groupRows = rowsByGroup.get(group.id) ?? []
+    const checkboxId = `edit-checkbox-${group.id}`
+    const checkbox = (
+        <EditCheckbox
+            id={checkboxId}
+            checked={enabled}
+            onChange={setEnabled}
+            testId={`edit_group_${group.id}`}
+            highlight={highlight}
+        />
+    )
+    const statSpec = (editRow: EditRow, statIndent: number, whoseCheckbox: EditStatSpec['checkbox']): EditStatSpec => ({
+        kind: 'stat',
+        key: `stat-${editRow.row.statpath}`,
+        highlight,
+        indent: statIndent,
+        enabled,
+        editRow,
+        checkbox: whoseCheckbox,
+    })
+    if (groupRows.length === 1) {
+        return [statSpec(groupRows[0], indent, { kind: 'own', node: checkbox })]
+    }
+    return [
+        { kind: 'header', key: `group-${group.id}`, indent, highlight, enabled, checkbox, name: group.name, warning: warningsByGroup.get(group.id) },
+        ...groupRows.map(editRow => statSpec(editRow, indent + 1, { kind: 'headers', id: checkboxId })),
+    ]
+}
+
+function categoryBodyRows(sections: SectionTreeState[], rowsByGroup: Map<string, EditRow[]>, warningsByGroup: Map<string, ReactNode>): EditBodyRow[] {
+    return sections.flatMap((section): EditBodyRow[] => {
+        if (section.kind === 'Group') {
+            return groupBodyRows(section.group, 1, rowsByGroup, warningsByGroup)
         }
+        const { subcategory, status, toggle, highlight, groups } = section
         return [
-            { kind: 'group-header', key: `group-${group.id}`, highlight, enabled, checkbox, name: group.name, warning: warningsByGroup.get(group.id) },
-            ...groupRows.map(editRow => statSpec(editRow, 2, { kind: 'headers', id: checkboxId })),
+            {
+                kind: 'header',
+                key: `subcategory-${subcategory.id}`,
+                indent: 1,
+                highlight,
+                // Keeps the header out of the collapsible run whenever it has something to show
+                enabled: groups.some(({ enabled }) => enabled),
+                checkbox: (
+                    <EditCheckbox
+                        checked={status === true}
+                        indeterminate={status === 'indeterminate'}
+                        onChange={toggle}
+                        testId={`edit_subcategory_${subcategory.id}`}
+                        highlight={highlight}
+                    />
+                ),
+                name: subcategory.name,
+            },
+            ...groups.flatMap(group => groupBodyRows(group, 2, rowsByGroup, warningsByGroup)),
         ]
     })
 }
@@ -260,7 +294,7 @@ function EditCategory(props: {
 }): ReactNode {
     const tree = useCategoryTreeState(props.category, props.expansion)
     const expanded = props.searching || tree.expanded
-    const segments = editBodySegments(categoryBodyRows(tree.groups, props.rowsByGroup, props.warningsByGroup), expanded)
+    const segments = editBodySegments(categoryBodyRows(tree.sections, props.rowsByGroup, props.warningsByGroup), expanded)
     const anythingToExpand = segments.some(segment => segment.collapsible)
 
     return (
@@ -298,7 +332,7 @@ function EditCategory(props: {
                 </div>
             </TableRowContainer>
             {segments.map((segment) => {
-                const rows = segment.rows.map(({ spec, index }) => spec.kind === 'group-header'
+                const rows = segment.rows.map(({ spec, index }) => spec.kind === 'header'
                     ? (
                             <EditLabelRow
                                 key={spec.key}
@@ -306,7 +340,7 @@ function EditCategory(props: {
                                 highlight={spec.highlight}
                                 checkbox={spec.checkbox}
                                 name={spec.name}
-                                paddingLeft={treeIndent(1)}
+                                paddingLeft={treeIndent(spec.indent)}
                                 warning={spec.warning === undefined ? undefined : { layout: props.layout, content: spec.warning }}
                             />
                         )

--- a/react/src/components/edit-table.tsx
+++ b/react/src/components/edit-table.tsx
@@ -76,13 +76,20 @@ export function editRowsByGroup(
     return result
 }
 
+/** The collapsible run an unselected row belongs to. Absent on rows that are always shown. */
+interface RowCollapse {
+    key: string
+    expanded: boolean
+}
+
 interface EditHeaderSpec {
     kind: 'header'
     key: string
     indent: number
     highlight: boolean
-    enabled: boolean
+    collapse?: RowCollapse
     checkbox: ReactNode
+    toggle?: ReactNode
     name: string
     /** Set for a group the year or source selection leaves with nothing to show. */
     warning?: ReactNode
@@ -94,6 +101,7 @@ interface EditStatSpec {
     highlight: boolean
     indent: number
     enabled: boolean
+    collapse?: RowCollapse
     editRow: EditRow
     checkbox: { kind: 'own', node: ReactNode } | { kind: 'headers', id: string }
 }
@@ -120,20 +128,32 @@ function EditLabelRow(props: {
     index: number
     highlight: boolean
     checkbox: ReactNode
+    toggle?: ReactNode
     name: string
     paddingLeft: string
     warning?: { layout: MeasuredTableLayout, content: ReactNode }
 }): ReactNode {
-    const { warning } = props
+    const { warning, toggle } = props
+    const width = warning === undefined ? '100%' : `${warning.layout.widthLeftHeader}%`
+    const label = (
+        <EditCheckboxLabel
+            highlight={props.highlight}
+            style={toggle === undefined ? { width, paddingLeft: props.paddingLeft } : undefined}
+            checkbox={props.checkbox}
+        >
+            {props.name}
+        </EditCheckboxLabel>
+    )
     return (
         <TableRowContainer index={props.index}>
-            <EditCheckboxLabel
-                highlight={props.highlight}
-                style={{ width: warning === undefined ? '100%' : `${warning.layout.widthLeftHeader}%`, paddingLeft: props.paddingLeft }}
-                checkbox={props.checkbox}
-            >
-                {props.name}
-            </EditCheckboxLabel>
+            {toggle === undefined
+                ? label
+                : (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: `${toggleGapEm}em`, width, paddingLeft: props.paddingLeft }}>
+                            {toggle}
+                            {label}
+                        </div>
+                    )}
             {warning !== undefined && <WarningRowMessage layout={warning.layout} content={warning.content} />}
         </TableRowContainer>
     )
@@ -189,6 +209,7 @@ function AnimatedCollapse({ expanded, children }: { expanded: boolean, children:
 function groupBodyRows(
     { group, enabled, setEnabled, highlight }: GroupTreeState,
     indent: number,
+    collapse: RowCollapse,
     rowsByGroup: Map<string, EditRow[]>,
     warningsByGroup: Map<string, ReactNode>,
 ): EditBodyRow[] {
@@ -203,12 +224,14 @@ function groupBodyRows(
             highlight={highlight}
         />
     )
+    const rowCollapse = enabled ? undefined : collapse
     const statSpec = (editRow: EditRow, statIndent: number, whoseCheckbox: EditStatSpec['checkbox']): EditStatSpec => ({
         kind: 'stat',
         key: `stat-${editRow.row.statpath}`,
         highlight,
         indent: statIndent,
         enabled,
+        collapse: rowCollapse,
         editRow,
         checkbox: whoseCheckbox,
     })
@@ -216,25 +239,33 @@ function groupBodyRows(
         return [statSpec(groupRows[0], indent, { kind: 'own', node: checkbox })]
     }
     return [
-        { kind: 'header', key: `group-${group.id}`, indent, highlight, enabled, checkbox, name: group.name, warning: warningsByGroup.get(group.id) },
+        { kind: 'header', key: `group-${group.id}`, indent, highlight, collapse: rowCollapse, checkbox, name: group.name, warning: warningsByGroup.get(group.id) },
         ...groupRows.map(editRow => statSpec(editRow, indent + 1, { kind: 'headers', id: checkboxId })),
     ]
 }
 
-function categoryBodyRows(sections: SectionTreeState[], rowsByGroup: Map<string, EditRow[]>, warningsByGroup: Map<string, ReactNode>): EditBodyRow[] {
+function categoryBodyRows(
+    sections: SectionTreeState[],
+    { categoryExpanded, searching }: { categoryExpanded: boolean, searching: boolean },
+    rowsByGroup: Map<string, EditRow[]>,
+    warningsByGroup: Map<string, ReactNode>,
+): EditBodyRow[] {
+    const categoryCollapse = { key: 'category', expanded: categoryExpanded }
     return sections.flatMap((section): EditBodyRow[] => {
         if (section.kind === 'Group') {
-            return groupBodyRows(section.group, 1, rowsByGroup, warningsByGroup)
+            return groupBodyRows(section.group, 1, categoryCollapse, rowsByGroup, warningsByGroup)
         }
-        const { subcategory, status, toggle, highlight, groups } = section
+        const { subcategory, status, toggle, highlight, expanded, setExpanded, groups } = section
+        const shown = searching || (categoryExpanded && expanded)
+        const anythingToExpand = groups.some(group => !group.enabled)
         return [
             {
                 kind: 'header',
                 key: `subcategory-${subcategory.id}`,
                 indent: 1,
                 highlight,
-                // Keeps the header out of the collapsible run whenever it has something to show
-                enabled: groups.some(({ enabled }) => enabled),
+                // The header stays out of the category's collapsible run whenever it has something to show
+                collapse: groups.some(group => group.enabled) ? undefined : categoryCollapse,
                 checkbox: (
                     <EditCheckbox
                         checked={status === true}
@@ -244,38 +275,52 @@ function categoryBodyRows(sections: SectionTreeState[], rowsByGroup: Map<string,
                         highlight={highlight}
                     />
                 ),
+                toggle: anythingToExpand && !searching
+                    ? (
+                            <ExpandButton
+                                isExpanded={shown}
+                                data-subcategory-id={subcategory.id}
+                                onClick={() => { setExpanded(!expanded) }}
+                                style={{ ...toggleSize, backgroundSize: '16px' }}
+                                aria-label={shown ? `Collapse ${subcategory.name} subcategory` : `Expand ${subcategory.name} subcategory`}
+                            />
+                        )
+                    : <div style={toggleSize} />,
                 name: subcategory.name,
             },
-            ...groups.flatMap(group => groupBodyRows(group, 2, rowsByGroup, warningsByGroup)),
+            ...groups.flatMap(group => groupBodyRows(group, 2, { key: `subcategory-${subcategory.id}`, expanded: shown }, rowsByGroup, warningsByGroup)),
         ]
     })
 }
 
 interface EditBodySegment {
     key: string
-    collapsible: boolean
+    /** Unset on a run that is always shown. */
+    expanded?: boolean
     rows: { spec: EditBodyRow, index: number }[]
 }
 
 /**
- * Splits a category's rows into runs of selected rows, which the category shows whether or
- * not it is expanded, and runs of unselected ones, which only the expanded category shows.
+ * Splits a category's rows into runs of selected rows, which are shown whether or not the
+ * category is expanded, and runs of unselected ones, each belonging to the category's or a
+ * subcategory's collapse.
  *
  * Rows are striped by the position they end up at, counting only the rows currently on
  * display, so the alternation is unbroken in either state. The category header is row 0.
  */
-function editBodySegments(bodyRows: EditBodyRow[], expanded: boolean): EditBodySegment[] {
+function editBodySegments(bodyRows: EditBodyRow[]): EditBodySegment[] {
     const segments: EditBodySegment[] = []
     let segment: EditBodySegment | undefined
+    let collapseKey: string | undefined
     let index = 1
     for (const spec of bodyRows) {
-        const collapsible = !spec.enabled
-        if (segment?.collapsible !== collapsible) {
-            segment = { key: spec.key, collapsible, rows: [] }
+        if (segment === undefined || collapseKey !== spec.collapse?.key) {
+            collapseKey = spec.collapse?.key
+            segment = { key: spec.key, expanded: spec.collapse?.expanded, rows: [] }
             segments.push(segment)
         }
         segment.rows.push({ spec, index })
-        if (expanded || !collapsible) {
+        if (spec.collapse?.expanded !== false) {
             index++
         }
     }
@@ -294,8 +339,14 @@ function EditCategory(props: {
 }): ReactNode {
     const tree = useCategoryTreeState(props.category, props.expansion)
     const expanded = props.searching || tree.expanded
-    const segments = editBodySegments(categoryBodyRows(tree.sections, props.rowsByGroup, props.warningsByGroup), expanded)
-    const anythingToExpand = segments.some(segment => segment.collapsible)
+    const bodyRows = categoryBodyRows(
+        tree.sections,
+        { categoryExpanded: expanded, searching: props.searching },
+        props.rowsByGroup,
+        props.warningsByGroup,
+    )
+    const segments = editBodySegments(bodyRows)
+    const anythingToExpand = bodyRows.some(row => row.collapse !== undefined)
 
     return (
         <>
@@ -339,16 +390,18 @@ function EditCategory(props: {
                                 index={index}
                                 highlight={spec.highlight}
                                 checkbox={spec.checkbox}
+                                toggle={spec.toggle}
                                 name={spec.name}
-                                paddingLeft={treeIndent(spec.indent)}
+                                // A toggle takes up the space treeIndent reserves for one, so the checkboxes stay in line
+                                paddingLeft={spec.toggle === undefined ? treeIndent(spec.indent) : `${spec.indent * indentEm}em`}
                                 warning={spec.warning === undefined ? undefined : { layout: props.layout, content: spec.warning }}
                             />
                         )
                     : <EditStatRow key={spec.key} layout={props.layout} index={index} spec={spec} />,
                 )
-                return segment.collapsible
-                    ? <AnimatedCollapse key={segment.key} expanded={expanded}>{rows}</AnimatedCollapse>
-                    : <React.Fragment key={segment.key}>{rows}</React.Fragment>
+                return segment.expanded === undefined
+                    ? <React.Fragment key={segment.key}>{rows}</React.Fragment>
+                    : <AnimatedCollapse key={segment.key} expanded={segment.expanded}>{rows}</AnimatedCollapse>
             })}
         </>
     )

--- a/react/src/components/warning-message.tsx
+++ b/react/src/components/warning-message.tsx
@@ -2,10 +2,10 @@ import React, { ReactNode } from 'react'
 
 import { useColors } from '../page_template/colors'
 import type { MissingGroupReason, MissingSources } from '../page_template/statistic-settings'
-import type { Category, Group } from '../page_template/statistic-tree'
+import type { Category, Group, Subcategory } from '../page_template/statistic-tree'
 
 /** `onEdit` is unset on the edit tree's own warnings, which are already where it would send the user. */
-export function warningMessage(reason: MissingGroupReason, groupOrCategory: Group | Category, onEdit?: () => void): ReactNode {
+export function warningMessage(reason: MissingGroupReason, groupOrCategory: Group | Subcategory | Category, onEdit?: () => void): ReactNode {
     switch (reason.kind) {
         case 'year':
             return (
@@ -72,10 +72,11 @@ function EditButton({ onEdit, children }: { onEdit: () => void, children: ReactN
     )
 }
 
-function theseStatistics(groupOrCategory: Group | Category): string {
+function theseStatistics(groupOrCategory: Group | Subcategory | Category): string {
     switch (groupOrCategory.kind) {
         case 'Group':
             return 'this statistic'
+        case 'Subcategory':
         case 'Category':
             return 'these statistics'
     }

--- a/react/src/data/statistics_tree.ts
+++ b/react/src/data/statistics_tree.ts
@@ -149,6 +149,7 @@ export const rawStatsTree = [
             {
                 "id": "population",
                 "name": "Population",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -272,6 +273,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_1",
                 "name": "PW Density (r=1km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -395,6 +397,7 @@ export const rawStatsTree = [
             {
                 "id": "sd",
                 "name": "AW Density",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -482,6 +485,7 @@ export const rawStatsTree = [
             {
                 "id": "area",
                 "name": "Area",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": null,
@@ -507,6 +511,7 @@ export const rawStatsTree = [
             {
                 "id": "compactness",
                 "name": "Compactness",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": null,
@@ -538,6 +543,7 @@ export const rawStatsTree = [
             {
                 "id": "gridded_hilliness",
                 "name": "PW Mean Hilliness (Grade)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -563,6 +569,7 @@ export const rawStatsTree = [
             {
                 "id": "gridded_elevation",
                 "name": "PW Mean Elevation",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -594,6 +601,10 @@ export const rawStatsTree = [
             {
                 "id": "white",
                 "name": "White %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -665,6 +676,10 @@ export const rawStatsTree = [
             {
                 "id": "hispanic",
                 "name": "Hispanic %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -736,6 +751,10 @@ export const rawStatsTree = [
             {
                 "id": "black",
                 "name": "Black %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -807,6 +826,10 @@ export const rawStatsTree = [
             {
                 "id": "asian",
                 "name": "Asian %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -878,6 +901,10 @@ export const rawStatsTree = [
             {
                 "id": "native",
                 "name": "Native %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -949,6 +976,10 @@ export const rawStatsTree = [
             {
                 "id": "hawaiian_pi",
                 "name": "Hawaiian / PI %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1020,6 +1051,10 @@ export const rawStatsTree = [
             {
                 "id": "other  slash  mixed",
                 "name": "Other / Mixed %",
+                "subcategory": {
+                    "id": "race_composition",
+                    "name": "Racial Composition"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1091,6 +1126,7 @@ export const rawStatsTree = [
             {
                 "id": "homogeneity_250",
                 "name": "Racial Homogeneity %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2000,
@@ -1182,6 +1218,7 @@ export const rawStatsTree = [
             {
                 "id": "segregation_250",
                 "name": "Segregation %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2000,
@@ -1273,6 +1310,7 @@ export const rawStatsTree = [
             {
                 "id": "segregation_250_10",
                 "name": "Mean Local Segregation %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2000,
@@ -1370,6 +1408,10 @@ export const rawStatsTree = [
             {
                 "id": "citizenship_citizen_by_birth",
                 "name": "Citizen by Birth %",
+                "subcategory": {
+                    "id": "citizenship",
+                    "name": "Citizenship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1403,6 +1445,10 @@ export const rawStatsTree = [
             {
                 "id": "citizenship_citizen_by_naturalization",
                 "name": "Citizen by Naturalization %",
+                "subcategory": {
+                    "id": "citizenship",
+                    "name": "Citizenship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1436,6 +1482,10 @@ export const rawStatsTree = [
             {
                 "id": "citizenship_not_citizen",
                 "name": "Non-citizen %",
+                "subcategory": {
+                    "id": "citizenship",
+                    "name": "Citizenship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1469,6 +1519,10 @@ export const rawStatsTree = [
             {
                 "id": "birthplace_non_us",
                 "name": "Born outside US %",
+                "subcategory": {
+                    "id": "birthplace",
+                    "name": "Birthplace"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1494,6 +1548,10 @@ export const rawStatsTree = [
             {
                 "id": "birthplace_us_not_state",
                 "name": "Born in us outside state %",
+                "subcategory": {
+                    "id": "birthplace",
+                    "name": "Birthplace"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1519,6 +1577,10 @@ export const rawStatsTree = [
             {
                 "id": "birthplace_us_state",
                 "name": "Born in state of residence %",
+                "subcategory": {
+                    "id": "birthplace",
+                    "name": "Birthplace"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1544,6 +1606,10 @@ export const rawStatsTree = [
             {
                 "id": "language_english_only",
                 "name": "Only English at Home %",
+                "subcategory": {
+                    "id": "language",
+                    "name": "Language at Home"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1577,6 +1643,10 @@ export const rawStatsTree = [
             {
                 "id": "language_spanish",
                 "name": "Spanish at Home %",
+                "subcategory": {
+                    "id": "language",
+                    "name": "Language at Home"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1610,6 +1680,10 @@ export const rawStatsTree = [
             {
                 "id": "language_french_canada",
                 "name": "French at Home % [StatCan]",
+                "subcategory": {
+                    "id": "language",
+                    "name": "Language at Home"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1635,6 +1709,10 @@ export const rawStatsTree = [
             {
                 "id": "language_other_non_french_canada",
                 "name": "Other (non-French) at Home % [StatCan]",
+                "subcategory": {
+                    "id": "language",
+                    "name": "Language at Home"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1660,6 +1738,10 @@ export const rawStatsTree = [
             {
                 "id": "language_other",
                 "name": "Other at Home %",
+                "subcategory": {
+                    "id": "language",
+                    "name": "Language at Home"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1691,6 +1773,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_no_religion_canada",
                 "name": "No religion % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1716,6 +1799,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_catholic_canada",
                 "name": "Catholic % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1741,6 +1825,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_protestant_canada",
                 "name": "Protestant (non-Catholic Christian) % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1766,6 +1851,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_hindu_canada",
                 "name": "Hindu % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1791,6 +1877,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_jewish_canada",
                 "name": "Jewish % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1816,6 +1903,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_muslim_canada",
                 "name": "Muslim % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1841,6 +1929,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_sikh_canada",
                 "name": "Sikh % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1866,6 +1955,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_buddhist_canada",
                 "name": "Buddhist % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1891,6 +1981,7 @@ export const rawStatsTree = [
             {
                 "id": "religion_other_canada",
                 "name": "Other religion % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -1922,6 +2013,10 @@ export const rawStatsTree = [
             {
                 "id": "education_high_school",
                 "name": "High School %",
+                "subcategory": {
+                    "id": "education_attainment",
+                    "name": "Educational Attainment"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1947,6 +2042,10 @@ export const rawStatsTree = [
             {
                 "id": "education_ugrad",
                 "name": "Undergrad %",
+                "subcategory": {
+                    "id": "education_attainment",
+                    "name": "Educational Attainment"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1972,6 +2071,10 @@ export const rawStatsTree = [
             {
                 "id": "education_grad",
                 "name": "Grad %",
+                "subcategory": {
+                    "id": "education_attainment",
+                    "name": "Educational Attainment"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -1997,6 +2100,10 @@ export const rawStatsTree = [
             {
                 "id": "education_high_school_canada",
                 "name": "High school diploma [25-64] %",
+                "subcategory": {
+                    "id": "education_attainment",
+                    "name": "Educational Attainment"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2022,6 +2129,10 @@ export const rawStatsTree = [
             {
                 "id": "education_ugrad_canada",
                 "name": "Bachelor's degree [25-64] %",
+                "subcategory": {
+                    "id": "education_attainment",
+                    "name": "Educational Attainment"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2047,6 +2158,10 @@ export const rawStatsTree = [
             {
                 "id": "education_grad_canada",
                 "name": "Graduate degree [25-64] %",
+                "subcategory": {
+                    "id": "education_attainment",
+                    "name": "Educational Attainment"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2072,6 +2187,10 @@ export const rawStatsTree = [
             {
                 "id": "education_field_stem",
                 "name": "Undergrad STEM %",
+                "subcategory": {
+                    "id": "education_field",
+                    "name": "Field of Study"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2097,6 +2216,10 @@ export const rawStatsTree = [
             {
                 "id": "education_field_humanities",
                 "name": "Undergrad Humanities %",
+                "subcategory": {
+                    "id": "education_field",
+                    "name": "Field of Study"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2122,6 +2245,10 @@ export const rawStatsTree = [
             {
                 "id": "education_field_business",
                 "name": "Undergrad Business %",
+                "subcategory": {
+                    "id": "education_field",
+                    "name": "Field of Study"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2147,6 +2274,10 @@ export const rawStatsTree = [
             {
                 "id": "education_field_stem_canada",
                 "name": "Undergrad STEM [25-64] % [StatCan]",
+                "subcategory": {
+                    "id": "education_field",
+                    "name": "Field of Study"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2172,6 +2303,10 @@ export const rawStatsTree = [
             {
                 "id": "education_field_humanities_canada",
                 "name": "Undergrad Humanities [25-64] % [StatCan]",
+                "subcategory": {
+                    "id": "education_field",
+                    "name": "Field of Study"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2197,6 +2332,10 @@ export const rawStatsTree = [
             {
                 "id": "education_field_business_canada",
                 "name": "Undergrad Business [25-64] % [StatCan]",
+                "subcategory": {
+                    "id": "education_field",
+                    "name": "Field of Study"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2222,6 +2361,7 @@ export const rawStatsTree = [
             {
                 "id": "female_hs_gap_4",
                 "name": "% of women with high school education - % of men with high school education",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2247,6 +2387,7 @@ export const rawStatsTree = [
             {
                 "id": "female_ugrad_gap_4",
                 "name": "% of women with undergraduate education - % of men with undergraduate education",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2272,6 +2413,7 @@ export const rawStatsTree = [
             {
                 "id": "female_grad_gap_4",
                 "name": "% of women with graduate education - % of men with graduate education",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2303,6 +2445,7 @@ export const rawStatsTree = [
             {
                 "id": "generation_silent",
                 "name": "Silent %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2336,6 +2479,7 @@ export const rawStatsTree = [
             {
                 "id": "generation_boomer",
                 "name": "Boomer %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2369,6 +2513,7 @@ export const rawStatsTree = [
             {
                 "id": "generation_genx",
                 "name": "Gen X %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2402,6 +2547,7 @@ export const rawStatsTree = [
             {
                 "id": "generation_millenial",
                 "name": "Millennial %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2435,6 +2581,7 @@ export const rawStatsTree = [
             {
                 "id": "generation_genz",
                 "name": "Gen Z %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2468,6 +2615,7 @@ export const rawStatsTree = [
             {
                 "id": "generation_genalpha",
                 "name": "Gen Alpha %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2507,6 +2655,7 @@ export const rawStatsTree = [
             {
                 "id": "median_household_income",
                 "name": "Median Household Income (USD)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2532,6 +2681,7 @@ export const rawStatsTree = [
             {
                 "id": "poverty_below_line",
                 "name": "Poverty %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2557,6 +2707,7 @@ export const rawStatsTree = [
             {
                 "id": "lico_at_canada",
                 "name": "LICO-AT %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2582,6 +2733,7 @@ export const rawStatsTree = [
             {
                 "id": "lim_at_canada",
                 "name": "LIM-AT %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2607,6 +2759,10 @@ export const rawStatsTree = [
             {
                 "id": "household_income_under_50k",
                 "name": "Household Income < $50k %",
+                "subcategory": {
+                    "id": "household_income",
+                    "name": "Household Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2632,6 +2788,10 @@ export const rawStatsTree = [
             {
                 "id": "household_income_50k_to_100k",
                 "name": "Household Income $50k - $100k %",
+                "subcategory": {
+                    "id": "household_income",
+                    "name": "Household Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2657,6 +2817,10 @@ export const rawStatsTree = [
             {
                 "id": "household_income_over_100k",
                 "name": "Household Income > $100k %",
+                "subcategory": {
+                    "id": "household_income",
+                    "name": "Household Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2682,6 +2846,10 @@ export const rawStatsTree = [
             {
                 "id": "household_income_under_50cad",
                 "name": "Household income < C$50k %",
+                "subcategory": {
+                    "id": "household_income",
+                    "name": "Household Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2707,6 +2875,10 @@ export const rawStatsTree = [
             {
                 "id": "household_income_50_to_100cad",
                 "name": "Household income C$50k - C$100k %",
+                "subcategory": {
+                    "id": "household_income",
+                    "name": "Household Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2732,6 +2904,10 @@ export const rawStatsTree = [
             {
                 "id": "household_income_above_100_cad",
                 "name": "Household income > C$100k %",
+                "subcategory": {
+                    "id": "household_income",
+                    "name": "Household Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2757,6 +2933,10 @@ export const rawStatsTree = [
             {
                 "id": "individual_income_under_50k",
                 "name": "Individual Income < $50k %",
+                "subcategory": {
+                    "id": "individual_income",
+                    "name": "Individual Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2782,6 +2962,10 @@ export const rawStatsTree = [
             {
                 "id": "individual_income_50k_to_100k",
                 "name": "Individual Income $50k - $100k %",
+                "subcategory": {
+                    "id": "individual_income",
+                    "name": "Individual Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2807,6 +2991,10 @@ export const rawStatsTree = [
             {
                 "id": "individual_income_over_100k",
                 "name": "Individual Income > $100k %",
+                "subcategory": {
+                    "id": "individual_income",
+                    "name": "Individual Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2832,6 +3020,10 @@ export const rawStatsTree = [
             {
                 "id": "individual_income_under_50cad",
                 "name": "Individual income < C$50k %",
+                "subcategory": {
+                    "id": "individual_income",
+                    "name": "Individual Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2857,6 +3049,10 @@ export const rawStatsTree = [
             {
                 "id": "individual_income_50_to_100cad",
                 "name": "Individual income C$50k - C$100k %",
+                "subcategory": {
+                    "id": "individual_income",
+                    "name": "Individual Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2882,6 +3078,10 @@ export const rawStatsTree = [
             {
                 "id": "individual_income_above_100_cad",
                 "name": "Individual income > C$100k %",
+                "subcategory": {
+                    "id": "individual_income",
+                    "name": "Individual Income"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -2913,6 +3113,7 @@ export const rawStatsTree = [
             {
                 "id": "housing_per_pop",
                 "name": "Housing Units per Adult",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -2984,6 +3185,7 @@ export const rawStatsTree = [
             {
                 "id": "housing_per_person",
                 "name": "Housing Units per Person",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3055,6 +3257,7 @@ export const rawStatsTree = [
             {
                 "id": "vacancy",
                 "name": "Vacancy %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3118,6 +3321,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_burden_under_20",
                 "name": "Rent/Income < 20%",
+                "subcategory": {
+                    "id": "rent_burden",
+                    "name": "Rent Burden"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3143,6 +3350,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_burden_20_to_40",
                 "name": "Rent/Income 20%-40%",
+                "subcategory": {
+                    "id": "rent_burden",
+                    "name": "Rent Burden"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3168,6 +3379,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_burden_over_40",
                 "name": "Rent/Income > 40%",
+                "subcategory": {
+                    "id": "rent_burden",
+                    "name": "Rent Burden"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3193,6 +3408,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_1br_under_750",
                 "name": "1BR Rent < $750 %",
+                "subcategory": {
+                    "id": "rent_1br",
+                    "name": "1BR Rent"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3218,6 +3437,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_1br_750_to_1500",
                 "name": "1BR Rent $750 - $1500 %",
+                "subcategory": {
+                    "id": "rent_1br",
+                    "name": "1BR Rent"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3243,6 +3466,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_1br_over_1500",
                 "name": "1BR Rent > $1500 %",
+                "subcategory": {
+                    "id": "rent_1br",
+                    "name": "1BR Rent"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3268,6 +3495,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_2br_under_750",
                 "name": "2BR Rent < $750 %",
+                "subcategory": {
+                    "id": "rent_2br",
+                    "name": "2BR Rent"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3293,6 +3524,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_2br_750_to_1500",
                 "name": "2BR Rent $750 - $1500 %",
+                "subcategory": {
+                    "id": "rent_2br",
+                    "name": "2BR Rent"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3318,6 +3553,10 @@ export const rawStatsTree = [
             {
                 "id": "rent_2br_over_1500",
                 "name": "2BR Rent > $1500 %",
+                "subcategory": {
+                    "id": "rent_2br",
+                    "name": "2BR Rent"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3343,6 +3582,10 @@ export const rawStatsTree = [
             {
                 "id": "year_built_1969_or_earlier",
                 "name": "% units built pre-1970",
+                "subcategory": {
+                    "id": "year_built",
+                    "name": "Year Built"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3368,6 +3611,10 @@ export const rawStatsTree = [
             {
                 "id": "year_built_1970_to_1979",
                 "name": "% units built in 1970s",
+                "subcategory": {
+                    "id": "year_built",
+                    "name": "Year Built"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3393,6 +3640,10 @@ export const rawStatsTree = [
             {
                 "id": "year_built_1980_to_1989",
                 "name": "% units built in 1980s",
+                "subcategory": {
+                    "id": "year_built",
+                    "name": "Year Built"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3418,6 +3669,10 @@ export const rawStatsTree = [
             {
                 "id": "year_built_1990_to_1999",
                 "name": "% units built in 1990s",
+                "subcategory": {
+                    "id": "year_built",
+                    "name": "Year Built"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3443,6 +3698,10 @@ export const rawStatsTree = [
             {
                 "id": "year_built_2000_to_2009",
                 "name": "% units built in 2000s",
+                "subcategory": {
+                    "id": "year_built",
+                    "name": "Year Built"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3468,6 +3727,10 @@ export const rawStatsTree = [
             {
                 "id": "year_built_2010_or_later",
                 "name": "% units built in 2010s+",
+                "subcategory": {
+                    "id": "year_built",
+                    "name": "Year Built"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3493,6 +3756,7 @@ export const rawStatsTree = [
             {
                 "id": "household_size_pw",
                 "name": "PW Household Size",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3526,6 +3790,7 @@ export const rawStatsTree = [
             {
                 "id": "rent_or_own_rent",
                 "name": "Renter %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3559,6 +3824,7 @@ export const rawStatsTree = [
             {
                 "id": "rent_burden_over_30_canada",
                 "name": "Housing Cost/Income > 30% [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3590,6 +3856,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_car_no_wfh",
                 "name": "Commute Car %",
+                "subcategory": {
+                    "id": "commute_mode",
+                    "name": "Commute Mode"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3623,6 +3893,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_bike_no_wfh",
                 "name": "Commute Bike %",
+                "subcategory": {
+                    "id": "commute_mode",
+                    "name": "Commute Mode"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3656,6 +3930,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_walk_no_wfh",
                 "name": "Commute Walk %",
+                "subcategory": {
+                    "id": "commute_mode",
+                    "name": "Commute Mode"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3689,6 +3967,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_transit_no_wfh",
                 "name": "Commute Transit %",
+                "subcategory": {
+                    "id": "commute_mode",
+                    "name": "Commute Mode"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3722,6 +4004,7 @@ export const rawStatsTree = [
             {
                 "id": "transportation_commute_time_median",
                 "name": "Median Commute Time (min)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3755,6 +4038,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_commute_time_under_15",
                 "name": "Commute Time < 15 min %",
+                "subcategory": {
+                    "id": "commute_time",
+                    "name": "Commute Time"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3788,6 +4075,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_commute_time_15_to_29",
                 "name": "Commute Time 15 - 29 min %",
+                "subcategory": {
+                    "id": "commute_time",
+                    "name": "Commute Time"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3821,6 +4112,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_commute_time_30_to_59",
                 "name": "Commute Time 30 - 59 min %",
+                "subcategory": {
+                    "id": "commute_time",
+                    "name": "Commute Time"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3854,6 +4149,10 @@ export const rawStatsTree = [
             {
                 "id": "transportation_commute_time_over_60",
                 "name": "Commute Time > 60 min %",
+                "subcategory": {
+                    "id": "commute_time",
+                    "name": "Commute Time"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3887,6 +4186,10 @@ export const rawStatsTree = [
             {
                 "id": "vehicle_ownership_none",
                 "name": "Households With no Vehicle %",
+                "subcategory": {
+                    "id": "vehicle_ownership",
+                    "name": "Vehicle Ownership"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3912,6 +4215,10 @@ export const rawStatsTree = [
             {
                 "id": "vehicle_ownership_at_least_1",
                 "name": "Households With 1+ Vehicles %",
+                "subcategory": {
+                    "id": "vehicle_ownership",
+                    "name": "Vehicle Ownership"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3937,6 +4244,10 @@ export const rawStatsTree = [
             {
                 "id": "vehicle_ownership_at_least_2",
                 "name": "Households With 2+ Vehicles %",
+                "subcategory": {
+                    "id": "vehicle_ownership",
+                    "name": "Vehicle Ownership"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -3962,6 +4273,7 @@ export const rawStatsTree = [
             {
                 "id": "traffic_fatalities_last_decade_per_capita",
                 "name": "Traffic Fatalities Per Capita Per Year",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -3987,6 +4299,7 @@ export const rawStatsTree = [
             {
                 "id": "traffic_fatalities_ped_last_decade_per_capita",
                 "name": "Pedestrian/Cyclist Fatalities Per Capita Per Year",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4012,6 +4325,7 @@ export const rawStatsTree = [
             {
                 "id": "traffic_fatalities_last_decade",
                 "name": "Total Traffic Fatalities In Last Decade",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4037,6 +4351,7 @@ export const rawStatsTree = [
             {
                 "id": "traffic_fatalities_ped_last_decade",
                 "name": "Total Pedestrian/Cyclist Fatalities In Last Decade",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4068,6 +4383,7 @@ export const rawStatsTree = [
             {
                 "id": "GHLTH_cdc_2",
                 "name": "Fair or poor self-rated health status %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4093,6 +4409,7 @@ export const rawStatsTree = [
             {
                 "id": "PHLTH_cdc_2",
                 "name": "Physical health not good for two weeks in last year %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4118,6 +4435,7 @@ export const rawStatsTree = [
             {
                 "id": "ARTHRITIS_cdc_2",
                 "name": "Arthritis %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4143,6 +4461,7 @@ export const rawStatsTree = [
             {
                 "id": "CASTHMA_cdc_2",
                 "name": "Current asthma %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4168,6 +4487,7 @@ export const rawStatsTree = [
             {
                 "id": "BPHIGH_cdc_2",
                 "name": "High blood pressure %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4193,6 +4513,7 @@ export const rawStatsTree = [
             {
                 "id": "CANCER_cdc_2",
                 "name": "Cancer (excluding skin cancer) %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4218,6 +4539,7 @@ export const rawStatsTree = [
             {
                 "id": "KIDNEY_cdc_2",
                 "name": "Chronic kidney disease %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4243,6 +4565,7 @@ export const rawStatsTree = [
             {
                 "id": "COPD_cdc_2",
                 "name": "COPD %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4268,6 +4591,7 @@ export const rawStatsTree = [
             {
                 "id": "CHD_cdc_2",
                 "name": "Coronary heart disease %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4293,6 +4617,7 @@ export const rawStatsTree = [
             {
                 "id": "DIABETES_cdc_2",
                 "name": "Diagnosed diabetes %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4318,6 +4643,7 @@ export const rawStatsTree = [
             {
                 "id": "OBESITY_cdc_2",
                 "name": "Obesity %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4343,6 +4669,7 @@ export const rawStatsTree = [
             {
                 "id": "STROKE_cdc_2",
                 "name": "Stroke %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4368,6 +4695,7 @@ export const rawStatsTree = [
             {
                 "id": "DISABILITY_cdc_2",
                 "name": "Disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4393,6 +4721,7 @@ export const rawStatsTree = [
             {
                 "id": "HEARING_cdc_2",
                 "name": "Hearing disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4418,6 +4747,7 @@ export const rawStatsTree = [
             {
                 "id": "VISION_cdc_2",
                 "name": "Vision disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4443,6 +4773,7 @@ export const rawStatsTree = [
             {
                 "id": "COGNITION_cdc_2",
                 "name": "Cognitive disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4468,6 +4799,7 @@ export const rawStatsTree = [
             {
                 "id": "MOBILITY_cdc_2",
                 "name": "Mobility disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4493,6 +4825,7 @@ export const rawStatsTree = [
             {
                 "id": "SELFCARE_cdc_2",
                 "name": "Self-care disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4518,6 +4851,7 @@ export const rawStatsTree = [
             {
                 "id": "INDEPLIVE_cdc_2",
                 "name": "Independent living disability %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4543,6 +4877,7 @@ export const rawStatsTree = [
             {
                 "id": "BINGE_cdc_2",
                 "name": "Binge drinking among adults %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4568,6 +4903,7 @@ export const rawStatsTree = [
             {
                 "id": "CSMOKING_cdc_2",
                 "name": "Smoking %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4593,6 +4929,7 @@ export const rawStatsTree = [
             {
                 "id": "LPA_cdc_2",
                 "name": "No leisure-time physical activity %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4618,6 +4955,7 @@ export const rawStatsTree = [
             {
                 "id": "SLEEP_cdc_2",
                 "name": "Sleeping less than 7 hours %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4643,6 +4981,7 @@ export const rawStatsTree = [
             {
                 "id": "CHECKUP_cdc_2",
                 "name": "Attended doctor in last year %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4668,6 +5007,7 @@ export const rawStatsTree = [
             {
                 "id": "DENTAL_cdc_2",
                 "name": "Attended dentist in last year %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4693,6 +5033,7 @@ export const rawStatsTree = [
             {
                 "id": "CHOLSCREEN_cdc_2",
                 "name": "Cholesterol screening in last year %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4718,6 +5059,7 @@ export const rawStatsTree = [
             {
                 "id": "life_expectancy_2019",
                 "name": "Life Expectancy (2019)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4743,6 +5085,7 @@ export const rawStatsTree = [
             {
                 "id": "performance_score_adj_2019",
                 "name": "IHME Health Performance Score (2019)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4774,6 +5117,7 @@ export const rawStatsTree = [
             {
                 "id": "pm_25_2018_2022",
                 "name": "PW Mean PM2.5 Pollution",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4799,6 +5143,10 @@ export const rawStatsTree = [
             {
                 "id": "heating_utility_gas",
                 "name": "Utility gas heating %",
+                "subcategory": {
+                    "id": "heating",
+                    "name": "Heating Fuel"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -4824,6 +5172,10 @@ export const rawStatsTree = [
             {
                 "id": "heating_electricity",
                 "name": "Electricity heating %",
+                "subcategory": {
+                    "id": "heating",
+                    "name": "Heating Fuel"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -4849,6 +5201,10 @@ export const rawStatsTree = [
             {
                 "id": "heating_bottled_tank_lp_gas",
                 "name": "Bottled, tank, or LP gas heating %",
+                "subcategory": {
+                    "id": "heating",
+                    "name": "Heating Fuel"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -4874,6 +5230,10 @@ export const rawStatsTree = [
             {
                 "id": "heating_feul_oil_kerosene",
                 "name": "Fuel oil, kerosene, etc. heating %",
+                "subcategory": {
+                    "id": "heating",
+                    "name": "Heating Fuel"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -4899,6 +5259,10 @@ export const rawStatsTree = [
             {
                 "id": "heating_other",
                 "name": "Other fuel heating %",
+                "subcategory": {
+                    "id": "heating",
+                    "name": "Heating Fuel"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -4924,6 +5288,10 @@ export const rawStatsTree = [
             {
                 "id": "heating_no",
                 "name": "No heating %",
+                "subcategory": {
+                    "id": "heating",
+                    "name": "Heating Fuel"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -4955,6 +5323,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_agriculture,_forestry,_fishing_and_hunting",
                 "name": "Employed in Agriculture, forestry, fishing and hunting %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -4988,6 +5357,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_mining,_quarrying,_and_oil_and_gas_extraction",
                 "name": "Employed in Mining, quarrying, and oil and gas extraction %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5021,6 +5391,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_accommodation_and_food_services",
                 "name": "Employed in Accommodation and food services %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5054,6 +5425,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_arts,_entertainment,_and_recreation",
                 "name": "Employed in Arts, entertainment, and recreation %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5087,6 +5459,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_construction",
                 "name": "Employed in Construction %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5120,6 +5493,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_educational_services",
                 "name": "Employed in Educational services %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5153,6 +5527,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_health_care_and_social_assistance",
                 "name": "Employed in Health care and social assistance %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5186,6 +5561,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_finance_and_insurance",
                 "name": "Employed in Finance and insurance %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5219,6 +5595,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_real_estate_and_rental_and_leasing",
                 "name": "Employed in Real estate and rental and leasing %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5252,6 +5629,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_information",
                 "name": "Employed in Information %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5285,6 +5663,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_manufacturing",
                 "name": "Employed in Manufacturing %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5318,6 +5697,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_other_services,_except_public_administration",
                 "name": "Employed in Other services, except public administration %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5351,6 +5731,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_administrative_and_support_and_waste_management_services",
                 "name": "Employed in Administrative and support and waste management services %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5384,6 +5765,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_management_of_companies_and_enterprises",
                 "name": "Employed in Management of companies and enterprises %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5417,6 +5799,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_professional,_scientific,_and_technical_services",
                 "name": "Employed in Professional, scientific, and technical services %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5450,6 +5833,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_public_administration",
                 "name": "Employed in Public administration %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5483,6 +5867,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_retail_trade",
                 "name": "Employed in Retail trade %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5516,6 +5901,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_transportation_and_warehousing",
                 "name": "Employed in Transportation and warehousing %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5549,6 +5935,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_utilities",
                 "name": "Employed in Utilities %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5582,6 +5969,7 @@ export const rawStatsTree = [
             {
                 "id": "industry_wholesale_trade",
                 "name": "Employed in Wholesale trade %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5621,6 +6009,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_architecture_and_engineering_occupations",
                 "name": "Architecture and engineering occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5646,6 +6035,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_computer_and_mathematical_occupations",
                 "name": "Computer and mathematical occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5671,6 +6061,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_life,_physical,_and_social_science_occupations",
                 "name": "Life, physical, and social science occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5696,6 +6087,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_arts,_design,_entertainment,_sports,_and_media_occupations",
                 "name": "Arts, design, entertainment, sports, and media occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5721,6 +6113,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_community_and_social_service_occupations",
                 "name": "Community and social service occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5746,6 +6139,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_educational_instruction,_and_library_occupations",
                 "name": "Educational instruction, and library occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5771,6 +6165,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_legal_occupations",
                 "name": "Legal occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5796,6 +6191,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_health_diagnosing_and_treating_practitioners_and_other_technical_occupations",
                 "name": "Health diagnosing and treating practitioners and other technical occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5821,6 +6217,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_health_technologists_and_technicians",
                 "name": "Health technologists and technicians %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5846,6 +6243,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_business_and_financial_operations_occupations",
                 "name": "Business and financial operations occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5871,6 +6269,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_management_occupations",
                 "name": "Management occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5896,6 +6295,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_construction_and_extraction_occupations",
                 "name": "Construction and extraction occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5921,6 +6321,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_farming,_fishing,_and_forestry_occupations",
                 "name": "Farming, fishing, and forestry occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5946,6 +6347,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_installation,_maintenance,_and_repair_occupations",
                 "name": "Installation, maintenance, and repair occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5971,6 +6373,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_material_moving_occupations",
                 "name": "Material moving occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -5996,6 +6399,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_production_occupations",
                 "name": "Production occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6021,6 +6425,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_transportation_occupations",
                 "name": "Transportation occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6046,6 +6451,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_office_and_administrative_support_occupations",
                 "name": "Office and administrative support occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6071,6 +6477,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_sales_and_related_occupations",
                 "name": "Sales and related occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6096,6 +6503,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_building_and_grounds_cleaning_and_maintenance_occupations",
                 "name": "Building and grounds cleaning and maintenance occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6121,6 +6529,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_food_preparation_and_serving_related_occupations",
                 "name": "Food preparation and serving related occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6146,6 +6555,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_healthcare_support_occupations",
                 "name": "Healthcare support occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6171,6 +6581,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_personal_care_and_service_occupations",
                 "name": "Personal care and service occupations %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6196,6 +6607,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_firefighting_and_prevention,_and_other_protective_service_workers_including_supervisors",
                 "name": "Firefighting and prevention, and other protective service workers including supervisors %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6221,6 +6633,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_law_enforcement_workers_including_supervisors",
                 "name": "Law enforcement workers including supervisors %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6246,6 +6659,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_legislative_and_senior_management_canada",
                 "name": "Legislative and senior management occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6271,6 +6685,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_business_finance_and_administration_canada",
                 "name": "Business, finance and administration occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6296,6 +6711,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_natural_and_applied_sciences_canada",
                 "name": "Natural and applied sciences occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6321,6 +6737,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_health_canada",
                 "name": "Health occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6346,6 +6763,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_education_law_social_community_government_canada",
                 "name": "Education, law, social, community and government occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6371,6 +6789,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_art_culture_recreation_sport_canada",
                 "name": "Art, culture, recreation and sport occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6396,6 +6815,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_sales_and_service_canada",
                 "name": "Sales and service occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6421,6 +6841,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_trades_transport_equipment_canada",
                 "name": "Trades, transport and equipment operators occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6446,6 +6867,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_natural_resources_agriculture_canada",
                 "name": "Natural resources and agriculture occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6471,6 +6893,7 @@ export const rawStatsTree = [
             {
                 "id": "occupation_manufacturing_utilities_canada",
                 "name": "Manufacturing and utilities occupations % [StatCan]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6502,6 +6925,10 @@ export const rawStatsTree = [
             {
                 "id": "sors_unpartnered_householder",
                 "name": "Not Cohabiting With Partner %",
+                "subcategory": {
+                    "id": "household_relationship",
+                    "name": "Household Relationship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6527,6 +6954,10 @@ export const rawStatsTree = [
             {
                 "id": "sors_cohabiting_partnered_gay",
                 "name": "Cohabiting With Partner (Gay) %",
+                "subcategory": {
+                    "id": "household_relationship",
+                    "name": "Household Relationship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6552,6 +6983,10 @@ export const rawStatsTree = [
             {
                 "id": "sors_cohabiting_partnered_straight",
                 "name": "Cohabiting With Partner (Straight) %",
+                "subcategory": {
+                    "id": "household_relationship",
+                    "name": "Household Relationship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6577,6 +7012,10 @@ export const rawStatsTree = [
             {
                 "id": "sors_child",
                 "name": "Living With Parents %",
+                "subcategory": {
+                    "id": "household_relationship",
+                    "name": "Household Relationship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6602,6 +7041,10 @@ export const rawStatsTree = [
             {
                 "id": "sors_other",
                 "name": "Other Living Situation %",
+                "subcategory": {
+                    "id": "household_relationship",
+                    "name": "Household Relationship"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6627,6 +7070,10 @@ export const rawStatsTree = [
             {
                 "id": "marriage_never_married",
                 "name": "Never Married %",
+                "subcategory": {
+                    "id": "marital_status",
+                    "name": "Marital Status"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6660,6 +7107,10 @@ export const rawStatsTree = [
             {
                 "id": "marriage_married_not_divorced",
                 "name": "Married (not divorced) %",
+                "subcategory": {
+                    "id": "marital_status",
+                    "name": "Marital Status"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6693,6 +7144,10 @@ export const rawStatsTree = [
             {
                 "id": "marriage_divorced",
                 "name": "Divorced %",
+                "subcategory": {
+                    "id": "marital_status",
+                    "name": "Marital Status"
+                },
                 "contents": [
                     {
                         "year": 2020,
@@ -6732,6 +7187,7 @@ export const rawStatsTree = [
             {
                 "id": "us_presidential_election",
                 "name": "US Presidential Election",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2010,
@@ -6874,6 +7330,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_coalition_margin",
                 "name": "Canadian GE: 2-Coalition Margin",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -6983,6 +7440,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_lib",
                 "name": "Canadian GE: Liberal",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7092,6 +7550,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_con",
                 "name": "Canadian GE: Conservative",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7201,6 +7660,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_ndp",
                 "name": "Canadian GE: NDP",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7310,6 +7770,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_bq",
                 "name": "Canadian GE: Bloc Qu\u00e9b\u00e9cois",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7419,6 +7880,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_grn",
                 "name": "Canadian GE: Green",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7528,6 +7990,7 @@ export const rawStatsTree = [
             {
                 "id": "canada_general_election_ppc",
                 "name": "Canadian GE: PPC",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7609,6 +8072,7 @@ export const rawStatsTree = [
             {
                 "id": "metadata_show_metadata_congressional_representatives",
                 "name": "Congressional Representatives",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": null,
@@ -7642,6 +8106,7 @@ export const rawStatsTree = [
             {
                 "id": "park_percent_1km_v2",
                 "name": "PW Mean % of parkland within 1km",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7667,6 +8132,7 @@ export const rawStatsTree = [
             {
                 "id": "within_Hospital_10",
                 "name": "Within 10km of Hospital %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7692,6 +8158,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_dist_Hospital_updated",
                 "name": "Mean distance to nearest Hospital",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7717,6 +8184,7 @@ export const rawStatsTree = [
             {
                 "id": "within_Public School_2",
                 "name": "Within 2km of Public School %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7742,6 +8210,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_dist_Public School_updated",
                 "name": "Mean distance to nearest Public School",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7767,6 +8236,7 @@ export const rawStatsTree = [
             {
                 "id": "within_Airport_30",
                 "name": "Within 30km of Airport %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7792,6 +8262,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_dist_Airport_updated",
                 "name": "Mean distance to nearest Airport",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7817,6 +8288,7 @@ export const rawStatsTree = [
             {
                 "id": "within_Active Superfund Site_10",
                 "name": "Within 10km of Active Superfund Site %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7842,6 +8314,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_dist_Active Superfund Site_updated",
                 "name": "Mean distance to nearest Active Superfund Site",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7867,6 +8340,7 @@ export const rawStatsTree = [
             {
                 "id": "lapophalfshare_usda_fra_1",
                 "name": "Within 0.5mi of a grocery store %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7892,6 +8366,7 @@ export const rawStatsTree = [
             {
                 "id": "lapop1share_usda_fra_1",
                 "name": "Within 1mi of a grocery store %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7917,6 +8392,7 @@ export const rawStatsTree = [
             {
                 "id": "lapop10share_usda_fra_1",
                 "name": "Within 10mi of a grocery store %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7942,6 +8418,7 @@ export const rawStatsTree = [
             {
                 "id": "lapop20share_usda_fra_1",
                 "name": "Within 20mi of a grocery store %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7973,6 +8450,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_4",
                 "name": "Mean high temp",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -7998,6 +8476,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_low_temp",
                 "name": "Mean low temp",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8023,6 +8502,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_heat_index_4",
                 "name": "Mean high heat index",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8048,6 +8528,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_dewpoint_4",
                 "name": "Mean high dewpt",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8073,6 +8554,7 @@ export const rawStatsTree = [
             {
                 "id": "days_above_90_4",
                 "name": "High temperature Above 90\u00b0F %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8098,6 +8580,7 @@ export const rawStatsTree = [
             {
                 "id": "days_between_40_and_90_4",
                 "name": "High temperature Between 40 and 90\u00b0F %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8123,6 +8606,7 @@ export const rawStatsTree = [
             {
                 "id": "days_below_40_4",
                 "name": "High temperature Below 40\u00b0F %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8148,6 +8632,7 @@ export const rawStatsTree = [
             {
                 "id": "days_dewpoint_70_inf_4",
                 "name": "Humid days (dewpt > 70\u00b0F) %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8173,6 +8658,7 @@ export const rawStatsTree = [
             {
                 "id": "days_dewpoint_50_70_4",
                 "name": "Non-humid, Non-dry days (50\u00b0F < dewpt < 70\u00b0F) %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8198,6 +8684,7 @@ export const rawStatsTree = [
             {
                 "id": "days_dewpoint_-inf_50_4",
                 "name": "Dry days (dewpt < 50\u00b0F) %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8223,6 +8710,7 @@ export const rawStatsTree = [
             {
                 "id": "hours_sunny_4",
                 "name": "Mean sunny hours",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8248,6 +8736,7 @@ export const rawStatsTree = [
             {
                 "id": "rainfall_4",
                 "name": "Rainfall",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8273,6 +8762,7 @@ export const rawStatsTree = [
             {
                 "id": "snowfall_4",
                 "name": "Snowfall [rain-equivalent]",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8298,6 +8788,7 @@ export const rawStatsTree = [
             {
                 "id": "wind_speed_over_10mph_4",
                 "name": "High windspeed (>10mph) days %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8323,6 +8814,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_djf",
                 "name": "Mean high temperature in Dec/Jan/Feb",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8348,6 +8840,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_mam",
                 "name": "Mean high temperature in Mar/Apr/May",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8373,6 +8866,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_jja",
                 "name": "Mean high temperature in Jun/Jul/Aug",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8398,6 +8892,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_son",
                 "name": "Mean high temperature in Sep/Oct/Nov",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8423,6 +8918,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_low_temp_djf",
                 "name": "Mean low temperature in Dec/Jan/Feb",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8448,6 +8944,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_low_temp_mam",
                 "name": "Mean low temperature in Mar/Apr/May",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8473,6 +8970,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_low_temp_jja",
                 "name": "Mean low temperature in Jun/Jul/Aug",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8498,6 +8996,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_low_temp_son",
                 "name": "Mean low temperature in Sep/Oct/Nov",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8529,6 +9028,7 @@ export const rawStatsTree = [
             {
                 "id": "internet_no_access",
                 "name": "No internet access %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8554,6 +9054,7 @@ export const rawStatsTree = [
             {
                 "id": "insurance_coverage_none",
                 "name": "Uninsured %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8579,6 +9080,7 @@ export const rawStatsTree = [
             {
                 "id": "insurance_coverage_govt",
                 "name": "Public Insurance %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8604,6 +9106,7 @@ export const rawStatsTree = [
             {
                 "id": "insurance_coverage_private",
                 "name": "Private Insurance %",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8635,6 +9138,7 @@ export const rawStatsTree = [
             {
                 "id": "metadata_show_metadata_fips",
                 "name": "FIPS",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": null,
@@ -8662,6 +9166,7 @@ export const rawStatsTree = [
             {
                 "id": "metadata_show_metadata_statcan_geocode",
                 "name": "StatCan GeoCode",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": null,
@@ -8689,6 +9194,7 @@ export const rawStatsTree = [
             {
                 "id": "metadata_show_metadata_iso_code",
                 "name": "ISO Code",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": null,
@@ -8722,6 +9228,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_0.25",
                 "name": "PW Density (r=250m)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8837,6 +9344,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_0.5",
                 "name": "PW Density (r=500m)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -8952,6 +9460,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_1.609344",
                 "name": "PW Density (r=1mi)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9075,6 +9584,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_2",
                 "name": "PW Density (r=2km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9198,6 +9708,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_4",
                 "name": "PW Density (r=4km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9321,6 +9832,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_8",
                 "name": "PW Density (r=8km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9444,6 +9956,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_16",
                 "name": "PW Density (r=16km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9567,6 +10080,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_32",
                 "name": "PW Density (r=32km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9690,6 +10204,7 @@ export const rawStatsTree = [
             {
                 "id": "ad_64",
                 "name": "PW Density (r=64km)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9819,6 +10334,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_summer_4",
                 "name": "Mean high temperature in summer",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9844,6 +10360,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_winter_4",
                 "name": "Mean high temperature in winter",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9869,6 +10386,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_fall_4",
                 "name": "Mean high temperature in fall",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9894,6 +10412,7 @@ export const rawStatsTree = [
             {
                 "id": "mean_high_temp_spring_4",
                 "name": "Mean high temperature in spring",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9919,6 +10438,7 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_car",
                 "name": "Commute Car % (incl WFH)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9944,6 +10464,7 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_bike",
                 "name": "Commute Bike % (incl WFH)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9969,6 +10490,7 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_walk",
                 "name": "Commute Walk % (incl WFH)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -9994,6 +10516,7 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_transit",
                 "name": "Commute Transit % (incl WFH)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,
@@ -10019,6 +10542,7 @@ export const rawStatsTree = [
             {
                 "id": "transportation_means_worked_at_home",
                 "name": "Commute Work From Home % (incl WFH)",
+                "subcategory": null,
                 "contents": [
                     {
                         "year": 2020,

--- a/react/src/page_template/settings-vector.ts
+++ b/react/src/page_template/settings-vector.ts
@@ -4,7 +4,7 @@
 
 import * as base58 from 'base58-js'
 
-import { defaultSettingsList, RelationshipKey, Settings, SettingsDictionary, StatCategorySavedIndeterminateKey, useSettings } from './settings'
+import { defaultSettingsList, RelationshipKey, Settings, SettingsDictionary, StatCategorySavedIndeterminateKey, StatSubcategorySavedIndeterminateKey, useSettings } from './settings'
 
 const underflow = Symbol()
 
@@ -504,6 +504,7 @@ const settingsVector = [
 type NotIncludedInSettingsVector = (
     RelationshipKey
     | StatCategorySavedIndeterminateKey
+    | StatSubcategorySavedIndeterminateKey
     | 'theme' | 'colorblind_mode' | 'clean_background'
     | 'juxtastatCompactEmoji' | 'syauRequireEnter' | 'mapperSettingsColumnProp'
     | 'randomFilterByCurrentUniverse'

--- a/react/src/page_template/settings.ts
+++ b/react/src/page_template/settings.ts
@@ -10,7 +10,7 @@ import type { UnitSettings } from '../utils/quantity'
 import { useObserverSets } from '../utils/useObserverSets'
 
 import { Theme } from './color-themes'
-import { allGroups, allYears, CategoryIdentifier, DataSource, GroupIdentifier, SourceCategoryIdentifier, StatPath, statsTree, Year } from './statistic-tree'
+import { allGroups, allSubcategories, allYears, CategoryIdentifier, DataSource, GroupIdentifier, SourceCategoryIdentifier, StatPath, statsTree, SubcategoryIdentifier, Year } from './statistic-tree'
 
 export type RelationshipKey = `related__${string}__${string}`
 
@@ -25,6 +25,7 @@ export type PlotMode = 'monthly_time_series' | 'temperature_histogram'
 
 export type StatGroupKey<G extends GroupIdentifier = GroupIdentifier> = `show_stat_group_${G}`
 export type StatCategorySavedIndeterminateKey<C extends CategoryIdentifier = CategoryIdentifier> = `stat_category_saved_indeterminate_${C}`
+export type StatSubcategorySavedIndeterminateKey<S extends SubcategoryIdentifier = SubcategoryIdentifier> = `stat_subcategory_saved_indeterminate_${S}`
 export type StatYearKey<Y extends Year = Year> = `show_stat_year_${Y}`
 // D extends unknown is vacuous, this is a trick to make sure that D['category'] and D['name'] are coupled
 // so we don't end up with a cartesian product.
@@ -57,6 +58,7 @@ export type SettingsDictionary = {
 /* eslint-enable no-restricted-syntax */
 & { [G in GroupIdentifier as StatGroupKey<G>]: boolean }
 & { [C in CategoryIdentifier as StatCategorySavedIndeterminateKey<C>]: GroupIdentifier[] }
+& { [S in SubcategoryIdentifier as StatSubcategorySavedIndeterminateKey<S>]: GroupIdentifier[] }
 & { [Y in Year as StatYearKey<Y>]: boolean }
 & { [D in DataSource as StatSourceKey<D>]: boolean }
 & { [P in StatPathWithExtra as RowExpandedKey<P>]: boolean }
@@ -91,6 +93,7 @@ export const defaultSettingsList = [
     ),
     ...allGroups.map(group => [`show_stat_group_${group.id}` as const, defaultCategorySelections.has(group.parent.id)] as const),
     ...statsTree.map(category => [`stat_category_saved_indeterminate_${category.id}` as const, [] as GroupIdentifier[]] as const),
+    ...allSubcategories.map(subcategory => [`stat_subcategory_saved_indeterminate_${subcategory.id}` as const, [] as GroupIdentifier[]] as const),
     ...allYears.map(year => [`show_stat_year_${year}` as const, defaultEnabledYears.has(year)] as const),
     ...dataSources
         .flatMap(({ sources }) => sources

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -3,8 +3,8 @@ import { useContext, useMemo, useState } from 'react'
 import { dataSources } from '../data/statistics_tree'
 import { Navigator } from '../navigation/Navigator'
 
-import { isStagedChange, Settings, settingValue, sourceEnabledKey, StatGroupKey, StatYearKey, StatSourceKey, useSettings, useSettingsInfo } from './settings'
-import { allGroups, allYears, AmbiguousSources, Category, DataSource, DataSourceCheckboxes, findAmbiguousSourcesAll, Group, SourceIdentifier, sourceDisambiguation, statParents, StatPath, statsTree, Year, yearStatPaths } from './statistic-tree'
+import { isStagedChange, Settings, settingValue, sourceEnabledKey, StatCategorySavedIndeterminateKey, StatGroupKey, StatYearKey, StatSourceKey, StatSubcategorySavedIndeterminateKey, useSettings, useSettingsInfo } from './settings'
+import { allGroups, allYears, AmbiguousSources, Category, DataSource, DataSourceCheckboxes, findAmbiguousSourcesAll, Group, sectionsOf, SourceIdentifier, sourceDisambiguation, statParents, StatPath, statsTree, Subcategory, Year, yearStatPaths } from './statistic-tree'
 
 export type StatGroupSettings = Record<StatGroupKey | StatYearKey | StatSourceKey, boolean>
 
@@ -65,7 +65,7 @@ export function useVisibleRows<T>(rows: (settings: StatGroupSettings) => T, show
     )
 }
 
-function categoryStatus(enabled: boolean[]): boolean | 'indeterminate' {
+function checkboxStatus(enabled: boolean[]): boolean | 'indeterminate' {
     const checkedGroups = enabled.filter(value => value).length
 
     switch (checkedGroups) {
@@ -78,15 +78,31 @@ function categoryStatus(enabled: boolean[]): boolean | 'indeterminate' {
     }
 }
 
+/** A tri-state checkbox standing for the groups underneath it. */
+type StatNode = Category | Subcategory
+
+function nodeGroups(node: StatNode): Group[] {
+    return node.kind === 'Category' ? node.contents : node.parent.contents.filter(group => group.subcategory === node)
+}
+
+function savedIndeterminateKey(node: StatNode): StatCategorySavedIndeterminateKey | StatSubcategorySavedIndeterminateKey {
+    return node.kind === 'Category'
+        ? `stat_category_saved_indeterminate_${node.id}`
+        : `stat_subcategory_saved_indeterminate_${node.id}`
+}
+
 function changeStatGroupSetting(settings: Settings, group: Group, newValue: boolean): void {
     settings.setSetting(`show_stat_group_${group.id}`, newValue)
     saveIndeterminateState(settings, group.parent)
+    if (group.subcategory !== undefined) {
+        saveIndeterminateState(settings, group.subcategory)
+    }
 }
 
-function saveIndeterminateState(settings: Settings, category: Category): void {
+function saveIndeterminateState(settings: Settings, node: StatNode): void {
     settings.setSetting(
-        `stat_category_saved_indeterminate_${category.id}`,
-        category.contents
+        savedIndeterminateKey(node),
+        nodeGroups(node)
             .map(group => group.id)
             .filter(id => settings.get(`show_stat_group_${id}`)),
     )
@@ -136,10 +152,11 @@ export function useExpansionState(): ExpansionState {
  * indeterminate -> checked -> unchecked -(if nonempty saved indeterminate)-> indeterminate
  *                                       -(if empty saved indeterminate)-> checked
  */
-function toggleCategorySetting(settings: Settings, expansion: ExpansionState, category: Category, availableGroups: Group[], status: boolean | 'indeterminate'): void {
+function toggleNodeSetting(settings: Settings, expansion: ExpansionState, node: StatNode, availableGroups: Group[], status: boolean | 'indeterminate'): void {
     const setAllGroups = (value: (group: Group) => boolean): void => {
-        category.contents.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, value(group)) })
+        nodeGroups(node).forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, value(group)) })
     }
+    const category = node.kind === 'Category' ? node : node.parent
     const expandCategory = (): void => { expansion.setExpanded(category, true) }
     switch (status) {
         case 'indeterminate':
@@ -150,7 +167,7 @@ function toggleCategorySetting(settings: Settings, expansion: ExpansionState, ca
             setAllGroups(() => false)
             break
         case false:
-            const savedDeterminate = new Set(settings.get(`stat_category_saved_indeterminate_${category.id}`))
+            const savedDeterminate = new Set(settings.get(savedIndeterminateKey(node)))
             // The saved state can refer to groups that don't exist on this page, which would restore nothing
             if (availableGroups.every(group => !savedDeterminate.has(group.id))) {
                 setAllGroups(() => true)
@@ -161,6 +178,9 @@ function toggleCategorySetting(settings: Settings, expansion: ExpansionState, ca
             expandCategory() // Either way should expand to show the selection
             break
     }
+    if (node.kind === 'Subcategory') {
+        saveIndeterminateState(settings, category)
+    }
 }
 
 export interface GroupTreeState {
@@ -170,13 +190,25 @@ export interface GroupTreeState {
     highlight: boolean
 }
 
+export interface SubcategoryTreeState {
+    subcategory: Subcategory
+    status: boolean | 'indeterminate'
+    toggle: () => void
+    highlight: boolean
+    groups: GroupTreeState[]
+}
+
+export type SectionTreeState =
+    { kind: 'Group', group: GroupTreeState } |
+    ({ kind: 'Subcategory' } & SubcategoryTreeState)
+
 export interface CategoryTreeState {
     status: boolean | 'indeterminate'
     toggle: () => void
     highlight: boolean
     expanded: boolean
     setExpanded: (expanded: boolean) => void
-    groups: GroupTreeState[]
+    sections: SectionTreeState[]
 }
 
 export function useCategoryTreeState(category: Category, expansion: ExpansionState): CategoryTreeState {
@@ -184,22 +216,39 @@ export function useCategoryTreeState(category: Category, expansion: ExpansionSta
     const availableGroups = useAvailableGroups(category)
     const info = useSettingsInfo(groupKeys(availableGroups))
 
-    const groups = availableGroups.map(group => ({
+    const groupState = (group: Group): GroupTreeState => ({
         group,
         enabled: settingValue(info[`show_stat_group_${group.id}`]),
         setEnabled: (newValue: boolean) => { changeStatGroupSetting(settings, group, newValue) },
         highlight: isStagedChange(info[`show_stat_group_${group.id}`]),
-    }))
+    })
 
-    const status = categoryStatus(groups.map(group => group.enabled))
+    const sections = sectionsOf(availableGroups).map((section): SectionTreeState => {
+        if (section.kind === 'Group') {
+            return { kind: 'Group', group: groupState(section.group) }
+        }
+        const groups = section.groups.map(groupState)
+        const status = checkboxStatus(groups.map(group => group.enabled))
+        return {
+            kind: 'Subcategory',
+            subcategory: section.subcategory,
+            status,
+            toggle: () => { toggleNodeSetting(settings, expansion, section.subcategory, section.groups, status) },
+            highlight: groups.some(group => group.highlight),
+            groups,
+        }
+    })
+
+    const enabled = sections.flatMap(section => section.kind === 'Group' ? [section.group.enabled] : section.groups.map(group => group.enabled))
+    const status = checkboxStatus(enabled)
 
     return {
         status,
-        toggle: () => { toggleCategorySetting(settings, expansion, category, availableGroups, status) },
-        highlight: groups.some(group => group.highlight),
+        toggle: () => { toggleNodeSetting(settings, expansion, category, availableGroups, status) },
+        highlight: sections.some(section => section.kind === 'Group' ? section.group.highlight : section.highlight),
         expanded: expansion.isExpanded(category),
         setExpanded: (newValue: boolean) => { expansion.setExpanded(category, newValue) },
-        groups,
+        sections,
     }
 }
 
@@ -209,9 +258,10 @@ function searchMatch(searchTerm: string, target: string): boolean {
 
 /**
  * A category whose own name matches is kept whole; otherwise it is narrowed to its matching
- * groups. Narrowing scopes everything downstream (including useCategoryTreeState) to those
- * groups, so while searching, the category checkbox acts on what's visible rather than on
- * the groups the search is hiding.
+ * groups, a subcategory whose name matches counting as a match for all of its groups. Narrowing
+ * scopes everything downstream (including useCategoryTreeState) to those groups, so while
+ * searching, the category checkbox acts on what's visible rather than on the groups the search
+ * is hiding.
  */
 export function useCategoriesMatchingSearch(searchTerm: string): Category[] {
     const { categories, groups } = useAvailableTree()
@@ -219,7 +269,8 @@ export function useCategoriesMatchingSearch(searchTerm: string): Category[] {
         if (searchMatch(searchTerm, category.name)) {
             return [category]
         }
-        const contents = category.contents.filter(group => groups.has(group) && searchMatch(searchTerm, group.name))
+        const contents = category.contents.filter(group => groups.has(group)
+            && (searchMatch(searchTerm, group.name) || (group.subcategory !== undefined && searchMatch(searchTerm, group.subcategory.name))))
         return contents.length > 0 ? [{ ...category, contents }] : []
     })
 }
@@ -255,11 +306,11 @@ export type MissingGroupReason =
     ({ kind: 'yearAndSource', years: Year[] } & MissingSources)
 
 export interface MissingGroup {
-    groupOrCategory: Group | Category
+    groupOrCategory: Group | Subcategory | Category
     reason: MissingGroupReason
 }
 
-/** Groups only consolidate into their category when their warnings would read identically. */
+/** Groups only consolidate into their subcategory or category when their warnings would read identically. */
 function reasonKey(reason: MissingGroupReason): string {
     switch (reason.kind) {
         case 'year':
@@ -396,13 +447,14 @@ export function useMissingGroupReasonsOfEveryGroup(): { group: Group, reason: Mi
 }
 
 /**
- * If all of the groups in a category are present in-order in the list, replace them with that category
+ * If all of the groups in a category are present in-order in the list, replace them with that category;
+ * otherwise do the same for each of its subcategories.
  *
  * `groups` **must** be a subset of available groups
  */
-function consolidateGroupsIn({ categories: availableCategories, groups: availableGroups }: AvailableTree): (groups: Group[]) => (Group | Category)[] {
+function consolidateGroupsIn({ categories: availableCategories, groups: availableGroups }: AvailableTree): (groups: Group[]) => (Group | Subcategory | Category)[] {
     return (groups) => {
-        const result: (Group | Category)[] = []
+        const result: (Group | Subcategory | Category)[] = []
         let indexOfGroup = 0
         for (const category of availableCategories) {
             const categoryContents = category.contents.filter(group => availableGroups.has(group))
@@ -418,8 +470,8 @@ function consolidateGroupsIn({ categories: availableCategories, groups: availabl
                 result.push(category)
             }
             else {
-                // If not, push all the groups we iterated through
-                result.push(...groups.slice(startIndexOfGroup, indexOfGroup))
+                // If not, push all the groups we iterated through, consolidated a level down
+                result.push(...consolidateSubcategories(groups.slice(startIndexOfGroup, indexOfGroup), categoryContents))
             }
             if (indexOfGroup > groups.length) {
                 throw new Error('Something has gone terribly wrong')
@@ -428,6 +480,27 @@ function consolidateGroupsIn({ categories: availableCategories, groups: availabl
         result.push(...groups.slice(indexOfGroup))
         return result
     }
+}
+
+/** The same, one level down: a run covering all of a subcategory's available groups becomes that subcategory. */
+function consolidateSubcategories(groups: Group[], categoryContents: Group[]): (Group | Subcategory)[] {
+    const availableIn = new Map(sectionsOf(categoryContents)
+        .flatMap(section => section.kind === 'Subcategory' ? [[section.subcategory, section.groups] as const] : []))
+    const result: (Group | Subcategory)[] = []
+    let index = 0
+    while (index < groups.length) {
+        const subcategory = groups[index].subcategory
+        const contents = subcategory === undefined ? undefined : availableIn.get(subcategory)
+        if (subcategory !== undefined && contents?.every((group, offset) => groups[index + offset] === group)) {
+            result.push(subcategory)
+            index += contents.length
+        }
+        else {
+            result.push(groups[index])
+            index++
+        }
+    }
+    return result
 }
 
 /**

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -166,15 +166,17 @@ export function useExpansionState(): ExpansionState {
  * indeterminate -> checked -> unchecked -(if nonempty saved indeterminate)-> indeterminate
  *                                       -(if empty saved indeterminate)-> checked
  */
-function toggleNodeSetting(settings: Settings, expansion: ExpansionState, node: StatNode, availableGroups: Group[], status: boolean | 'indeterminate'): void {
+function toggleNodeSetting(settings: Settings, expansion: ExpansionState, category: Category, subcategory: Subcategory | undefined, availableGroups: Group[], status: boolean | 'indeterminate'): void {
+    const node: StatNode = subcategory ?? category
+    // Via the given category, which a search may have narrowed, not nodeGroups' whole-tree view
+    const toggledGroups = category.contents.filter(group => subcategory === undefined || group.subcategory === subcategory)
     const setAllGroups = (value: (group: Group) => boolean): void => {
-        nodeGroups(node).forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, value(group)) })
+        toggledGroups.forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, value(group)) })
     }
-    const category = node.kind === 'Category' ? node : node.parent
     const expandCategory = (): void => {
         expansion.setExpanded(category, true)
-        if (node.kind === 'Subcategory') {
-            expansion.setExpanded(node, true)
+        if (subcategory !== undefined) {
+            expansion.setExpanded(subcategory, true)
         }
     }
     switch (status) {
@@ -197,8 +199,8 @@ function toggleNodeSetting(settings: Settings, expansion: ExpansionState, node: 
             expandCategory() // Either way should expand to show the selection
             break
     }
-    if (node.kind === 'Subcategory') {
-        saveIndeterminateState(settings, category)
+    if (subcategory !== undefined) {
+        saveIndeterminateState(settings, subcategory.parent)
     }
 }
 
@@ -254,7 +256,7 @@ export function useCategoryTreeState(category: Category, expansion: ExpansionSta
             kind: 'Subcategory',
             subcategory: section.subcategory,
             status,
-            toggle: () => { toggleNodeSetting(settings, expansion, section.subcategory, section.groups, status) },
+            toggle: () => { toggleNodeSetting(settings, expansion, category, section.subcategory, section.groups, status) },
             highlight: groups.some(group => group.highlight),
             expanded: expansion.isExpanded(section.subcategory),
             setExpanded: (newValue: boolean) => { expansion.setExpanded(section.subcategory, newValue) },
@@ -267,7 +269,7 @@ export function useCategoryTreeState(category: Category, expansion: ExpansionSta
 
     return {
         status,
-        toggle: () => { toggleNodeSetting(settings, expansion, category, availableGroups, status) },
+        toggle: () => { toggleNodeSetting(settings, expansion, category, undefined, availableGroups, status) },
         highlight: sections.some(section => section.kind === 'Group' ? section.group.highlight : section.highlight),
         expanded: expansion.isExpanded(category),
         setExpanded: (newValue: boolean) => { expansion.setExpanded(category, newValue) },

--- a/react/src/page_template/statistic-settings.ts
+++ b/react/src/page_template/statistic-settings.ts
@@ -109,36 +109,50 @@ function saveIndeterminateState(settings: Settings, node: StatNode): void {
 }
 
 export interface ExpansionState {
-    isExpanded: (category: Category) => boolean
-    setExpanded: (category: Category, expanded: boolean) => void
+    isExpanded: (node: StatNode) => boolean
+    setExpanded: (node: StatNode, expanded: boolean) => void
+}
+
+function expansionKey(node: StatNode): string {
+    return `${node.kind}_${node.id}`
 }
 
 /**
- * Which categories are open, for as long as edit mode lasts. A category starts open when it has a
- * selected group, or one staging is changing, which a closed category would hide.
+ * Which categories and subcategories are open, for as long as edit mode lasts. A node starts open
+ * when it has a selected group, or one staging is changing, which a closed node would hide.
  */
 export function useExpansionState(): ExpansionState {
     const settings = useContext(Settings.Context)
     const { categories, groups: availableGroups } = useAvailableTree()
-    const [expanded, setExpanded] = useState(() => new Set(categories
-        .filter(category => category.contents.some((group) => {
-            if (!availableGroups.has(group)) {
-                return false
+    const [expanded, setExpanded] = useState(() => {
+        const open = new Set<string>()
+        for (const category of categories) {
+            for (const group of category.contents) {
+                if (!availableGroups.has(group)) {
+                    continue
+                }
+                const info = settings.getSettingInfo(`show_stat_group_${group.id}`)
+                if (!settingValue(info) && !isStagedChange(info)) {
+                    continue
+                }
+                open.add(expansionKey(category))
+                if (group.subcategory !== undefined) {
+                    open.add(expansionKey(group.subcategory))
+                }
             }
-            const info = settings.getSettingInfo(`show_stat_group_${group.id}`)
-            return settingValue(info) || isStagedChange(info)
-        }))
-        .map(category => category.id)))
+        }
+        return open
+    })
     return {
-        isExpanded: category => expanded.has(category.id),
-        setExpanded: (category, value) => {
+        isExpanded: node => expanded.has(expansionKey(node)),
+        setExpanded: (node, value) => {
             setExpanded((current) => {
                 const next = new Set(current)
                 if (value) {
-                    next.add(category.id)
+                    next.add(expansionKey(node))
                 }
                 else {
-                    next.delete(category.id)
+                    next.delete(expansionKey(node))
                 }
                 return next
             })
@@ -157,7 +171,12 @@ function toggleNodeSetting(settings: Settings, expansion: ExpansionState, node: 
         nodeGroups(node).forEach((group) => { settings.setSetting(`show_stat_group_${group.id}`, value(group)) })
     }
     const category = node.kind === 'Category' ? node : node.parent
-    const expandCategory = (): void => { expansion.setExpanded(category, true) }
+    const expandCategory = (): void => {
+        expansion.setExpanded(category, true)
+        if (node.kind === 'Subcategory') {
+            expansion.setExpanded(node, true)
+        }
+    }
     switch (status) {
         case 'indeterminate':
             setAllGroups(() => true)
@@ -195,6 +214,8 @@ export interface SubcategoryTreeState {
     status: boolean | 'indeterminate'
     toggle: () => void
     highlight: boolean
+    expanded: boolean
+    setExpanded: (expanded: boolean) => void
     groups: GroupTreeState[]
 }
 
@@ -235,6 +256,8 @@ export function useCategoryTreeState(category: Category, expansion: ExpansionSta
             status,
             toggle: () => { toggleNodeSetting(settings, expansion, section.subcategory, section.groups, status) },
             highlight: groups.some(group => group.highlight),
+            expanded: expansion.isExpanded(section.subcategory),
+            setExpanded: (newValue: boolean) => { expansion.setExpanded(section.subcategory, newValue) },
             groups,
         }
     })

--- a/react/src/page_template/statistic-tree.ts
+++ b/react/src/page_template/statistic-tree.ts
@@ -15,6 +15,7 @@ export type StatName = (typeof statNames)[number]
 
 export type CategoryIdentifier = (typeof rawStatsTree)[number]['id']
 export type GroupIdentifier = (typeof rawStatsTree)[number]['contents'][number]['id']
+export type SubcategoryIdentifier = NonNullable<(typeof rawStatsTree)[number]['contents'][number]['subcategory']>['id']
 export type Year = Exclude<(typeof rawStatsTree)[number]['contents'][number]['contents'][number]['year'], null>
 export type DataSource = (typeof rawStatsTree)[number]['contents'][number]['contents'][number]['stats_by_source'][number]['stats'][number]['source']
 export type SourceCategoryIdentifier = DataSource['category']
@@ -30,12 +31,21 @@ export interface Category {
     statPaths: Set<StatPath> // which StatPaths does this category contain
 }
 
+export interface Subcategory {
+    kind: 'Subcategory'
+    id: SubcategoryIdentifier
+    name: string
+    parent: Category
+    statPaths: Set<StatPath> // which StatPaths does this subcategory contain
+}
+
 export interface Group {
     kind: 'Group'
     id: GroupIdentifier
     name: string
     contents: GroupYear[]
     parent: Category
+    subcategory?: Subcategory
     years: Set<Year | null> // for which years does this group have data
     statPaths: Set<StatPath> // which StatPaths does this group contain
 }
@@ -74,51 +84,74 @@ export interface MetadataStatistic extends BaseStatistic {
 
 export type Statistic = DataStatistic | MetadataStatistic
 
-export const statsTree: StatsTree = rawStatsTree.map(category => (
-    {
+export const statsTree: StatsTree = rawStatsTree.map((category) => {
+    const groups: Group[] = category.contents.map(group => ({
+        kind: 'Group',
+        id: group.id,
+        name: group.name,
+        contents: group.contents.map(({ year, stats_by_source }) => ({
+            year,
+            stats: stats_by_source.map(({ name, indentedName, stats: s }) => ({
+                name,
+                indentedName: indentedName ?? undefined,
+                bySource: s.map((stat) => {
+                    switch (stat.kind) {
+                        case 'data':
+                            return {
+                                kind: 'data',
+                                source: stat.source,
+                                path: statPaths[stat.column],
+                                name: statNames[stat.column],
+                                statcol: stats[stat.column],
+                                parent: undefined as unknown as GroupYear, // set below
+                            } satisfies DataStatistic
+                        case 'metadata':
+                            return {
+                                kind: 'metadata',
+                                source: stat.source,
+                                path: stat.path,
+                                name,
+                                metadataIndex: stat.metadata_index,
+                                parent: undefined as unknown as GroupYear, // set below
+                            } satisfies MetadataStatistic
+                    }
+                }),
+            } satisfies MultiSourceStatistic)),
+            parent: undefined as unknown as Group, // set below
+        } satisfies GroupYear)),
+        parent: undefined as unknown as Category, // set below
+        years: new Set(group.contents.map(({ year }) => year)),
+        statPaths: new Set(), // set below
+    } satisfies Group))
+
+    // A run of groups tagged with the same subcategory is that subcategory
+    let subcategory: Subcategory | undefined
+    category.contents.forEach((rawGroup, index) => {
+        if (rawGroup.subcategory === null) {
+            subcategory = undefined
+            return
+        }
+        if (subcategory?.id !== rawGroup.subcategory.id) {
+            subcategory = {
+                kind: 'Subcategory',
+                id: rawGroup.subcategory.id,
+                name: rawGroup.subcategory.name,
+                parent: undefined as unknown as Category, // set below
+                statPaths: new Set(), // set below
+            }
+        }
+        groups[index].subcategory = subcategory
+    })
+
+    return {
         kind: 'Category',
-        ...category,
-        contents: category.contents.map(group => ({
-            kind: 'Group',
-            ...group,
-            contents: group.contents.map(({ year, stats_by_source }) => ({
-                year,
-                stats: stats_by_source.map(({ name, indentedName, stats: s }) => ({
-                    name,
-                    indentedName: indentedName ?? undefined,
-                    bySource: s.map((stat) => {
-                        switch (stat.kind) {
-                            case 'data':
-                                return {
-                                    kind: 'data',
-                                    source: stat.source,
-                                    path: statPaths[stat.column],
-                                    name: statNames[stat.column],
-                                    statcol: stats[stat.column],
-                                    parent: undefined as unknown as GroupYear, // set below
-                                } satisfies DataStatistic
-                            case 'metadata':
-                                return {
-                                    kind: 'metadata',
-                                    source: stat.source,
-                                    path: stat.path,
-                                    name,
-                                    metadataIndex: stat.metadata_index,
-                                    parent: undefined as unknown as GroupYear, // set below
-                                } satisfies MetadataStatistic
-                        }
-                    }),
-                } satisfies MultiSourceStatistic)),
-                parent: undefined as unknown as Group, // set below
-            } satisfies GroupYear)),
-            parent: undefined as unknown as Category, // set below
-            years: new Set(group.contents.map(({ year }) => year)),
-            statPaths: new Set(), // set below
-        } satisfies Group)),
+        id: category.id,
+        name: category.name,
+        contents: groups,
         years: new Set(), // set below
         statPaths: new Set(), // set below
     } satisfies Category
-))
+})
 
 // For a given year, what statpaths does it include
 export const yearStatPaths = new DefaultMap<Year, Set<StatPath>>(() => new Set())
@@ -127,12 +160,16 @@ export const yearStatPaths = new DefaultMap<Year, Set<StatPath>>(() => new Set()
 for (const category of statsTree) {
     for (const group of category.contents) {
         group.parent = category
+        if (group.subcategory !== undefined) {
+            group.subcategory.parent = category
+        }
         for (const yearGroup of group.contents) {
             yearGroup.parent = group
             for (const statsBySource of yearGroup.stats) {
                 for (const stat of statsBySource.bySource) {
                     stat.parent = yearGroup
                     group.statPaths.add(stat.path)
+                    group.subcategory?.statPaths.add(stat.path)
                     category.statPaths.add(stat.path)
                     if (yearGroup.year !== null) {
                         yearStatPaths.get(yearGroup.year).add(stat.path)
@@ -149,6 +186,31 @@ function sortYears(year1: Year, year2: Year): number {
 }
 
 export const allGroups = statsTree.flatMap(category => category.contents)
+export const allSubcategories = Array.from(new Set(allGroups.flatMap(group => group.subcategory ?? [])))
+
+export type Section = { kind: 'Group', group: Group } | { kind: 'Subcategory', subcategory: Subcategory, groups: Group[] }
+
+/**
+ * Lays out a category's groups for display, gathering each run of groups that share a subcategory.
+ * Takes the groups rather than reading the category so that a narrowed list (by availability, or
+ * by a search) produces subcategories holding only the groups that survived.
+ */
+export function sectionsOf(groups: Group[]): Section[] {
+    const sections: Section[] = []
+    for (const group of groups) {
+        const last = sections.at(-1)
+        if (group.subcategory === undefined) {
+            sections.push({ kind: 'Group', group })
+        }
+        else if (last?.kind === 'Subcategory' && last.subcategory === group.subcategory) {
+            last.groups.push(group)
+        }
+        else {
+            sections.push({ kind: 'Subcategory', subcategory: group.subcategory, groups: [group] })
+        }
+    }
+    return sections
+}
 export const allYears = Array.from(
     new Set(allGroups
         .flatMap(group => Array.from(group.years))

--- a/react/test/article_edit_tree_test_template.ts
+++ b/react/test/article_edit_tree_test_template.ts
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe'
 
-import { categoryCheckbox, categoryToggleButton, enterEditMode, exitEditMode, filterBox, groupCheckbox, groupMemberRow, groupWarning, interactableGroupCheckbox, setCategoryExpanded, sourceCheckbox, yearCheckbox } from './edit_mode_test_utils'
+import { categoryCheckbox, categoryToggleButton, enterEditMode, exitEditMode, filterBox, groupCheckbox, groupMemberRow, groupWarning, interactableGroupCheckbox, setCategoryExpanded, setSubcategoryExpanded, sourceCheckbox, subcategoryCheckbox, yearCheckbox } from './edit_mode_test_utils'
 import { clickUniverseFlag, getLocation, resizeForPlatform, safeReload, screencap, target, uncheckAllCategories, urbanstatsFixture, warningRowNames } from './test_utils'
 
 const mainCheck = categoryCheckbox('main')
@@ -19,6 +19,12 @@ const housingExpandButton = categoryToggleButton('housing', 'Expand')
 const housingCollapseButton = categoryToggleButton('housing', 'Collapse')
 const vacancyCheckInteractable = interactableGroupCheckbox('vacancy')
 const renterCheckInteractable = interactableGroupCheckbox('rent_or_own_rent')
+// Race is the category with a subcategory in it (the races, which add to 100%) alongside
+// groups that are in none (the segregation statistics).
+const raceCheck = categoryCheckbox('race')
+const raceCompositionCheck = subcategoryCheckbox('race_composition')
+const hispanicCheckInteractable = interactableGroupCheckbox('hispanic')
+const segregationCheckInteractable = interactableGroupCheckbox('homogeneity_250')
 const sourceSectionHeader = Selector('.stats_table div').withExactText('Population Sources')
 const ghslCheck = sourceCheckbox('Population', 'GHSL')
 const year2020Check = yearCheckbox(2020)
@@ -111,6 +117,72 @@ export function articleEditTreeTest(platform: 'mobile' | 'desktop'): void {
         await t.expect(mainCheck.checked).eql(false)
         await t.expect(mainCollapseButton.exists).ok()
         await t.expect(populationCheckInteractable.exists).ok()
+    })
+
+    test('subcategory-check-selects-its-groups', async (t) => {
+        /**
+         * The subcategory checkbox stands for its groups the way a category's does, so checking
+         * it leaves the category itself indeterminate -- the segregation groups are still off.
+         */
+        await enterEditMode(t)
+        await setCategoryExpanded(t, 'race', true)
+        await t.expect(raceCompositionCheck.checked).eql(false)
+
+        await t.click(raceCompositionCheck)
+        await t.expect(raceCompositionCheck.checked).eql(true)
+        await t.expect(hispanicCheckInteractable.checked).eql(true)
+        await t.expect(raceCheck.indeterminate).eql(true)
+    })
+
+    test('subcategory-expands-independently-of-its-category', async (t) => {
+        /**
+         * An expanded category shows the subcategory header, not the groups behind it, so a
+         * category of pie charts doesn't unfold into dozens of rows at once.
+         */
+        await enterEditMode(t)
+        await setCategoryExpanded(t, 'race', true)
+        await t.expect(segregationCheckInteractable.exists).ok()
+        await t.expect(hispanicCheckInteractable.exists).notOk()
+
+        await setSubcategoryExpanded(t, 'race_composition', true)
+        await t.expect(hispanicCheckInteractable.exists).ok()
+        await screencap(t)
+
+        // Collapsing the category still takes the whole subcategory with it.
+        await setCategoryExpanded(t, 'race', false)
+        await t.expect(hispanicCheckInteractable.exists).notOk()
+    })
+
+    test('subcategory-expansion-resets-with-edit-mode', async (t) => {
+        // Like a category's, the expansion lasts only as long as edit mode does.
+        await enterEditMode(t)
+        await setCategoryExpanded(t, 'race', true)
+        await setSubcategoryExpanded(t, 'race_composition', true)
+        await exitEditMode(t)
+        await enterEditMode(t)
+        await t.expect(categoryToggleButton('race', 'Expand').exists).ok()
+        await t.expect(hispanicCheckInteractable.exists).notOk()
+    })
+
+    test('subcategory-warning-names-the-subcategory', async (t) => {
+        // One warning for the whole pie chart rather than one per race, since the category
+        // around it has groups that aren't selected and so can't stand in.
+        await enterEditMode(t)
+        await uncheckAllCategories(t)
+        await setCategoryExpanded(t, 'race', true)
+        await t.click(raceCompositionCheck)
+        await t.click(year2020Check)
+        await exitEditMode(t)
+        await t.expect(await warningRowNames()).eql(['Racial Composition'])
+    })
+
+    test('search-matches-a-subcategory-name', async (t) => {
+        // The name is on the tree, so it has to be searchable; matching it keeps the groups
+        // underneath it, which don't have "racial" in their own names.
+        await enterEditMode(t)
+        await t.typeText(filterBox, 'racial comp')
+        await t.expect(hispanicCheckInteractable.exists).ok()
+        await t.expect(segregationCheckInteractable.exists).notOk()
     })
 
     test('indeterminate-cycle-expanded', async (t) => {

--- a/react/test/article_edit_tree_test_template.ts
+++ b/react/test/article_edit_tree_test_template.ts
@@ -24,6 +24,9 @@ const renterCheckInteractable = interactableGroupCheckbox('rent_or_own_rent')
 const raceCheck = categoryCheckbox('race')
 const raceCompositionCheck = subcategoryCheckbox('race_composition')
 const hispanicCheckInteractable = interactableGroupCheckbox('hispanic')
+// eslint-disable-next-line no-restricted-syntax -- a stat group id, not a css color
+const whiteCheck = groupCheckbox('white')
+const hispanicCheck = groupCheckbox('hispanic')
 const segregationCheckInteractable = interactableGroupCheckbox('homogeneity_250')
 const sourceSectionHeader = Selector('.stats_table div').withExactText('Population Sources')
 const ghslCheck = sourceCheckbox('Population', 'GHSL')
@@ -183,6 +186,22 @@ export function articleEditTreeTest(platform: 'mobile' | 'desktop'): void {
         await t.typeText(filterBox, 'racial comp')
         await t.expect(hispanicCheckInteractable.exists).ok()
         await t.expect(segregationCheckInteractable.exists).notOk()
+    })
+
+    test('search-scopes-a-subcategory-checkbox-to-what-it-shows', async (t) => {
+        // Like the category checkbox, the subcategory one acts on the groups the search leaves
+        // visible rather than on the ones it is hiding.
+        await enterEditMode(t)
+        // eslint-disable-next-line no-restricted-syntax -- a stat group name, not a css color
+        await t.typeText(filterBox, 'white')
+        await t.expect(raceCompositionCheck.checked).eql(false)
+        await t.click(raceCompositionCheck)
+        await t.expect(raceCompositionCheck.checked).eql(true)
+
+        await t.selectText(filterBox).pressKey('delete')
+        await t.expect(whiteCheck.checked).eql(true)
+        await t.expect(hispanicCheck.checked).eql(false)
+        await t.expect(raceCompositionCheck.indeterminate).eql(true)
     })
 
     test('indeterminate-cycle-expanded', async (t) => {

--- a/react/test/edit_mode_staging_expansion.test.ts
+++ b/react/test/edit_mode_staging_expansion.test.ts
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe'
 
-import { categoryToggleButton, enterEditMode, filterBox, interactableGroupCheckbox, setCategoryExpanded } from './edit_mode_test_utils'
+import { categoryToggleButton, enterEditMode, filterBox, interactableGroupCheckbox, setCategoryExpanded, setSubcategoryExpanded, subcategoryToggleButton } from './edit_mode_test_utils'
 import { getLocation, target, urbanstatsFixture } from './test_utils'
 
 /**
@@ -13,6 +13,7 @@ const californiaPage = `${target}/article.html?longname=California%2C+USA`
 
 const stagingControls = Selector('[data-test-id=staging_controls]')
 const vacancy = interactableGroupCheckbox('vacancy')
+const hispanic = interactableGroupCheckbox('hispanic')
 
 let vacancyOffLink: string
 
@@ -46,4 +47,36 @@ test('the category whose only selection is staged off is expanded', async (t) =>
 
 test('categories with nothing staged behind them stay collapsed', async (t) => {
     await t.expect(categoryToggleButton('race', 'Expand').exists).ok()
+})
+
+let hispanicOffLink: string
+
+urbanstatsFixture('generate link with an unselected group inside a subcategory', californiaPage)
+
+test('a link records Hispanic as unselected', async (t) => {
+    await enterEditMode(t)
+    await setCategoryExpanded(t, 'race', true)
+    await setSubcategoryExpanded(t, 'race_composition', true)
+    await t.click(hispanic)
+    await t.click(hispanic)
+
+    hispanicOffLink = await getLocation()
+})
+
+urbanstatsFixture('visit that link with Hispanic selected', californiaPage, async (t) => {
+    await enterEditMode(t)
+    await setCategoryExpanded(t, 'race', true)
+    await setSubcategoryExpanded(t, 'race_composition', true)
+    await t.click(hispanic)
+
+    await t.navigateTo(hispanicOffLink)
+})
+
+test('the subcategory whose only selection is staged off is expanded along with its category', async (t) => {
+    await t.expect(stagingControls.exists).ok()
+    await t.expect(categoryToggleButton('race', 'Collapse').exists).ok()
+    await t.expect(subcategoryToggleButton('race_composition', 'Collapse').exists).ok()
+
+    await t.expect(hispanic.checked).notOk()
+    await t.expect(hispanic.getAttribute('data-test-highlight')).eql('true')
 })

--- a/react/test/edit_mode_test_utils.ts
+++ b/react/test/edit_mode_test_utils.ts
@@ -36,7 +36,7 @@ export async function withEditMode<T>(t: TestController, block: () => Promise<T>
  * The `data-test-id` prefix each kind of edit-tree checkbox carries. Sources use a space
  * because their id embeds the category and source names.
  */
-export const editCheckboxPrefixes = { category: 'edit_category_', group: 'edit_group_', year: 'edit_year_', source: 'edit_source ' } as const
+export const editCheckboxPrefixes = { category: 'edit_category_', subcategory: 'edit_subcategory_', group: 'edit_group_', year: 'edit_year_', source: 'edit_source ' } as const
 
 /**
  * A checkbox with its `indeterminate` state readable. It's a DOM property rather than an
@@ -51,6 +51,10 @@ function checkboxByTestId(testId: string, extraCss = ''): CheckboxSelector {
 
 export function categoryCheckbox(categoryId: string): CheckboxSelector {
     return checkboxByTestId(`${editCheckboxPrefixes.category}${categoryId}`)
+}
+
+export function subcategoryCheckbox(subcategoryId: string): CheckboxSelector {
+    return checkboxByTestId(`${editCheckboxPrefixes.subcategory}${subcategoryId}`)
 }
 
 /**

--- a/react/test/edit_mode_test_utils.ts
+++ b/react/test/edit_mode_test_utils.ts
@@ -129,3 +129,13 @@ export async function ensureCategoryExpanded(t: TestController, categoryId: stri
         await setCategoryExpanded(t, categoryId, true)
     }
 }
+
+/** The same, for a subcategory. Its toggle is only reachable while its category is expanded. */
+export function subcategoryToggleButton(subcategoryId: string, direction: 'Expand' | 'Collapse'): Selector {
+    return Selector(`[data-subcategory-id=${subcategoryId}]`).withAttribute('aria-label', new RegExp(`^${direction} `))
+}
+
+export async function setSubcategoryExpanded(t: TestController, subcategoryId: string, expanded: boolean): Promise<void> {
+    await t.click(subcategoryToggleButton(subcategoryId, expanded ? 'Expand' : 'Collapse'))
+    await t.wait(collapseAnimationMs)
+}

--- a/react/unit/missing-groups.test.ts
+++ b/react/unit/missing-groups.test.ts
@@ -138,6 +138,7 @@ void test('no year selected and no source enabled asks for both', () => {
 void test('a whole subcategory in an incomplete category consolidates into the subcategory', () => {
     // The segregation groups are available but unselected, so the Race category can't stand in;
     // its pie chart of races can.
+    // eslint-disable-next-line no-restricted-syntax -- these are stat paths, not css colors
     const race: StatPath[] = ['white', 'black', 'homogeneity_250_2020']
     assert.deepStrictEqual(
         warnings([race], ['show_stat_group_white', 'show_stat_group_black']),

--- a/react/unit/missing-groups.test.ts
+++ b/react/unit/missing-groups.test.ts
@@ -134,3 +134,13 @@ void test('no year selected and no source enabled asks for both', () => {
         ['Population: Select **2020**, **2010**, or **2000** and enable **US Census** or **GHSL** to see this statistic.'],
     )
 })
+
+void test('a whole subcategory in an incomplete category consolidates into the subcategory', () => {
+    // The segregation groups are available but unselected, so the Race category can't stand in;
+    // its pie chart of races can.
+    const race: StatPath[] = ['white', 'black', 'homogeneity_250_2020']
+    assert.deepStrictEqual(
+        warnings([race], ['show_stat_group_white', 'show_stat_group_black']),
+        ['Racial Composition: Select **2020** to see these statistics.'],
+    )
+})

--- a/urbanstats/statistics/statistics_tree.py
+++ b/urbanstats/statistics/statistics_tree.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-lines
 
+import itertools
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -24,6 +25,19 @@ class Source:
 
     def json(self) -> Dict[str, Any]:
         return {"category": self.category, "name": self.name}
+
+
+@dataclass(frozen=True)
+class Subcategory:
+    """
+    Groups statistics within a category, e.g. the ones that add up to 100%.
+    """
+
+    id: str
+    name: str
+
+    def json(self) -> Dict[str, Any]:
+        return {"id": self.id, "name": self.name}
 
 
 @dataclass
@@ -122,6 +136,7 @@ class StatisticGroup:
     by_year: Dict[Optional[int], List[MultiSource]]
     group_name_statcol: Optional[str] = None
     group_name: Optional[str] = None
+    subcategory: Optional[Subcategory] = None
 
     def __post_init__(self) -> None:
         for year, cols in self.by_year.items():
@@ -165,6 +180,7 @@ class StatisticGroup:
         return {
             "id": group_id_path,
             "name": self.compute_group_name(name_map),
+            "subcategory": self.subcategory.json() if self.subcategory else None,
             "contents": [
                 self.flatten_year(year, stats, name_map, list(name_map))
                 for year, stats in self.by_year.items()
@@ -203,6 +219,27 @@ class StatisticCategory:
         assert isinstance(self.contents, dict)
         assert all(
             isinstance(value, StatisticGroup) for value in self.contents.values()
+        )
+        # The frontend reconstructs a subcategory from the run of groups carrying it.
+        seen = set()
+        for subcategory, _ in itertools.groupby(
+            group.subcategory for group in self.contents.values()
+        ):
+            if subcategory is None:
+                continue
+            assert subcategory.id not in seen, (
+                f"Subcategory {subcategory.id} is not contiguous within "
+                f"category {self.name}"
+            )
+            seen.add(subcategory.id)
+
+    def subcategories(self) -> List[Subcategory]:
+        return list(
+            dict.fromkeys(
+                group.subcategory
+                for group in self.contents.values()
+                if group.subcategory is not None
+            )
         )
 
     def internal_statistics(self) -> List[Union[str, Tuple[str, ...]]]:
@@ -245,6 +282,14 @@ class StatisticTree:
         assert all(
             isinstance(value, StatisticCategory) for value in self.categories.values()
         )
+        # Subcategory ids become settings keys, so they must be unique site-wide.
+        ids = [
+            subcategory.id
+            for category in self.categories.values()
+            for subcategory in category.subcategories()
+        ]
+        duplicated = {id_ for id_ in ids if ids.count(id_) > 1}
+        assert not duplicated, f"Duplicated subcategory ids: {duplicated}"
 
     def internal_statistics(self) -> List[Union[str, Tuple[str, ...]]]:
         return [
@@ -420,6 +465,18 @@ def census_segregation(col_name: str) -> Dict[str, StatisticGroup]:
             }
         )
     }
+
+
+def in_subcategory(
+    subcategory_id: str, name: str, *groups: Dict[str, StatisticGroup]
+) -> Dict[str, StatisticGroup]:
+    subcategory = Subcategory(subcategory_id, name)
+    result = {}
+    for group_dict in groups:
+        for col_name, group in group_dict.items():
+            group.subcategory = subcategory
+            result[col_name] = group
+    return result
 
 
 def just_2020(
@@ -629,13 +686,17 @@ statistics_tree = StatisticTree(
         "race": StatisticCategory(
             name="Race",
             contents={
-                **census_basics_with_canada("white", change=False),
-                **census_basics_with_canada("hispanic", change=False),
-                **census_basics_with_canada("black", change=False),
-                **census_basics_with_canada("asian", change=False),
-                **census_basics_with_canada("native", change=False),
-                **census_basics_with_canada("hawaiian_pi", change=False),
-                **census_basics_with_canada("other / mixed", change=False),
+                **in_subcategory(
+                    "race_composition",
+                    "Racial Composition",
+                    census_basics_with_canada("white", change=False),
+                    census_basics_with_canada("hispanic", change=False),
+                    census_basics_with_canada("black", change=False),
+                    census_basics_with_canada("asian", change=False),
+                    census_basics_with_canada("native", change=False),
+                    census_basics_with_canada("hawaiian_pi", change=False),
+                    census_basics_with_canada("other / mixed", change=False),
+                ),
                 **census_segregation("homogeneity_250"),
                 **census_segregation("segregation_250"),
                 **census_segregation("segregation_250_10"),
@@ -644,29 +705,41 @@ statistics_tree = StatisticTree(
         "national_origin": StatisticCategory(
             name="National Origin",
             contents={
-                **just_2020_with_canada(
-                    "citizenship_citizen_by_birth",
-                    "citizenship_citizen_by_naturalization",
-                    "citizenship_not_citizen",
+                **in_subcategory(
+                    "citizenship",
+                    "Citizenship",
+                    just_2020_with_canada(
+                        "citizenship_citizen_by_birth",
+                        "citizenship_citizen_by_naturalization",
+                        "citizenship_not_citizen",
+                    ),
                 ),
-                **just_2020(
-                    "birthplace_non_us",
-                    "birthplace_us_not_state",
-                    "birthplace_us_state",
-                    source=population_census,
+                **in_subcategory(
+                    "birthplace",
+                    "Birthplace",
+                    just_2020(
+                        "birthplace_non_us",
+                        "birthplace_us_not_state",
+                        "birthplace_us_state",
+                        source=population_census,
+                    ),
                 ),
-                **just_2020_with_canada(
-                    "language_english_only",
-                    "language_spanish",
-                ),
-                **just_2020(
-                    "language_french_canada",
-                    "language_other_non_french_canada",
-                    source=population_canada,
-                ),
-                **just_2020(
-                    "language_other",
-                    source=population_census,
+                **in_subcategory(
+                    "language",
+                    "Language at Home",
+                    just_2020_with_canada(
+                        "language_english_only",
+                        "language_spanish",
+                    ),
+                    just_2020(
+                        "language_french_canada",
+                        "language_other_non_french_canada",
+                        source=population_canada,
+                    ),
+                    just_2020(
+                        "language_other",
+                        source=population_census,
+                    ),
                 ),
             },
         ),
@@ -690,29 +763,37 @@ statistics_tree = StatisticTree(
         "education": StatisticCategory(
             name="Education",
             contents={
-                **just_2020(
-                    "education_high_school",
-                    "education_ugrad",
-                    "education_grad",
-                    source=population_census,
+                **in_subcategory(
+                    "education_attainment",
+                    "Educational Attainment",
+                    just_2020(
+                        "education_high_school",
+                        "education_ugrad",
+                        "education_grad",
+                        source=population_census,
+                    ),
+                    just_2020(
+                        "education_high_school_canada",
+                        "education_ugrad_canada",
+                        "education_grad_canada",
+                        source=population_canada,
+                    ),
                 ),
-                **just_2020(
-                    "education_high_school_canada",
-                    "education_ugrad_canada",
-                    "education_grad_canada",
-                    source=population_canada,
-                ),
-                **just_2020(
-                    "education_field_stem",
-                    "education_field_humanities",
-                    "education_field_business",
-                    source=population_census,
-                ),
-                **just_2020(
-                    "education_field_stem_canada",
-                    "education_field_humanities_canada",
-                    "education_field_business_canada",
-                    source=population_canada,
+                **in_subcategory(
+                    "education_field",
+                    "Field of Study",
+                    just_2020(
+                        "education_field_stem",
+                        "education_field_humanities",
+                        "education_field_business",
+                        source=population_census,
+                    ),
+                    just_2020(
+                        "education_field_stem_canada",
+                        "education_field_humanities_canada",
+                        "education_field_business_canada",
+                        source=population_canada,
+                    ),
                 ),
                 **just_2020(
                     "female_hs_gap_4",
@@ -745,29 +826,37 @@ statistics_tree = StatisticTree(
                     "lim_at_canada",
                     source=population_canada,
                 ),
-                **just_2020(
-                    "household_income_under_50k",
-                    "household_income_50k_to_100k",
-                    "household_income_over_100k",
-                    source=population_census,
+                **in_subcategory(
+                    "household_income",
+                    "Household Income",
+                    just_2020(
+                        "household_income_under_50k",
+                        "household_income_50k_to_100k",
+                        "household_income_over_100k",
+                        source=population_census,
+                    ),
+                    just_2020(
+                        "household_income_under_50cad",
+                        "household_income_50_to_100cad",
+                        "household_income_above_100_cad",
+                        source=population_canada,
+                    ),
                 ),
-                **just_2020(
-                    "household_income_under_50cad",
-                    "household_income_50_to_100cad",
-                    "household_income_above_100_cad",
-                    source=population_canada,
-                ),
-                **just_2020(
-                    "individual_income_under_50k",
-                    "individual_income_50k_to_100k",
-                    "individual_income_over_100k",
-                    source=population_census,
-                ),
-                **just_2020(
-                    "individual_income_under_50cad",
-                    "individual_income_50_to_100cad",
-                    "individual_income_above_100_cad",
-                    source=population_canada,
+                **in_subcategory(
+                    "individual_income",
+                    "Individual Income",
+                    just_2020(
+                        "individual_income_under_50k",
+                        "individual_income_50k_to_100k",
+                        "individual_income_over_100k",
+                        source=population_census,
+                    ),
+                    just_2020(
+                        "individual_income_under_50cad",
+                        "individual_income_50_to_100cad",
+                        "individual_income_above_100_cad",
+                        source=population_canada,
+                    ),
                 ),
             },
         ),
@@ -777,23 +866,48 @@ statistics_tree = StatisticTree(
                 **census_basics_with_canada("housing_per_pop", change=False),
                 **census_basics_with_canada("housing_per_person", change=False),
                 **census_basics("vacancy", change=False),
-                **just_2020(
-                    "rent_burden_under_20",
-                    "rent_burden_20_to_40",
-                    "rent_burden_over_40",
-                    "rent_1br_under_750",
-                    "rent_1br_750_to_1500",
-                    "rent_1br_over_1500",
-                    "rent_2br_under_750",
-                    "rent_2br_750_to_1500",
-                    "rent_2br_over_1500",
-                    "year_built_1969_or_earlier",
-                    "year_built_1970_to_1979",
-                    "year_built_1980_to_1989",
-                    "year_built_1990_to_1999",
-                    "year_built_2000_to_2009",
-                    "year_built_2010_or_later",
-                    source=population_census,
+                **in_subcategory(
+                    "rent_burden",
+                    "Rent Burden",
+                    just_2020(
+                        "rent_burden_under_20",
+                        "rent_burden_20_to_40",
+                        "rent_burden_over_40",
+                        source=population_census,
+                    ),
+                ),
+                **in_subcategory(
+                    "rent_1br",
+                    "1BR Rent",
+                    just_2020(
+                        "rent_1br_under_750",
+                        "rent_1br_750_to_1500",
+                        "rent_1br_over_1500",
+                        source=population_census,
+                    ),
+                ),
+                **in_subcategory(
+                    "rent_2br",
+                    "2BR Rent",
+                    just_2020(
+                        "rent_2br_under_750",
+                        "rent_2br_750_to_1500",
+                        "rent_2br_over_1500",
+                        source=population_census,
+                    ),
+                ),
+                **in_subcategory(
+                    "year_built",
+                    "Year Built",
+                    just_2020(
+                        "year_built_1969_or_earlier",
+                        "year_built_1970_to_1979",
+                        "year_built_1980_to_1989",
+                        "year_built_1990_to_1999",
+                        "year_built_2000_to_2009",
+                        "year_built_2010_or_later",
+                        source=population_census,
+                    ),
                 ),
                 **just_2020_with_canada(
                     "household_size_pw",
@@ -810,24 +924,38 @@ statistics_tree = StatisticTree(
         "transportation": StatisticCategory(
             name="Transportation",
             contents={
-                **just_2020_with_canada(
-                    "transportation_means_car_no_wfh",
-                    "transportation_means_bike_no_wfh",
-                    "transportation_means_walk_no_wfh",
-                    "transportation_means_transit_no_wfh",
+                **in_subcategory(
+                    "commute_mode",
+                    "Commute Mode",
+                    just_2020_with_canada(
+                        "transportation_means_car_no_wfh",
+                        "transportation_means_bike_no_wfh",
+                        "transportation_means_walk_no_wfh",
+                        "transportation_means_transit_no_wfh",
+                    ),
                 ),
                 **just_2020_with_canada(
                     "transportation_commute_time_median",
-                    "transportation_commute_time_under_15",
-                    "transportation_commute_time_15_to_29",
-                    "transportation_commute_time_30_to_59",
-                    "transportation_commute_time_over_60",
                 ),
-                **just_2020(
-                    "vehicle_ownership_none",
-                    "vehicle_ownership_at_least_1",
-                    "vehicle_ownership_at_least_2",
-                    source=population_census,
+                **in_subcategory(
+                    "commute_time",
+                    "Commute Time",
+                    just_2020_with_canada(
+                        "transportation_commute_time_under_15",
+                        "transportation_commute_time_15_to_29",
+                        "transportation_commute_time_30_to_59",
+                        "transportation_commute_time_over_60",
+                    ),
+                ),
+                **in_subcategory(
+                    "vehicle_ownership",
+                    "Vehicle Ownership",
+                    just_2020(
+                        "vehicle_ownership_none",
+                        "vehicle_ownership_at_least_1",
+                        "vehicle_ownership_at_least_2",
+                        source=population_census,
+                    ),
                 ),
                 **just_2020(
                     "traffic_fatalities_last_decade_per_capita",
@@ -884,14 +1012,18 @@ statistics_tree = StatisticTree(
                     "pm_25_2018_2022",
                     source=pollution_acag,
                 ),
-                **just_2020(
-                    "heating_utility_gas",
-                    "heating_electricity",
-                    "heating_bottled_tank_lp_gas",
-                    "heating_feul_oil_kerosene",
-                    "heating_other",
-                    "heating_no",
-                    source=population_census,
+                **in_subcategory(
+                    "heating",
+                    "Heating Fuel",
+                    just_2020(
+                        "heating_utility_gas",
+                        "heating_electricity",
+                        "heating_bottled_tank_lp_gas",
+                        "heating_feul_oil_kerosene",
+                        "heating_other",
+                        "heating_no",
+                        source=population_census,
+                    ),
                 ),
             },
         ),
@@ -968,18 +1100,26 @@ statistics_tree = StatisticTree(
         "relationships": StatisticCategory(
             name="Relationships",
             contents={
-                **just_2020(
-                    "sors_unpartnered_householder",
-                    "sors_cohabiting_partnered_gay",
-                    "sors_cohabiting_partnered_straight",
-                    "sors_child",
-                    "sors_other",
-                    source=population_census,
+                **in_subcategory(
+                    "household_relationship",
+                    "Household Relationship",
+                    just_2020(
+                        "sors_unpartnered_householder",
+                        "sors_cohabiting_partnered_gay",
+                        "sors_cohabiting_partnered_straight",
+                        "sors_child",
+                        "sors_other",
+                        source=population_census,
+                    ),
                 ),
-                **just_2020_with_canada(
-                    "marriage_never_married",
-                    "marriage_married_not_divorced",
-                    "marriage_divorced",
+                **in_subcategory(
+                    "marital_status",
+                    "Marital Status",
+                    just_2020_with_canada(
+                        "marriage_never_married",
+                        "marriage_married_not_divorced",
+                        "marriage_divorced",
+                    ),
                 ),
             },
         ),


### PR DESCRIPTION
Closes #220. Stacked on #2435.

A subcategory is a tag on each group, not a container in the tree: a contiguous run of groups carrying the same one *is* that subcategory. The alternative, making `Category.contents` a union of groups and containers, would have rippled through `GroupIdentifier`, `allGroups`, `statParents`, `statPathToOrder`, and the eight places that just want a category's groups flat. As tagged, group ids, tree ordering, and the `?s=` link vector are untouched, so existing links and saved settings keep working. Python asserts the contiguity and id uniqueness this representation leans on.

Subcategories have their own expand toggle. The first pass gave them none, on the theory that a second level of `AnimatedCollapse` wasn't worth it, but that made Race worse in the other direction: reaching the segregation groups meant unfolding seven races. Instead of nesting the collapses in the DOM, each row names the collapse it belongs to, and a subcategory's run shows only when both it and its category are expanded.

Which runs became subcategories is a judgement call; categories that are already a single pie chart (Industry, Occupation, Generation, Religion) were left alone, since a subcategory there is a redundant row.

Checkbox grouping only — this is the structure a pie chart would need, but it draws none. The new screenshot reference was generated on arm64 and may want regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)