### PR TITLE
extract out computation of the operator in a human readable node

### DIFF
--- a/react/src/urban-stats-script/derive-human-readable-name.ts
+++ b/react/src/urban-stats-script/derive-human-readable-name.ts
@@ -9,9 +9,14 @@ import { abbreviate, formatToSignificantFigures, separateNumber, trimTrailingZer
 import { locationOf, UrbanStatsASTExpression, UrbanStatsASTStatement } from './ast'
 import * as l from './literal-parser'
 import { noLocation } from './location'
-import { expressionOperatorMap } from './operators'
+import { BinaryOperatorSymbol, expressionOperatorMap } from './operators'
 import { TypeEnvironment } from './types-values'
 import { ConstantUnits, inferConstantUnits, readAsANumber, unitsReadAndDropped, whereWritten } from './unit-inference'
+
+/** The operator an expression prints as, where it prints as one at all. */
+function operatorInHumanReadable(ast: UrbanStatsASTExpression): typeof expressionOperatorMap[BinaryOperatorSymbol] | undefined {
+    return ast.type === 'binaryOperator' ? expressionOperatorMap[ast.operator.node] : undefined
+}
 
 function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTStatement, typeEnvironment: TypeEnvironment, units: ConstantUnits): HumanReadableElement[] | undefined {
     switch (ast.type) {
@@ -27,21 +32,16 @@ function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTState
              */
             let lhs = humanReadableElements(ast.left, typeEnvironment, units)
             if (lhs === undefined) return
-            if (ast.left.type === 'binaryOperator') {
-                const leftOp = expressionOperatorMap[ast.left.operator.node]
-                if (!(leftOp.precedence > centerOp.precedence
-                    || leftOp === centerOp)) {
-                    lhs = [{ type: 'parens', value: lhs }]
-                }
+            const leftOp = operatorInHumanReadable(ast.left)
+            if (leftOp !== undefined && !(leftOp.precedence > centerOp.precedence || leftOp === centerOp)) {
+                lhs = [{ type: 'parens', value: lhs }]
             }
 
             let rhs = humanReadableElements(ast.right, typeEnvironment, units)
             if (rhs === undefined) return
-            if (ast.right.type === 'binaryOperator') {
-                const rightOp = expressionOperatorMap[ast.right.operator.node]
-                if (!(rightOp.precedence > centerOp.precedence || (centerOp === rightOp && centerOp.isAssociative))) {
-                    rhs = [{ type: 'parens', value: rhs }]
-                }
+            const rightOp = operatorInHumanReadable(ast.right)
+            if (rightOp !== undefined && !(rightOp.precedence > centerOp.precedence || (centerOp === rightOp && centerOp.isAssociative))) {
+                rhs = [{ type: 'parens', value: rhs }]
             }
 
             let humanReadableOperator: string
@@ -107,7 +107,7 @@ function humanReadableElements(ast: UrbanStatsASTExpression | UrbanStatsASTState
             if (written === undefined) return
             // a sign binds tighter than adding, so -(a + b) would otherwise read as -a + b, which
             // is a different number. It binds looser than multiplying, which needs no brackets.
-            const inner = ast.expr.type === 'binaryOperator' ? expressionOperatorMap[ast.expr.operator.node] : undefined
+            const inner = operatorInHumanReadable(ast.expr)
             const operand: HumanReadableElement[] = inner !== undefined && inner.precedence < expressionOperatorMap['*'].precedence
                 ? [{ type: 'parens', value: written }]
                 : written


### PR DESCRIPTION
Three places in `derive-human-readable-name.ts` worked out the same thing for themselves — the operator a subexpression prints as, so they could decide whether it needs brackets:

```ts
ast.left.type === 'binaryOperator' ? expressionOperatorMap[ast.left.operator.node] : undefined
```

once for each operand of a binary operator, and once for the operand of a unary one. They now ask `operatorInHumanReadable`.

No behaviour change: same condition, same answers, and the two `if (…type === 'binaryOperator')` blocks become the `!== undefined` guard the third site already used.

Split off #2393, where the answer stops being "the node's own operator" — a conversion makes an identifier print as `(Mean high temp − 0°F)`, which the enclosing operator has to bracket. That belongs behind this seam rather than inline three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHKp7QCPqi74raCmowqSZH