### PR TITLE
Keep maps flat

### DIFF
--- a/react/src/components/map-common.tsx
+++ b/react/src/components/map-common.tsx
@@ -44,6 +44,9 @@ function CommonMaplibreMapImpl(props: CommonMapProps, ref: React.Ref<MapRef>): R
         <Map
             ref={ref}
             mapStyle="https://tiles.openfreemap.org/styles/bright"
+            maxPitch={0}
+            pitchWithRotate={false}
+            touchPitch={false}
             canvasContextAttributes={{
                 preserveDrawingBuffer: true, // Allows screenshots
             }}


### PR DESCRIPTION
Tilt was never a feature here — nothing reads or sets pitch, and screenshots and insets assume top-down — so the only way a user reaches a pitched view is by accident, via a ctrl-drag or two-finger drag they then have to undo.

Compass rotation stays enabled: bearing keeps the map flat, so it doesn't cause the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)