### PR TITLE
Pick each shard's newest attempt when combining assets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -241,8 +241,11 @@ jobs:
           name="${{ matrix.test-file }}"
           echo "name=${name:0:200}" >> $GITHUB_OUTPUT
       # A re-run keeps the artifacts the earlier attempt uploaded, so these names carry the
-      # attempt. Re-running only the failed jobs loses nothing, because only a failing shard
-      # writes changed assets, and a failing shard is exactly what gets re-run.
+      # attempt and merge-assets takes each shard's newest one. The marker makes the delta
+      # artifact unconditional, so a shard that re-ran and passed is distinguishable from one
+      # that wasn't re-run at all; without it the earlier attempt's delta would be picked up.
+      - if: "!cancelled()"
+        run: mkdir -p react/delta && touch react/delta/shard-ran
       - uses: actions/upload-artifact@v4
         if: "!cancelled()"
         with:
@@ -277,14 +280,35 @@ jobs:
       - uses: ./.github/actions/node_modules
       - uses: actions/download-artifact@v4
         with:
-          pattern: "delta-${{ github.run_attempt }}-*"
-          path: combined/delta
-          merge-multiple: true
+          pattern: "delta-*"
+          path: attempts/delta
       - uses: actions/download-artifact@v4
         with:
-          pattern: "changed_assets-${{ github.run_attempt }}-*"
-          path: combined/changed_assets
-          merge-multiple: true
+          pattern: "changed_assets-*"
+          path: attempts/changed_assets
+      - name: Keep each shard's newest attempt
+        run: |
+          declare -A newest
+          for dir in attempts/delta/delta-*; do
+            [ -d "$dir" ] || continue
+            base="$(basename "$dir")"
+            attempt="${base#delta-}"
+            attempt="${attempt%%-*}"
+            shard="${base#delta-$attempt-}"
+            if [ "$attempt" -gt "${newest[$shard]:-0}" ]; then
+              newest[$shard]="$attempt"
+            fi
+          done
+          mkdir -p combined/delta combined/changed_assets
+          for shard in "${!newest[@]}"; do
+            attempt="${newest[$shard]}"
+            cp -R "attempts/delta/delta-$attempt-$shard/." combined/delta/
+            changed="attempts/changed_assets/changed_assets-$attempt-$shard"
+            if [ -d "$changed" ]; then
+              cp -R "$changed/." combined/changed_assets/
+            fi
+          done
+          rm -f combined/delta/shard-ran
       - id: upload-combined
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -57,9 +57,7 @@ jobs:
               return;
             }
 
-            const latestRun = usableRuns[0];
-            core.setOutput('run-id', latestRun.id);
-            core.setOutput('run-attempt', latestRun.run_attempt);
+            core.setOutput('run-id', usableRuns[0].id);
 
       - name: Download combined artifact
         uses: actions/github-script@v7
@@ -67,19 +65,24 @@ jobs:
           script: |
             const fs = require('fs');
 
-            const name = `combined-${{ steps.workflow-run.outputs.run-attempt }}`;
-
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: '${{ steps.workflow-run.outputs.run-id }}',
-              name
+              per_page: 100
             });
 
-            const artifact = artifacts.data.artifacts[0];
+            // Re-running one job bumps the run's attempt without re-running merge-assets, so
+            // the newest combined artifact isn't necessarily the current attempt's.
+            const artifact = artifacts
+              .flatMap(candidate => {
+                const attempt = /^combined-(\d+)$/.exec(candidate.name)?.[1];
+                return attempt === undefined ? [] : [{ candidate, attempt: Number(attempt) }];
+              })
+              .sort((a, b) => b.attempt - a.attempt)[0]?.candidate;
 
             if (!artifact) {
-              core.setFailed(`No ${name} artifact found`);
+              core.setFailed('No combined artifact found');
               return;
             }
 


### PR DESCRIPTION
Re-running a single failed e2e job breaks `!updateAssets`. `github.run_attempt` is a property of the whole run, not of the job that was re-run, so `merge-assets` re-runs under attempt 2 and looks for `delta-2-*` while every shard that wasn't re-run still has its delta under `delta-1-*`. In [run 34009072766](https://github.com/kavigupta/urbanstats/actions/runs/34009072766/job/101421554030) the one re-run shard passed, so the merge found nothing and uploaded no combined artifact at all, with five shards still failing and their deltas ready to apply.

The attempt prefix is load-bearing — artifact names must be unique within a run — so it stays, and `merge-assets` resolves the newest attempt per shard instead of assuming they all match the run's. That only works if the delta artifact exists unconditionally: a shard that re-ran and passed uploads nothing, which is otherwise indistinguishable from a shard that never re-ran, and the newest-attempt rule would then resurrect the flake's delta and commit it. Hence `shard-ran`, which is stripped after merging so nothing downstream sees it.

The alternative was resolving each shard's attempt from the jobs API, which needs no marker file, but GitHub truncates matrix job names, so mapping a job back to its shard becomes prefix matching against a name that may have been cut off. A marker file is harder to get subtly wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)