### PR TITLE
unit inference regression tests

### DIFF
--- a/react/unit/unit-inference.test.ts
+++ b/react/unit/unit-inference.test.ts
@@ -211,6 +211,81 @@ void test('a regression says nothing of a parameter it cannot read', () => {
     assert.equal(inferred('regr = regression(x1=area)\nregr.b'), 'unknown')
 })
 
+void test('a script can shadow a built-in, and calling it is not calling the built-in', () => {
+    assert.equal(inferred('sqrt = area\nsqrt(population)'), 'unknown')
+    assert.equal(inferred('ln = area\nln(population)'), 'unknown')
+})
+
+void test('a node the editor wraps is read through', () => {
+    assert.equal(inferred('autoUXNode(population, "{}")'), 'person^1 times=1 x1')
+    assert.equal(inferred('autoUXNode(population + area, "{}")'), 'inconsistent')
+})
+
+void test('an object literal is read field by field', () => {
+    assert.equal(inferred('x = { a: population, b: area }\nx.a'), 'person^1 times=1 x1')
+    assert.equal(inferred('x = { a: population, b: area }\nx.b'), 'm^2 times=1 x1000000')
+    assert.equal(inferred('x = { a: population }\nx.nonesuch'), 'unknown')
+})
+
+void test('unlike units in an operation', () => {
+    assert.equal(inferred('population + area'), 'inconsistent')
+    assert.equal(inferred('area + population'), 'inconsistent')
+    assert.equal(inferred('population - area'), 'inconsistent')
+    assert.equal(inferred('population < area'), 'unknown')
+    assert.equal(inferred('area >= population'), 'unknown')
+})
+
+void test('a literal beside unlike units', () => {
+    assert.equal(inferred('population + area * 2'), 'inconsistent')
+    assert.equal(inferred('population + area / 2'), 'inconsistent')
+    assert.equal(inferred('population + sqrt(area)'), 'inconsistent')
+    assert.equal(inferred('commute_bike + population'), 'inconsistent')
+})
+
+void test('several unlike units in one expression', () => {
+    assert.equal(inferred('population + area + area'), 'inconsistent')
+    assert.equal(inferred('population * 2 + area'), 'inconsistent')
+    assert.equal(inferred('(population + area) * 2'), 'inconsistent')
+    assert.equal(inferred('x = area\npopulation + x'), 'inconsistent')
+})
+
+void test('arguments of a call that share a unit', () => {
+    assert.equal(inferred('maximum(area, population)'), 'inconsistent')
+    assert.equal(inferred('minimum(population, area)'), 'inconsistent')
+    assert.equal(inferred('inverseQuantile(population, area)'), 'inconsistent')
+})
+
+void test('operations on matching units', () => {
+    assert.equal(inferred('population + population'), 'person^1 times=2 x1')
+    assert.equal(inferred('area / area'), 'dimensionless times=1 x1')
+    assert.equal(inferred('high_temp + low_temp'), 'F^1 times=2 x1')
+})
+
+void test('if arms and vector elements of unlike units', () => {
+    assert.equal(inferred('[population, area, sunny_hours]'), 'unknown')
+    assert.equal(inferred('[population, area]'), 'unknown')
+    assert.equal(inferred('if (population > 0) { population } else { area }'), 'unknown')
+})
+
+void test('a temperature in a product', () => {
+    assert.equal(inferred('high_temp * area'), 'inconsistent')
+    assert.equal(inferred('area * high_temp'), 'inconsistent')
+    assert.equal(inferred('high_temp / area'), 'inconsistent')
+    assert.equal(inferred('high_temp ** 2'), 'inconsistent')
+    assert.equal(inferred('high_temp ** 2 * area'), 'inconsistent')
+    assert.equal(inferred('sqrt(high_temp)'), 'inconsistent')
+    // a bare number scales the reading itself, which keeps its zero
+    assert.equal(inferred('high_temp * 2'), 'F^1 times=2 x1')
+    assert.equal(inferred('(high_temp + low_temp) / 2'), 'F^1 times=1 x1')
+})
+
+void test('a temperature in a sum of unlike units', () => {
+    assert.equal(inferred('high_temp + population'), 'inconsistent')
+    assert.equal(inferred('population + high_temp'), 'inconsistent')
+    assert.equal(inferred('high_temp - low_temp + population'), 'inconsistent')
+    assert.equal(inferred('if (population > 0) { high_temp } else { area }'), 'unknown')
+})
+
 void test('what cannot be read comes back as anything, rather than throwing', () => {
     assert.equal(inferred('someFunctionOrOther(population)'), 'unknown')
     assert.equal(inferred('"a string"'), 'unknown')

--- a/react/unit/urban-stats-script-derive-human-readable-name.test.ts
+++ b/react/unit/urban-stats-script-derive-human-readable-name.test.ts
@@ -87,6 +87,67 @@ testMapLabel(test, 'cMap(data=-(population * 2), scale=linearScale(), ramp=rampU
 testMapLabel(test, 'cMap(data=-(area ** 2), scale=linearScale(), ramp=rampUridis)', '-Area^{2}')
 testMapLabel(test, 'cMap(data=-population, scale=linearScale(), ramp=rampUridis)', '-Population')
 
+// How a caption reads a script whose units are not the ones needed.
+for (const [data, expected] of [
+    ['population + area', 'Population + Area'],
+    ['area + population', 'Area + Population'],
+    ['population - area', 'Population − Area'],
+    ['population < area', 'Population < Area'],
+    ['area >= population', 'Area ≥ Population'],
+    ['commute_bike + population', 'Commute Bike % + Population'],
+    // a literal already written is read for what it must be
+    ['population + area * 2', 'Population + Area × 2/km^{2}'],
+    ['population + area / 2', 'Population + Area ÷ 2km^{2}/person'],
+    ['population + sqrt(area)', 'Population + sqrt(Area)'],
+    ['population + area + area', 'Population + Area + Area'],
+    ['population * 2 + area', 'Population × 2km^{2}/person + Area'],
+    ['(population + area) * 2', '(Population + Area) × 2'],
+    ['maximum(area, population)', 'max(Area, Population)'],
+    ['minimum(population, area)', 'min(Population, Area)'],
+    ['inverseQuantile(population, area)', 'quantile^{-1}(Population, Area)'],
+    // a temperature is counted from a zero of its own
+    ['high_temp * area', 'Mean high temp × Area'],
+    ['high_temp / area', 'Mean high temp ÷ Area'],
+    ['high_temp ** 2', 'Mean high temp^{2}'],
+    ['high_temp ** 2 * area', 'Mean high temp^{2} × Area'],
+    ['sqrt(high_temp)', 'sqrt(Mean high temp)'],
+    ['high_temp / high_temp', 'Mean high temp ÷ Mean high temp'],
+    ['high_temp + population', 'Mean high temp + Population'],
+    ['population + high_temp', 'Population + Mean high temp'],
+    ['high_temp - low_temp + population', '(Mean high temp − Mean low temp) + Population'],
+    // what is written after an expression, and the brackets that go round it
+    ['ln(area + area)', 'ln(Area + Area [in km^{2}])'],
+    ['ln(population + area)', 'ln(Population + Area)'],
+    // and nothing is written where the two sides already have the same unit
+    ['population + population', 'Population + Population'],
+    ['area / area', 'Area ÷ Area'],
+] as const) {
+    testMapLabel(test, `cMap(data=${data}, scale=linearScale(), ramp=rampUridis)`, expected)
+}
+
+// What a caption says to a reader of other units.
+const imperial = { useImperial: true }
+const celsius = { temperatureUnit: 'celsius' }
+
+for (const [data, reader, settings, expected] of [
+    ['population + area', 'imperial', imperial, 'Population + Area'],
+    ['area + population', 'imperial', imperial, 'Area + Population'],
+    ['population + sqrt(area)', 'imperial', imperial, 'Population + sqrt(Area)'],
+    ['high_temp + population', 'celsius', celsius, 'Mean high temp + Population'],
+    ['population + high_temp', 'celsius', celsius, 'Population + Mean high temp'],
+    ['high_temp * area', 'celsius', celsius, 'Mean high temp × Area'],
+    ['high_temp * area', 'imperial', imperial, 'Mean high temp × Area'],
+    // what a number was counted in does not change with the reader
+    ['ln(area)', 'imperial', imperial, 'ln(Area [in km^{2}])'],
+    ['ln(high_temp)', 'celsius', celsius, 'ln(Mean high temp [in °F])'],
+] as const) {
+    void test(`${data} to a ${reader} reader`, () => {
+        const label = deriveMapLabel(mapUSSFromString(`cMap(data=${data}, scale=linearScale(), ramp=rampUridis)`), getTypeEnvironment())
+        assert.ok(label)
+        assert.equal(reifyString(label, settings), expected)
+    })
+}
+
 void test('a label reads in the units of whoever is reading it', () => {
     const label = deriveMapLabel(mapUSSFromString('condition (high_temp > 80 & area > 100)\ncMap(data=population, scale=linearScale(), ramp=rampUridis)'), getTypeEnvironment())
     assert.ok(label)


### PR DESCRIPTION
Tests only, all passing on `main` as it stands. No behaviour change.

Most of these are scripts whose parts are not in the units the operation wants — `population + area`, `high_temp * area`, `maximum(area, population)` — recorded as what they infer and how they are captioned today. A few cover paths that had no test at all: a name that shadows a built-in and is then called, an object literal read field by field, and a node the editor wraps.

Split out of #2393, which changes most of these answers. Landing the tests first means that PR shows the answers changing rather than a wall of new test code alongside the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHKp7QCPqi74raCmowqSZH